### PR TITLE
fix(layout): Fix UniformFlow height calculation when using aspect_ratio

### DIFF
--- a/src/nuiitivet/layout/uniform_flow.py
+++ b/src/nuiitivet/layout/uniform_flow.py
@@ -152,6 +152,12 @@ class UniformFlow(Widget):
             pref_w, pref_h = measure_preferred_size(child, max_width=col_limit)
             max_w = max(max_w, max(0, pref_w))
             max_h = max(max_h, max(0, pref_h))
+
+        # If we have a constrained column width, use it for aspect ratio and size calculation
+        # This matches layout() logic where columns expand to fill available width
+        if col_limit is not None and col_limit > 0:
+            max_w = max(max_w, col_limit)
+
         if self.aspect_ratio and max_w > 0:
             max_h = max(max_h, self._height_from_aspect(max_w))
 


### PR DESCRIPTION
## Description
Fixes a bug where `UniformFlow` underestimated its height when `aspect_ratio` was used effectively. 

When `UniformFlow` stretches its columns to fill the available width (a common behavior), the `preferred_size` calculation was still based on the child's minimum/preferred width. This mismatch caused the height, calculated via aspect ratio, to be too small, resulting in truncated content.

The fix ensures `preferred_size` considers the `col_limit` (stretched column width) when calculating the height from aspect ratio.

## Related Issue
Fixes #14

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verification
- Validated with reproduction script (UniformFlow with `aspect_ratio=1.0` and width constraint).
- Confirmed existing tests pass (`pytest`).