### PR TITLE
fix(ci): fix invalid changelog configuration in release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   exclude:
-    - labels:
+    labels:
       - ignore-for-release
   categories:
     - title: '🚀 Features'


### PR DESCRIPTION
Corrects the `changelog.exclude` configuration in `.github/release.yml` from an array to an object to match the expected schema.

Closes #16