### PR TITLE
fix(app): measure unmounted composable children for auto window sizing

### DIFF
--- a/src/nuiitivet/widgeting/widget_builder.py
+++ b/src/nuiitivet/widgeting/widget_builder.py
@@ -531,6 +531,18 @@ class BuilderHostMixin:
     def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> Tuple[int, int]:
         if self._built:
             return measure_preferred_size(self._built, max_width=max_width, max_height=max_height)
+
+        # Unmounted composables still need intrinsic sizing (e.g. App auto
+        # window sizing before mount). Evaluate build once and measure the
+        # returned subtree directly.
+        try:
+            built = self.evaluate_build()
+        except Exception:
+            return super().preferred_size(max_width=max_width, max_height=max_height)  # type: ignore
+
+        if built is not None and built is not self:
+            return measure_preferred_size(built, max_width=max_width, max_height=max_height)
+
         return super().preferred_size(max_width=max_width, max_height=max_height)  # type: ignore
 
     def rebuild(self) -> None:

--- a/tests/test_app_initialization_patterns.py
+++ b/tests/test_app_initialization_patterns.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.container import Container
 from nuiitivet.layout.stack import Stack
 from nuiitivet.navigation import Navigator
 from nuiitivet.overlay import Overlay
 from nuiitivet.runtime.app import App, AppScope
-from nuiitivet.widgeting.widget import Widget
+from nuiitivet.widgeting.widget import ComposableWidget, Widget
 
 
 class _FlagWidget(Widget):
@@ -18,6 +20,11 @@ class _FlagWidget(Widget):
 
     def build(self) -> Widget:
         return self
+
+
+class _ComposableFixedBox(ComposableWidget):
+    def build(self) -> Widget:
+        return Container(width=200, height=50)
 
 
 def test_app_content_provides_root_overlay() -> None:
@@ -67,3 +74,16 @@ def test_app_navigation_sets_root_navigator_and_overlay() -> None:
     finally:
         Navigator._root = prev_nav  # type: ignore[attr-defined]
         Overlay._root_overlay = prev_overlay  # type: ignore[attr-defined]
+
+
+def test_app_auto_window_size_measures_unmounted_composable_children() -> None:
+    content = Column(
+        children=[_ComposableFixedBox()],
+        gap=16,
+        padding=16,
+    )
+
+    app = App(content=content, width="auto", height="auto")
+
+    assert app.width == 232
+    assert app.height == 82


### PR DESCRIPTION
## Summary
Fix auto window sizing so that content does not collapse when the root layout contains unmounted `ComposableWidget` children.

## What changed
- Updated preferred-size resolution for composable widgets to measure the built subtree when needed during auto-size calculation.
- Added a regression test for auto window sizing with composable children in app initialization flow.

## Why
Previously, auto sizing could evaluate to near-zero body height because preferred size measurement happened before composed subtrees were effectively measured, causing collapsed content.

## Validation
- Ran focused app initialization tests.
- Ran broader app-related test suite.
- Confirmed the regression scenario is covered by test.

## Impact
- Affects auto sizing behavior (`width="auto"`, `height="auto"`).
- No API changes.

Closes #47