### PR TITLE
fix(modifiers): preserve observable background updates after corner_radius

### DIFF
--- a/src/nuiitivet/modifiers/corner_radius.py
+++ b/src/nuiitivet/modifiers/corner_radius.py
@@ -28,32 +28,8 @@ class CornerRadiusModifier(ModifierElement):
         return False
 
     def apply(self, widget: Widget) -> Widget:
-        self._apply_to_box(widget)
-        # Optimization: Always merge with existing ModifierBox
-        if isinstance(widget, ModifierBox):
-            child = widget.children[0] if widget.children else None
-            if child is not None:
-                self._apply_to_box(child)
-            box = ModifierBox(
-                child=child,
-                width=widget.width_sizing,
-                height=widget.height_sizing,
-                padding=widget.padding,
-                modifier=widget._modifier_chain,
-                # Merged properties (overwrite radius)
-                background_color=widget.bgcolor,
-                border_width=widget.border_width,
-                border_color=widget.border_color,
-                corner_radius=self.radius,
-                shadow_blur=widget.shadow_blur,
-                shadow_color=widget.shadow_color,
-                shadow_offset=widget.shadow_offset,
-                alignment=widget.alignment,
-            )
-            box.clip_content = True
-            return box
-
         if isinstance(widget, Box):
+            self._apply_to_box(widget)
             widget.clip_content = True
             return widget
 

--- a/tests/test_modifier_complete.py
+++ b/tests/test_modifier_complete.py
@@ -1,6 +1,7 @@
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.widgets.box import Box
 from nuiitivet.modifiers import background, border, clip, corner_radius, shadow
+from nuiitivet.observable import Observable
 
 
 class MockWidget(Widget):
@@ -94,6 +95,21 @@ def test_corner_radius_modifier():
     assert result.corner_radius == 10
     assert result.clip_content is True
     assert result.children[0] is w
+
+
+def test_corner_radius_keeps_background_observable_binding():
+    source = Observable(False)
+    color = source.map(lambda hovered: "#2196F3" if hovered else "#E0E0E0")
+
+    w = MockWidget()
+    result = w.modifier(background(color) | corner_radius(10))
+
+    assert isinstance(result, Box)
+    assert result.bgcolor == "#E0E0E0"
+
+    source.value = True
+
+    assert result.bgcolor == "#2196F3"
 
 
 def test_clip_modifier():


### PR DESCRIPTION
## Summary
Fixes a reactive update break in modifier chaining where `background(observable)` followed by `corner_radius(...)` could stop background updates.

## Changes
- Simplified `corner_radius` apply path to avoid merge/rebuild behavior that could drop observable bindings.
- Added a regression test for `background(observable_color) | corner_radius(...)`.

## Verification
- `uv run pytest tests/test_modifier_complete.py -q` passed.
- Existing related tests remained green in local run.

## Issue
Closes #49