### PR TITLE
docs(guide): improve home and guide entry page structure

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,7 +4,23 @@ layout: default
 
 # Nuiitivet Guides
 
+This section is the practical user guide for building apps with Nuiitivet.
+Use it as a step-by-step path from fundamentals to common app patterns.
+
+## Recommended Path
+
+1. [Layout](layout.md)
+2. [Observable](observable.md)
+3. [Packaging](packaging.md)
+
+## Topics
+
+- [Dialogs](dialogs.md)
 - [Navigation](navigation.md)
-- [Layout](layout.md)
-- [Observable](observable.md)
-- [Threading](threading.md)
+- [Window](window.md)
+- [Modifiers](modifier.md)
+
+## Advanced
+
+- [Async & Threading](threading.md)
+- [Interaction](interaction_region.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,45 @@
 layout: default
 ---
 
-# Nuiitivet Docs
+# Welcome to Nuiitivet
 
-## Guides
+## Key Areas in the Docs
 
-- [Layout](guide/layout.md)
-- [Observable](guide/observable.md)
-- [Threading](guide/threading.md)
+- **[Guide](guide/index.md)**
+ A practical user guide to learn Nuiitivet step by step, from first app setup to common development workflows.
+- **[API Reference](api/nuiitivet.md)**
+ Provides reference docs.
+- **[Changelog](https://github.com/yuksblog/nuiitivet/releases)**
+ Tracks released versions and updates.
+
+## Quick Example
+
+```python
+from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import Text, FilledButton
+from nuiitivet.layout.column import Column
+from nuiitivet.observable import Observable
+from nuiitivet.widgeting.widget import ComposableWidget
+
+
+class CounterApp(ComposableWidget):
+  def __init__(self):
+    super().__init__()
+    self.count = Observable(0)
+
+  def handle_increment(self):
+    self.count.value += 1
+
+  def build(self):
+    return Column(
+      [
+        Text(f"count: {self.count.value}"),
+        FilledButton("Increment", on_click=self.handle_increment),
+      ],
+      gap=12,
+      padding=16,
+    )
+
+
+MaterialApp(home=CounterApp()).run()
+```


### PR DESCRIPTION
## Summary
This PR improves documentation entry pages to make navigation and learning flow clearer for users.

## Changes
- Updated docs/index.md
  - Made Key Areas links directly clickable (Guide, API Reference, Changelog)
  - Refined Guide description to explain its role as a user guide entry point
- Updated docs/guide/index.md
  - Added clear page purpose text
  - Reorganized content into:
    - Recommended Path (Layout, Observable, Packaging)
    - Topics (Dialogs, Navigation, Window, Modifiers)
    - Advanced (Async & Threading, Interaction)

## Why
- Reduces ambiguity in documentation entry pages
- Separates onboarding path from topic-based lookup
- Aligns guide hub with actual intended usage

## Related Issue
- Closes #58

## Checklist
- [x] Documentation only change
- [x] Links updated and validated in markdown
- [x] No code/runtime behavior changes