### PR TITLE
feat(material): align TextField API with MD3 supporting text and error state

### DIFF
--- a/src/nuiitivet/material/styles/text_field_style.py
+++ b/src/nuiitivet/material/styles/text_field_style.py
@@ -29,6 +29,8 @@ class TextFieldStyle:
     label_color: ColorSpec = ColorRole.ON_SURFACE_VARIANT
     focused_label_color: ColorSpec = ColorRole.PRIMARY
     error_label_color: ColorSpec = ColorRole.ERROR
+    supporting_text_color: ColorSpec = ColorRole.ON_SURFACE_VARIANT
+    error_supporting_text_color: ColorSpec = ColorRole.ERROR
 
     # Cursor & Selection
     cursor_color: ColorSpec = ColorRole.PRIMARY

--- a/src/samples/text_field_demo.py
+++ b/src/samples/text_field_demo.py
@@ -1,7 +1,9 @@
 from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import Checkbox, Text
 from nuiitivet.material.text_fields import FilledTextField, OutlinedTextField
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.column import Column
+from nuiitivet.layout.row import Row
 
 
 def main():
@@ -20,21 +22,37 @@ def main():
         value="",
         label="Password",
         leading_icon="lock",
+        obscure_text=True,
         width=300,
         padding=10,
+    )
+
+    def _toggle_obscure(checked: bool | None) -> None:
+        tf_outlined.obscure_text = bool(checked)
+
+    obscure_toggle = Row(
+        gap=8,
+        children=[
+            Checkbox(checked=True, on_toggle=_toggle_obscure),
+            Text("Obscure password text"),
+        ],
     )
 
     # Error State
     tf_error = OutlinedTextField(
         value="Invalid Input",
         label="Email",
-        error_text="Invalid email address",
+        supporting_text="Invalid email address",
+        is_error=True,
         width=300,
         padding=10,
     )
 
     root = Container(
-        child=Column(children=[tf_filled, tf_outlined, tf_error], gap=20), width=400, height=400, padding=20
+        child=Column(children=[tf_filled, tf_outlined, obscure_toggle, tf_error], gap=20),
+        width=400,
+        height=400,
+        padding=20,
     )
     app = MaterialApp(root)
     app.run()


### PR DESCRIPTION
## Summary
This PR aligns Material 3 TextField APIs and behavior with MD3 expectations.
It separates supporting text from error state, adds low-level icon tap APIs, and introduces proper obscure text handling.

## Changes
- Refactored TextField state model to center on `supporting_text` + `is_error`
- Kept backward compatibility by preserving `error_text` as a compatibility alias
- Added low-level icon interaction APIs:
  - `on_tap_leading_icon`
  - `on_tap_trailing_icon`
- Added `obscure_text` to TextField APIs and wired it through rendering
- Fixed obscure rendering so masked text is actually drawn
- Updated supporting text color handling with dedicated style tokens
- Updated demo to toggle `obscure_text` via checkbox interaction

## Compatibility Notes
- Existing `error_text` usage remains supported (compatibility path retained)
- New APIs are additive and intended to improve clarity without breaking existing flows

## Testing
Validated with full checks:
- `mypy` ✅
- `flake8` ✅
- `pytest` ✅ (`808 passed`)

Additional TextField-focused tests were expanded and split by responsibility:
- API contract tests: `tests/test_text_field_api.py`
- behavior/regression tests: `tests/test_text_field.py`, `tests/test_text_field_animation.py`

## Related
- Closes #18