### PR TITLE
feat(progress): implement MD3 linear and circular progress indicators

### DIFF
--- a/docs/md3/progress-indicators.md
+++ b/docs/md3/progress-indicators.md
@@ -1,0 +1,96 @@
+<!-- markdownlint-disable MD060 -->
+
+# Progress Indicators MD3 Specs
+
+Source: <https://m3.material.io/components/progress-indicators/specs>
+Collected: 2026-03-12
+
+## Summary
+
+- The primary token viewer exposes three non-deprecated token sets: shared common tokens plus linear and circular variant-specific baseline tokens.
+- Shared common tokens provide current color values and shape previews; the shape rows render as circular previews but do not expose textual numeric values.
+- Linear baseline geometry centers on a 4dp track, 10dp wavy height, 3dp wave amplitude, and 40dp wave wavelength, with a 20dp wavelength for indeterminate waves.
+- Circular baseline geometry centers on a 40dp size, 48dp wavy size, 4dp track thickness, 1.6dp wave amplitude, and 15dp wave wavelength.
+- The Measurements section explicitly states a 4dp screen-edge inset for linear indicators and defines amplitude and wavelength, but its remaining figure callouts are image-only in accessible text.
+
+## Tokens & Specs
+
+### Token sets discovered
+
+| Token set                     | Notes                                                                                                                                                             |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Progress Indicator - Common   | Context shown in the viewer: Default, Light. Non-deprecated groups: Color, Shape. Deprecated legacy thickness/spacing subgroup also appears in the shared viewer. |
+| Progress indicator - Linear   | Context shown in the viewer: Default, Light. Non-deprecated group: Linear - baseline. Deprecated thick subgroup also appears.                                     |
+| Progress indicator - Circular | Context shown in the viewer: Default, Light. Non-deprecated group: Circular - baseline. Deprecated thick subgroup also appears.                                   |
+
+### Extracted tokens
+
+#### Progress Indicator - Common
+
+| Token set                   | Group | Label                                     | Token                                             | Value                                | Notes                                                                                   |
+|-----------------------------|-------|-------------------------------------------|---------------------------------------------------|--------------------------------------|-----------------------------------------------------------------------------------------|
+| Progress Indicator - Common | Color | Progress indicator active indicator color | md.comp.progress-indicator.active-indicator.color | #6750A4                              |                                                                                         |
+| Progress Indicator - Common | Color | Progress indicator track color            | md.comp.progress-indicator.track.color            | #E8DEF8                              |                                                                                         |
+| Progress Indicator - Common | Color | Progress indicator stop indicator color   | md.comp.progress-indicator.stop-indicator.color   | #6750A4                              |                                                                                         |
+| Progress Indicator - Common | Shape | Progress indicator active indicator shape | md.comp.progress-indicator.active-indicator.shape | visual-only (circular-shape preview) | No textual value exposed inline; row selection did not expose additional popup details. |
+| Progress Indicator - Common | Shape | Progress indicator track shape            | md.comp.progress-indicator.track.shape            | visual-only (circular-shape preview) | No textual value exposed inline; row selection did not expose additional popup details. |
+| Progress Indicator - Common | Shape | Progress indicator stop indicator shape   | md.comp.progress-indicator.stop-indicator.shape   | visual-only (circular-shape preview) | No textual value exposed inline; row selection did not expose additional popup details. |
+
+#### Progress indicator - Linear
+
+| Token set                   | Group             | Label                                                   | Token                                                                            | Value | Notes                                                    |
+|-----------------------------|-------------------|---------------------------------------------------------|----------------------------------------------------------------------------------|-------|----------------------------------------------------------|
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear height                        | md.comp.progress-indicator.linear.height                                         | 4dp   |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear with wave height              | md.comp.progress-indicator.linear.with-wave.height                               | 10dp  |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear active indicator thickness    | md.comp.progress-indicator.linear.active-indicator.thickness                     | 4dp   |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear track thickness               | md.comp.progress-indicator.linear.track.thickness                                | 4dp   |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear stop indicator size           | md.comp.progress-indicator.linear.stop-indicator.size                            | 4dp   |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear track active indicator space  | md.comp.progress-indicator.linear.track-active-indicator-space                   | 4dp   |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear stop indicator trailing space | md.comp.progress-indicator.linear.stop-indicator.trailing-space                  | 0     |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear wave amplitude                | md.comp.progress-indicator.linear.active-indicator.wave.amplitude                | 3dp   |                                                          |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear wave wavelenght               | md.comp.progress-indicator.linear.active-indicator.wave.wavelength               | 40dp  | Display label on the page is misspelled as "wavelenght". |
+| Progress indicator - Linear | Linear - baseline | Progress indicator linear indeterminate wave wavelenght | md.comp.progress-indicator.linear.indeterminate.active-indicator.wave.wavelength | 20dp  | Display label on the page is misspelled as "wavelenght". |
+
+#### Progress indicator - Circular
+
+| Token set                     | Group               | Label                                                        | Token                                                                | Value | Notes |
+|-------------------------------|---------------------|--------------------------------------------------------------|----------------------------------------------------------------------|-------|-------|
+| Progress indicator - Circular | Circular - baseline | Progress indicator circular size                             | md.comp.progress-indicator.circular.size                             | 40dp  |       |
+| Progress indicator - Circular | Circular - baseline | Progress indicator circular size with wave                   | md.comp.progress-indicator.circular.with-wave.size                   | 48dp  |       |
+| Progress indicator - Circular | Circular - baseline | Progress indicator circular active indicator thickness       | md.comp.progress-indicator.circular.active-indicator.thickness       | 4dp   |       |
+| Progress indicator - Circular | Circular - baseline | Progress indicator circular track thickness                  | md.comp.progress-indicator.circular.track.thickness                  | 4dp   |       |
+| Progress indicator - Circular | Circular - baseline | Progress indicator circular track active indicator space     | md.comp.progress-indicator.circular.track-active-indicator-space     | 4dp   |       |
+| Progress indicator - Circular | Circular - baseline | Progress indicator circular active indicator wave amplitude  | md.comp.progress-indicator.circular.active-indicator.wave.amplitude  | 1.6dp |       |
+| Progress indicator - Circular | Circular - baseline | Progress indicator circular active indicator wave wavelength | md.comp.progress-indicator.circular.active-indicator.wave.wavelength | 15dp  |       |
+
+## Measurements
+
+| Category             | Item                          | Value                                                    | Notes                                                                                      |
+|----------------------|-------------------------------|----------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| Wave terminology     | Amplitude                     | Center of the resting position to the center of the peak | Explicit prose definition in Measurements.                                                 |
+| Wave terminology     | Wavelength                    | Distance between two adjacent peaks                      | Explicit prose definition in Measurements.                                                 |
+| Linear               | Default track thickness       | 4dp                                                      | Configurations lists fixed 4dp thickness; the linear baseline token set matches it.        |
+| Linear               | Wavy height                   | 10dp                                                     | From md.comp.progress-indicator.linear.with-wave.height.                                   |
+| Linear               | Active indicator thickness    | 4dp                                                      | From md.comp.progress-indicator.linear.active-indicator.thickness.                         |
+| Linear               | Track thickness               | 4dp                                                      | From md.comp.progress-indicator.linear.track.thickness.                                    |
+| Linear               | Stop indicator size           | 4dp                                                      | From md.comp.progress-indicator.linear.stop-indicator.size.                                |
+| Linear               | Track-active space            | 4dp                                                      | From md.comp.progress-indicator.linear.track-active-indicator-space.                       |
+| Linear               | Stop indicator trailing space | 0                                                        | From md.comp.progress-indicator.linear.stop-indicator.trailing-space.                      |
+| Linear               | Wave amplitude                | 3dp                                                      | From md.comp.progress-indicator.linear.active-indicator.wave.amplitude.                    |
+| Linear               | Wave wavelength               | 40dp                                                     | From md.comp.progress-indicator.linear.active-indicator.wave.wavelength.                   |
+| Linear indeterminate | Wave wavelength               | 20dp                                                     | From md.comp.progress-indicator.linear.indeterminate.active-indicator.wave.wavelength.     |
+| Linear               | Screen-edge inset             | 4dp                                                      | Explicit prose in Measurements: the indicator is inset from the edge of the screen by 4dp. |
+| Circular             | Default size                  | 40dp                                                     | From md.comp.progress-indicator.circular.size.                                             |
+| Circular             | Wavy size                     | 48dp                                                     | From md.comp.progress-indicator.circular.with-wave.size.                                   |
+| Circular             | Active indicator thickness    | 4dp                                                      | From md.comp.progress-indicator.circular.active-indicator.thickness.                       |
+| Circular             | Track thickness               | 4dp                                                      | From md.comp.progress-indicator.circular.track.thickness.                                  |
+| Circular             | Track-active space            | 4dp                                                      | From md.comp.progress-indicator.circular.track-active-indicator-space.                     |
+| Circular             | Wave amplitude                | 1.6dp                                                    | From md.comp.progress-indicator.circular.active-indicator.wave.amplitude.                  |
+| Circular             | Wave wavelength               | 15dp                                                     | From md.comp.progress-indicator.circular.active-indicator.wave.wavelength.                 |
+
+## Implementation Notes
+
+- Model shared colors separately from variant-specific geometry. Linear and circular sizing is not encoded in the common token set.
+- Treat the shared shape tokens as fully rounded/circular until another source exposes a resolved radius token; the rendered token previews use a circular-shape class and no numeric text.
+- Support both flat and wavy linear indicators; expressive linear geometry depends on wave height, amplitude, and wavelength tokens rather than only track thickness.
+- Keep deprecated thick token groups out of default implementation paths unless you intentionally need archived compatibility behavior.

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -25,6 +25,12 @@ if TYPE_CHECKING:
     from .chip import AssistChip, FilterChip, InputChip, SuggestionChip
     from .dialogs import AlertDialog
     from .loading_indicator import LoadingIndicator
+    from .progress_indicators import (
+        CircularProgressIndicator,
+        IndeterminateCircularProgressIndicator,
+        IndeterminateLinearProgressIndicator,
+        LinearProgressIndicator,
+    )
     from .menu import Menu, MenuDivider, MenuItem, SubMenuItem
     from .intents import LoadingIntent
     from .icon import Icon
@@ -84,6 +90,10 @@ __all__ = [
     "MaterialOverlay",
     "AlertDialog",
     "LoadingIndicator",
+    "LinearProgressIndicator",
+    "IndeterminateLinearProgressIndicator",
+    "CircularProgressIndicator",
+    "IndeterminateCircularProgressIndicator",
     "Menu",
     "MenuDivider",
     "MenuItem",
@@ -150,6 +160,10 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "MaterialOverlay": ("overlay", "MaterialOverlay"),
     "AlertDialog": ("dialogs", "AlertDialog"),
     "LoadingIndicator": ("loading_indicator", "LoadingIndicator"),
+    "LinearProgressIndicator": ("progress_indicators", "LinearProgressIndicator"),
+    "IndeterminateLinearProgressIndicator": ("progress_indicators", "IndeterminateLinearProgressIndicator"),
+    "CircularProgressIndicator": ("progress_indicators", "CircularProgressIndicator"),
+    "IndeterminateCircularProgressIndicator": ("progress_indicators", "IndeterminateCircularProgressIndicator"),
     "Menu": ("menu", "Menu"),
     "MenuDivider": ("menu", "MenuDivider"),
     "MenuItem": ("menu", "MenuItem"),

--- a/src/nuiitivet/material/progress_indicators.py
+++ b/src/nuiitivet/material/progress_indicators.py
@@ -1,0 +1,930 @@
+"""Material Design 3 progress indicators."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Tuple, TypeGuard, cast
+
+from nuiitivet.animation import Animatable, LinearMotion
+from nuiitivet.observable import ObservableProtocol, runtime
+from nuiitivet.rendering.sizing import SizingLike
+from nuiitivet.rendering.skia import draw_round_rect, make_paint, make_rect
+from nuiitivet.theme.manager import manager as theme_manager
+from nuiitivet.theme.resolver import resolve_color_to_rgba
+from nuiitivet.widgeting.widget import Widget
+
+from .styles.progress_indicator_style import (
+    CircularProgressIndicatorStyle,
+    LinearProgressIndicatorStyle,
+)
+
+PaddingArg = Tuple[int, int] | Tuple[int, int, int, int] | int
+
+# Jetpack Compose Material3 indeterminate linear timing specs.
+_LINEAR_ANIMATION_DURATION_MS = 1750.0
+_LINEAR_FIRST_HEAD_DURATION_MS = 1000.0
+_LINEAR_FIRST_TAIL_DURATION_MS = 1000.0
+_LINEAR_SECOND_HEAD_DURATION_MS = 850.0
+_LINEAR_SECOND_TAIL_DURATION_MS = 850.0
+_LINEAR_FIRST_HEAD_DELAY_MS = 0.0
+_LINEAR_FIRST_TAIL_DELAY_MS = 250.0
+_LINEAR_SECOND_HEAD_DELAY_MS = 650.0
+_LINEAR_SECOND_TAIL_DELAY_MS = 900.0
+
+# Jetpack Compose Material3 indeterminate circular timing specs.
+_CIRCULAR_ANIMATION_DURATION_MS = 6000.0
+_CIRCULAR_ADDITIONAL_ROTATION_DELAY_MS = 1500.0
+_CIRCULAR_ADDITIONAL_ROTATION_DURATION_MS = 300.0
+_CIRCULAR_ADDITIONAL_ROTATION_DEGREES_TARGET = 360.0
+_CIRCULAR_GLOBAL_ROTATION_DEGREES_TARGET = 1080.0
+_CIRCULAR_INDETERMINATE_MIN_PROGRESS = 0.1
+_CIRCULAR_INDETERMINATE_MAX_PROGRESS = 0.87
+
+# MotionTokens from androidx.compose.material3.tokens.MotionTokens
+_EASING_EMPHASIZED_ACCELERATE = (0.3, 0.0, 0.8, 0.15)
+_EASING_EMPHASIZED_DECELERATE = (0.05, 0.7, 0.1, 1.0)
+_EASING_STANDARD = (0.2, 0.0, 0.0, 1.0)
+
+
+def _is_observable(value: object) -> TypeGuard[ObservableProtocol[Any]]:
+    return hasattr(value, "subscribe") and hasattr(value, "value")
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _apply_alpha(rgba: tuple[int, int, int, int], alpha: float) -> tuple[int, int, int, int]:
+    r, g, b, a = rgba
+    clamped = max(0.0, min(1.0, float(alpha)))
+    return (int(r), int(g), int(b), int(round(a * clamped)))
+
+
+def _resolve_active_track_colors(
+    *,
+    style: LinearProgressIndicatorStyle | CircularProgressIndicatorStyle,
+    disabled: bool,
+) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
+    """Resolve active/track colors with disabled alpha handling."""
+    theme = theme_manager.current
+
+    active = resolve_color_to_rgba(style.active_indicator_color, theme=theme) or (0, 0, 0, 255)
+    track = resolve_color_to_rgba(style.track_color, theme=theme) or (0, 0, 0, 255)
+
+    if disabled:
+        active = _apply_alpha(active, style.disabled_active_alpha)
+        track = _apply_alpha(track, style.disabled_track_alpha)
+
+    return active, track
+
+
+def _circular_geometry(
+    *,
+    content_x: int,
+    content_y: int,
+    content_w: int,
+    content_h: int,
+    track_thickness: float,
+) -> tuple[float, float, float, float]:
+    """Return circular indicator center and radius from content bounds."""
+    side = float(min(content_w, content_h))
+    stroke_w = max(1.0, float(track_thickness))
+    radius = max(0.0, (side - stroke_w) / 2.0)
+    cx = float(content_x) + (float(content_w) / 2.0)
+    cy = float(content_y) + (float(content_h) / 2.0)
+    return stroke_w, radius, cx, cy
+
+
+def _clamp_square_size(size: int, max_width: int | None = None, max_height: int | None = None) -> tuple[int, int]:
+    """Clamp square widget size to layout constraints."""
+    clamped = int(size)
+    if max_width is not None:
+        clamped = min(clamped, int(max_width))
+    if max_height is not None:
+        clamped = min(clamped, int(max_height))
+    return (clamped, clamped)
+
+
+def _cubic_bezier_transform(t: float, x1: float, y1: float, x2: float, y2: float) -> float:
+    t = _clamp01(t)
+    if t <= 0.0:
+        return 0.0
+    if t >= 1.0:
+        return 1.0
+
+    def sample_x(u: float) -> float:
+        return ((3.0 * x1 - 3.0 * x2 + 1.0) * u * u * u) + ((3.0 * x2 - 6.0 * x1) * u * u) + ((3.0 * x1) * u)
+
+    def sample_y(u: float) -> float:
+        return ((3.0 * y1 - 3.0 * y2 + 1.0) * u * u * u) + ((3.0 * y2 - 6.0 * y1) * u * u) + ((3.0 * y1) * u)
+
+    def sample_dx(u: float) -> float:
+        return ((9.0 * x1 - 9.0 * x2 + 3.0) * u * u) + ((6.0 * x2 - 12.0 * x1) * u) + (3.0 * x1)
+
+    u = t
+    for _ in range(8):
+        x = sample_x(u) - t
+        dx = sample_dx(u)
+        if abs(dx) < 1e-6:
+            break
+        u -= x / dx
+        u = _clamp01(u)
+
+    if abs(sample_x(u) - t) > 1e-5:
+        low = 0.0
+        high = 1.0
+        u = t
+        for _ in range(12):
+            x = sample_x(u)
+            if x < t:
+                low = u
+            else:
+                high = u
+            u = (low + high) * 0.5
+
+    return sample_y(u)
+
+
+def _easing_transform(t: float, cubic: tuple[float, float, float, float]) -> float:
+    x1, y1, x2, y2 = cubic
+    return _cubic_bezier_transform(t, x1, y1, x2, y2)
+
+
+def _keyframe_fraction(
+    time_ms: float,
+    *,
+    delay_ms: float,
+    duration_ms: float,
+    easing: Callable[[float], float],
+) -> float:
+    if time_ms <= delay_ms:
+        return 0.0
+    end_ms = delay_ms + duration_ms
+    if time_ms >= end_ms:
+        return 1.0
+    normalized = (time_ms - delay_ms) / max(duration_ms, 1e-9)
+    return _clamp01(easing(_clamp01(normalized)))
+
+
+def _linear_indeterminate_segment_fractions(time_ms: float) -> tuple[float, float, float, float]:
+    """Return Jetpack-compatible head/tail fractions for indeterminate linear segments."""
+    t = float(time_ms) % _LINEAR_ANIMATION_DURATION_MS
+
+    def easing(value: float) -> float:
+        return _easing_transform(value, _EASING_EMPHASIZED_ACCELERATE)
+
+    first_head = _keyframe_fraction(
+        t,
+        delay_ms=_LINEAR_FIRST_HEAD_DELAY_MS,
+        duration_ms=_LINEAR_FIRST_HEAD_DURATION_MS,
+        easing=easing,
+    )
+    first_tail = _keyframe_fraction(
+        t,
+        delay_ms=_LINEAR_FIRST_TAIL_DELAY_MS,
+        duration_ms=_LINEAR_FIRST_TAIL_DURATION_MS,
+        easing=easing,
+    )
+    second_head = _keyframe_fraction(
+        t,
+        delay_ms=_LINEAR_SECOND_HEAD_DELAY_MS,
+        duration_ms=_LINEAR_SECOND_HEAD_DURATION_MS,
+        easing=easing,
+    )
+    second_tail = _keyframe_fraction(
+        t,
+        delay_ms=_LINEAR_SECOND_TAIL_DELAY_MS,
+        duration_ms=_LINEAR_SECOND_TAIL_DURATION_MS,
+        easing=easing,
+    )
+    return (first_head, first_tail, second_head, second_tail)
+
+
+def _circular_additional_rotation_degrees(time_ms: float) -> float:
+    t = time_ms % _CIRCULAR_ANIMATION_DURATION_MS
+
+    def emphasized_decelerate(v: float) -> float:
+        return _easing_transform(v, _EASING_EMPHASIZED_DECELERATE)
+
+    points = (
+        # Match Jetpack keyframes semantics:
+        # - only the first animated leg uses emphasized decelerate easing
+        # - remaining animated legs are linear
+        # - plateaus are holds
+        (0.0, 0.0, "hold"),
+        (_CIRCULAR_ADDITIONAL_ROTATION_DURATION_MS, 90.0, "decelerate"),
+        (_CIRCULAR_ADDITIONAL_ROTATION_DELAY_MS, 90.0, "hold"),
+        (_CIRCULAR_ADDITIONAL_ROTATION_DURATION_MS + _CIRCULAR_ADDITIONAL_ROTATION_DELAY_MS, 180.0, "linear"),
+        (_CIRCULAR_ADDITIONAL_ROTATION_DELAY_MS * 2.0, 180.0, "hold"),
+        (
+            _CIRCULAR_ADDITIONAL_ROTATION_DURATION_MS + (_CIRCULAR_ADDITIONAL_ROTATION_DELAY_MS * 2.0),
+            270.0,
+            "linear",
+        ),
+        (_CIRCULAR_ADDITIONAL_ROTATION_DELAY_MS * 3.0, 270.0, "hold"),
+        (
+            _CIRCULAR_ADDITIONAL_ROTATION_DURATION_MS + (_CIRCULAR_ADDITIONAL_ROTATION_DELAY_MS * 3.0),
+            _CIRCULAR_ADDITIONAL_ROTATION_DEGREES_TARGET,
+            "linear",
+        ),
+        (_CIRCULAR_ANIMATION_DURATION_MS, _CIRCULAR_ADDITIONAL_ROTATION_DEGREES_TARGET, "hold"),
+    )
+
+    for i in range(len(points) - 1):
+        start_t, start_v, _ = points[i]
+        end_t, end_v, mode = points[i + 1]
+        if t <= end_t:
+            if mode == "hold" or end_t <= start_t:
+                return start_v
+            local = (t - start_t) / (end_t - start_t)
+            if mode == "decelerate":
+                local = emphasized_decelerate(_clamp01(local))
+            else:
+                local = _clamp01(local)
+            return start_v + (end_v - start_v) * local
+    return _CIRCULAR_ADDITIONAL_ROTATION_DEGREES_TARGET
+
+
+def _circular_progress_fraction(time_ms: float) -> float:
+    t = time_ms % _CIRCULAR_ANIMATION_DURATION_MS
+    half = _CIRCULAR_ANIMATION_DURATION_MS / 2.0
+
+    def easing(v: float) -> float:
+        return _easing_transform(v, _EASING_STANDARD)
+
+    if t <= half:
+        local = _clamp01(t / max(half, 1e-9))
+        return _CIRCULAR_INDETERMINATE_MIN_PROGRESS + (
+            (_CIRCULAR_INDETERMINATE_MAX_PROGRESS - _CIRCULAR_INDETERMINATE_MIN_PROGRESS) * easing(local)
+        )
+
+    local = _clamp01((t - half) / max(half, 1e-9))
+    # Jetpack keyframes omit easing for the return leg, so keep this linear.
+    return _CIRCULAR_INDETERMINATE_MAX_PROGRESS + (
+        (_CIRCULAR_INDETERMINATE_MIN_PROGRESS - _CIRCULAR_INDETERMINATE_MAX_PROGRESS) * local
+    )
+
+
+class _ProgressIndicatorBase(Widget):
+    """Shared behavior for progress indicator widgets."""
+
+    def __init__(
+        self,
+        *,
+        disabled: bool | ObservableProtocol[bool],
+        width: SizingLike = None,
+        height: SizingLike = None,
+        padding: PaddingArg = 0,
+    ) -> None:
+        """Initialize shared progress indicator base state.
+
+        Args:
+            disabled: Disabled state or observable disabled state.
+            width: Width sizing.
+            height: Height sizing.
+            padding: Padding around the indicator.
+        """
+        self._disabled_external: ObservableProtocol[bool] | None = None
+        if _is_observable(disabled):
+            self._disabled_external = cast(ObservableProtocol[bool], disabled)
+            self._disabled = bool(self._disabled_external.value)
+        else:
+            self._disabled = bool(disabled)
+
+        super().__init__(width=width, height=height, padding=padding)
+
+    @property
+    def disabled(self) -> bool:
+        """Return whether the indicator is disabled."""
+        return bool(self._disabled)
+
+    def _sync_disabled_from_external(self) -> None:
+        if self._disabled_external is None:
+            return
+        next_disabled = bool(self._disabled_external.value)
+        if next_disabled == self._disabled:
+            return
+        self._disabled = next_disabled
+        self.invalidate()
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if self._disabled_external is not None:
+            self.observe(self._disabled_external, lambda _v: self._sync_disabled_from_external())
+        self._sync_disabled_from_external()
+
+
+class _DeterminateProgressBase(_ProgressIndicatorBase):
+    """Shared behavior for determinate indicators with value state."""
+
+    def __init__(
+        self,
+        value: float | ObservableProtocol[float],
+        *,
+        disabled: bool | ObservableProtocol[bool],
+        width: SizingLike = None,
+        height: SizingLike = None,
+        padding: PaddingArg = 0,
+    ) -> None:
+        """Initialize shared determinate progress indicator state.
+
+        Args:
+            value: Progress value or observable progress value.
+            disabled: Disabled state or observable disabled state.
+            width: Width sizing.
+            height: Height sizing.
+            padding: Padding around the indicator.
+        """
+        self._value_external: ObservableProtocol[float] | None = None
+        if _is_observable(value):
+            self._value_external = cast(ObservableProtocol[float], value)
+            self._value = _clamp01(float(self._value_external.value))
+        else:
+            self._value = _clamp01(float(cast(float, value)))
+
+        super().__init__(
+            disabled=disabled,
+            width=width,
+            height=height,
+            padding=padding,
+        )
+
+    @property
+    def value(self) -> float:
+        """Return determinate progress value in range [0.0, 1.0]."""
+        return float(self._value)
+
+    @value.setter
+    def value(self, value: float) -> None:
+        next_value = _clamp01(value)
+        if abs(next_value - self._value) < 1e-8:
+            return
+        self._value = next_value
+        if self._value_external is not None:
+            try:
+                self._value_external.value = next_value
+            except Exception:
+                pass
+        self.invalidate()
+
+    def _sync_value_from_external(self) -> None:
+        if self._value_external is None:
+            return
+        next_value = _clamp01(float(self._value_external.value))
+        if abs(next_value - self._value) < 1e-8:
+            return
+        self._value = next_value
+        self.invalidate()
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if self._value_external is not None:
+            self.observe(self._value_external, lambda _v: self._sync_value_from_external())
+        self._sync_value_from_external()
+
+
+class _IndeterminateProgressBase(_ProgressIndicatorBase):
+    """Shared behavior for indeterminate indicators with animated phase."""
+
+    def __init__(
+        self,
+        *,
+        disabled: bool | ObservableProtocol[bool],
+        width: SizingLike = None,
+        height: SizingLike = None,
+        padding: PaddingArg = 0,
+    ) -> None:
+        """Initialize shared indeterminate progress indicator state.
+
+        Args:
+            disabled: Disabled state or observable disabled state.
+            width: Width sizing.
+            height: Height sizing.
+            padding: Padding around the indicator.
+        """
+        super().__init__(disabled=disabled, width=width, height=height, padding=padding)
+        if not hasattr(self, "_animation_motion"):
+            self._animation_motion = LinearMotion(1.0)
+        self._phase_anim: Animatable[float] | None = None
+        self._phase_sub: Any = None
+        self._phase_timer: Any = None
+
+    @property
+    def phase(self) -> float:
+        """Return current indeterminate phase."""
+        if self._phase_anim is None:
+            return 0.0
+        return float(self._phase_anim.value)
+
+    def _animation_motion_duration(self) -> float:
+        return 0.2
+
+    def _start_phase_loop(self) -> None:
+        duration = max(0.01, float(self._animation_motion_duration()))
+
+        if self._phase_anim is None:
+            self._phase_anim = Animatable(0.0, motion=self._animation_motion)
+            self._phase_anim.target = 1.0
+
+        if self._phase_sub is not None:
+            self._phase_sub.dispose()
+        self._phase_sub = self._phase_anim.subscribe(lambda _v: self.invalidate())
+
+        if self._phase_timer is not None:
+            runtime.clock.unschedule(self._phase_timer)
+
+        def _advance(_dt: float) -> None:
+            if not getattr(self, "_app", None):
+                self._phase_timer = None
+                return
+            if self._phase_anim is not None:
+                self._phase_anim.target = self._phase_anim.target + 1.0
+            runtime.clock.schedule_once(_advance, duration)
+
+        self._phase_timer = _advance
+        runtime.clock.schedule_once(_advance, duration)
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._start_phase_loop()
+
+    def on_unmount(self) -> None:
+        if self._phase_sub is not None:
+            self._phase_sub.dispose()
+            self._phase_sub = None
+        if self._phase_timer is not None:
+            runtime.clock.unschedule(self._phase_timer)
+            self._phase_timer = None
+        if self._phase_anim is not None:
+            self._phase_anim.stop()
+            self._phase_anim = None
+        super().on_unmount()
+
+
+class LinearProgressIndicator(_DeterminateProgressBase):
+    """Material Design 3 determinate linear progress indicator."""
+
+    def __init__(
+        self,
+        value: float | ObservableProtocol[float] = 0.0,
+        *,
+        disabled: bool | ObservableProtocol[bool] = False,
+        width: SizingLike = "1%",
+        padding: PaddingArg = 0,
+        style: LinearProgressIndicatorStyle | None = None,
+    ) -> None:
+        """Initialize LinearProgressIndicator.
+
+        Args:
+            value: Progress value in range ``[0.0, 1.0]``. Values are clamped.
+            disabled: Disabled state.
+            width: Width sizing.
+            padding: Padding around the indicator.
+            style: Optional style override.
+        """
+        self._style = style
+        style_for_layout = style or LinearProgressIndicatorStyle.default()
+        super().__init__(
+            value=value,
+            disabled=disabled,
+            width=width,
+            height=max(1, int(round(style_for_layout.track_thickness))),
+            padding=padding,
+        )
+
+    @property
+    def style(self) -> LinearProgressIndicatorStyle:
+        """Return effective linear progress indicator style."""
+        if self._style is not None:
+            return self._style
+        from nuiitivet.material.theme.theme_data import MaterialThemeData
+
+        mat = theme_manager.current.extension(MaterialThemeData)
+        if mat is not None:
+            return mat.linear_progress_indicator_style
+        return LinearProgressIndicatorStyle.default()
+
+    def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int], tuple[int, int, int, int]]:
+        style = self.style
+        theme = theme_manager.current
+
+        active = resolve_color_to_rgba(style.active_indicator_color, theme=theme) or (0, 0, 0, 255)
+        track = resolve_color_to_rgba(style.track_color, theme=theme) or (0, 0, 0, 255)
+        stop = resolve_color_to_rgba(style.stop_indicator_color, theme=theme) or active
+
+        if self.disabled:
+            active = _apply_alpha(active, style.disabled_active_alpha)
+            track = _apply_alpha(track, style.disabled_track_alpha)
+            stop = _apply_alpha(active, style.disabled_active_alpha)
+
+        return active, track, stop
+
+    def paint(self, canvas: Any, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        if canvas is None:
+            return
+
+        content_x, content_y, content_w, content_h = self.content_rect(x, y, width, height)
+        if content_w <= 0 or content_h <= 0:
+            return
+
+        style = self.style
+        thickness = max(1.0, float(style.track_thickness))
+        track_active_space = max(0.0, float(style.track_active_space))
+        track_y = float(content_y) + (float(content_h) - thickness) / 2.0
+        radius = thickness / 2.0
+
+        rect_track = make_rect(float(content_x), track_y, float(content_w), thickness)
+        if rect_track is None:
+            return
+
+        active_rgba, track_rgba, stop_rgba = self._resolve_colors()
+        active_paint = make_paint(color=active_rgba, style="fill", aa=True)
+        track_paint = make_paint(color=track_rgba, style="fill", aa=True)
+
+        progress_x = float(content_x) + (float(content_w) * self.value)
+        gap = 0.0
+        if 0.0 < self.value < 1.0:
+            gap = min(track_active_space, float(content_w))
+
+        active_end = max(float(content_x), progress_x - (gap / 2.0))
+        track_start = min(float(content_x) + float(content_w), progress_x + (gap / 2.0))
+
+        active_w = max(0.0, active_end - float(content_x))
+        remaining_w = max(0.0, (float(content_x) + float(content_w)) - track_start)
+
+        if active_w > 0.0 and active_paint is not None:
+            rect_active = make_rect(float(content_x), track_y, active_w, thickness)
+            if rect_active is not None:
+                draw_round_rect(canvas, rect_active, radius, active_paint)
+
+        if remaining_w > 0.0 and track_paint is not None:
+            rect_remaining = make_rect(track_start, track_y, remaining_w, thickness)
+            if rect_remaining is not None:
+                draw_round_rect(canvas, rect_remaining, radius, track_paint)
+
+        stop_size = max(0.0, float(style.stop_indicator_size))
+        if stop_size <= 0.0:
+            return
+
+        # Stop indicator is anchored to the track's trailing edge.
+        stop_x = float(content_x) + float(content_w) - float(style.stop_indicator_trailing_space) - (stop_size / 2.0)
+        stop_x = min(
+            float(content_x) + float(content_w) - (stop_size / 2.0),
+            max(float(content_x) + (stop_size / 2.0), stop_x),
+        )
+        stop_y = track_y + (thickness / 2.0)
+
+        stop_paint = make_paint(color=stop_rgba, style="fill", aa=True)
+        if stop_paint is None:
+            return
+
+        if hasattr(canvas, "drawCircle"):
+            canvas.drawCircle(float(stop_x), float(stop_y), stop_size / 2.0, stop_paint)
+            return
+
+        oval_rect = make_rect(
+            float(stop_x) - (stop_size / 2.0),
+            float(stop_y) - (stop_size / 2.0),
+            stop_size,
+            stop_size,
+        )
+        if oval_rect is not None and hasattr(canvas, "drawOval"):
+            canvas.drawOval(oval_rect, stop_paint)
+
+
+class IndeterminateLinearProgressIndicator(_IndeterminateProgressBase):
+    """Material Design 3 indeterminate linear progress indicator."""
+
+    def __init__(
+        self,
+        *,
+        disabled: bool | ObservableProtocol[bool] = False,
+        width: SizingLike = "1%",
+        padding: PaddingArg = 0,
+        style: LinearProgressIndicatorStyle | None = None,
+    ) -> None:
+        """Initialize IndeterminateLinearProgressIndicator.
+
+        Args:
+            disabled: Disabled state.
+            width: Width sizing.
+            padding: Padding around the indicator.
+            style: Optional style override.
+        """
+        self._style = style
+        style_for_layout = style or LinearProgressIndicatorStyle.default()
+        self._animation_motion = LinearMotion(self._animation_motion_duration())
+        super().__init__(
+            disabled=disabled,
+            width=width,
+            height=max(1, int(round(style_for_layout.track_thickness))),
+            padding=padding,
+        )
+
+    @property
+    def style(self) -> LinearProgressIndicatorStyle:
+        """Return effective linear progress indicator style."""
+        if self._style is not None:
+            return self._style
+        from nuiitivet.material.theme.theme_data import MaterialThemeData
+
+        mat = theme_manager.current.extension(MaterialThemeData)
+        if mat is not None:
+            return mat.linear_progress_indicator_style
+        return LinearProgressIndicatorStyle.default()
+
+    def _animation_motion_duration(self) -> float:
+        return _LINEAR_ANIMATION_DURATION_MS / 1000.0
+
+    def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
+        return _resolve_active_track_colors(style=self.style, disabled=self.disabled)
+
+    def paint(self, canvas: Any, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        if canvas is None:
+            return
+
+        content_x, content_y, content_w, content_h = self.content_rect(x, y, width, height)
+        if content_w <= 0 or content_h <= 0:
+            return
+
+        style = self.style
+        thickness = max(1.0, float(style.track_thickness))
+        track_active_space = max(0.0, float(style.track_active_space))
+        track_y = float(content_y) + (float(content_h) - thickness) / 2.0
+        radius = thickness / 2.0
+
+        rect_track = make_rect(float(content_x), track_y, float(content_w), thickness)
+        if rect_track is None:
+            return
+
+        active_rgba, track_rgba = self._resolve_colors()
+
+        track_paint = make_paint(color=track_rgba, style="fill", aa=True)
+        if track_paint is not None:
+            draw_round_rect(canvas, rect_track, radius, track_paint)
+
+        active_min_x = float(content_x) + (track_active_space / 2.0)
+        active_w = max(0.0, float(content_w) - track_active_space)
+        if active_w <= 0.0:
+            return
+
+        phase = self.phase % 1.0
+        time_ms = phase * _LINEAR_ANIMATION_DURATION_MS
+        first_head, first_tail, second_head, second_tail = _linear_indeterminate_segment_fractions(time_ms)
+
+        active_paint = make_paint(color=active_rgba, style="fill", aa=True)
+        if active_paint is None:
+            return
+
+        def draw_segment(start_fraction: float, end_fraction: float) -> None:
+            start = _clamp01(start_fraction)
+            end = _clamp01(end_fraction)
+            if end <= start:
+                return
+
+            start_x = active_min_x + (active_w * start)
+            end_x = active_min_x + (active_w * end)
+            rect_active = make_rect(start_x, track_y, end_x - start_x, thickness)
+            if rect_active is not None:
+                draw_round_rect(canvas, rect_active, radius, active_paint)
+
+        draw_segment(first_tail, first_head)
+        draw_segment(second_tail, second_head)
+
+
+class CircularProgressIndicator(_DeterminateProgressBase):
+    """Material Design 3 determinate circular progress indicator."""
+
+    def __init__(
+        self,
+        value: float | ObservableProtocol[float] = 0.0,
+        *,
+        disabled: bool | ObservableProtocol[bool] = False,
+        size: int | None = None,
+        padding: PaddingArg = 0,
+        style: CircularProgressIndicatorStyle | None = None,
+    ) -> None:
+        """Initialize CircularProgressIndicator.
+
+        Args:
+            value: Progress value in range ``[0.0, 1.0]``. Values are clamped.
+            disabled: Disabled state.
+            size: Outer indicator size in dp. Uses style default when omitted.
+            padding: Padding around the indicator.
+            style: Optional style override.
+        """
+        self._style = style
+        style_for_layout = style or CircularProgressIndicatorStyle.default()
+        self._size = int(size) if size is not None else max(1, int(round(style_for_layout.size)))
+        super().__init__(
+            value=value,
+            disabled=disabled,
+            width=self._size,
+            height=self._size,
+            padding=padding,
+        )
+
+    @property
+    def style(self) -> CircularProgressIndicatorStyle:
+        """Return effective circular progress indicator style."""
+        if self._style is not None:
+            return self._style
+        from nuiitivet.material.theme.theme_data import MaterialThemeData
+
+        mat = theme_manager.current.extension(MaterialThemeData)
+        if mat is not None:
+            return mat.circular_progress_indicator_style
+        return CircularProgressIndicatorStyle.default()
+
+    def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
+        return _resolve_active_track_colors(style=self.style, disabled=self.disabled)
+
+    def preferred_size(self, max_width: int | None = None, max_height: int | None = None) -> tuple[int, int]:
+        return _clamp_square_size(self._size, max_width=max_width, max_height=max_height)
+
+    def paint(self, canvas: Any, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        if canvas is None:
+            return
+
+        content_x, content_y, content_w, content_h = self.content_rect(x, y, width, height)
+        if content_w <= 0 or content_h <= 0:
+            return
+
+        style = self.style
+        stroke_w, radius, cx, cy = _circular_geometry(
+            content_x=content_x,
+            content_y=content_y,
+            content_w=content_w,
+            content_h=content_h,
+            track_thickness=float(style.track_thickness),
+        )
+        track_active_space = max(0.0, float(style.track_active_space))
+
+        active_rgba, track_rgba = self._resolve_colors()
+        active_paint = make_paint(color=active_rgba, style="stroke", stroke_width=stroke_w, aa=True, stroke_cap="round")
+        track_paint = make_paint(color=track_rgba, style="stroke", stroke_width=stroke_w, aa=True, stroke_cap="round")
+        if active_paint is None and track_paint is None:
+            return
+
+        progress_sweep = max(0.0, min(360.0, 360.0 * self.value))
+        gap_deg = 0.0
+        if 0.0 < self.value < 1.0 and radius > 0.0 and track_active_space > 0.0:
+            # Round stroke caps consume approximately one stroke width at the
+            # active/track boundary. Compensate so the visible gap remains close
+            # to the MD3 track_active_space token.
+            adjusted_gap = track_active_space + stroke_w
+            circumference = 2.0 * math.pi * radius
+            if circumference > 0.0:
+                gap_deg = min(360.0, (adjusted_gap / circumference) * 360.0)
+
+        active_start = -90.0
+        active_sweep = progress_sweep
+        track_start = -90.0 + progress_sweep
+        track_sweep = max(0.0, 360.0 - progress_sweep)
+        if 0.0 < self.value < 1.0 and gap_deg > 0.0:
+            # Keep an explicit gap at both active/track boundaries.
+            active_start += gap_deg / 2.0
+            active_sweep = max(0.0, progress_sweep - gap_deg)
+            track_start += gap_deg / 2.0
+            track_sweep = max(0.0, 360.0 - progress_sweep - gap_deg)
+
+        arc_rect = make_rect(
+            cx - radius,
+            cy - radius,
+            radius * 2.0,
+            radius * 2.0,
+        )
+        if arc_rect is None:
+            return
+
+        if hasattr(canvas, "drawArc"):
+            if active_paint is not None and active_sweep > 0.0:
+                canvas.drawArc(arc_rect, active_start, active_sweep, False, active_paint)
+            if track_paint is not None and track_sweep > 0.0:
+                canvas.drawArc(arc_rect, track_start, track_sweep, False, track_paint)
+            return
+
+        # Fallback: draw full circle only when complete if arc API is unavailable.
+        if self.value >= 1.0 and active_paint is not None and hasattr(canvas, "drawCircle"):
+            canvas.drawCircle(cx, cy, radius, active_paint)
+        elif track_paint is not None and hasattr(canvas, "drawCircle"):
+            canvas.drawCircle(cx, cy, radius, track_paint)
+
+
+class IndeterminateCircularProgressIndicator(_IndeterminateProgressBase):
+    """Material Design 3 indeterminate circular progress indicator."""
+
+    def __init__(
+        self,
+        *,
+        disabled: bool | ObservableProtocol[bool] = False,
+        size: int | None = None,
+        padding: PaddingArg = 0,
+        style: CircularProgressIndicatorStyle | None = None,
+    ) -> None:
+        """Initialize IndeterminateCircularProgressIndicator.
+
+        Args:
+            disabled: Disabled state.
+            size: Outer indicator size in dp. Uses style default when omitted.
+            padding: Padding around the indicator.
+            style: Optional style override.
+        """
+        self._style = style
+        style_for_motion = style or CircularProgressIndicatorStyle.default()
+        self._size = int(size) if size is not None else max(1, int(round(style_for_motion.size)))
+        self._animation_motion = LinearMotion(self._animation_motion_duration())
+        super().__init__(
+            disabled=disabled,
+            width=self._size,
+            height=self._size,
+            padding=padding,
+        )
+
+    @property
+    def style(self) -> CircularProgressIndicatorStyle:
+        """Return effective circular progress indicator style."""
+        if self._style is not None:
+            return self._style
+        from nuiitivet.material.theme.theme_data import MaterialThemeData
+
+        mat = theme_manager.current.extension(MaterialThemeData)
+        if mat is not None:
+            return mat.circular_progress_indicator_style
+        return CircularProgressIndicatorStyle.default()
+
+    def _animation_motion_duration(self) -> float:
+        return _CIRCULAR_ANIMATION_DURATION_MS / 1000.0
+
+    def preferred_size(self, max_width: int | None = None, max_height: int | None = None) -> tuple[int, int]:
+        return _clamp_square_size(self._size, max_width=max_width, max_height=max_height)
+
+    def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
+        return _resolve_active_track_colors(style=self.style, disabled=self.disabled)
+
+    def paint(self, canvas: Any, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        if canvas is None:
+            return
+
+        content_x, content_y, content_w, content_h = self.content_rect(x, y, width, height)
+        if content_w <= 0 or content_h <= 0:
+            return
+
+        style = self.style
+        stroke_w, radius, cx, cy = _circular_geometry(
+            content_x=content_x,
+            content_y=content_y,
+            content_w=content_w,
+            content_h=content_h,
+            track_thickness=float(style.track_thickness),
+        )
+        track_active_space = max(0.0, float(style.track_active_space))
+
+        active_rgba, track_rgba = self._resolve_colors()
+
+        active_paint = make_paint(color=active_rgba, style="stroke", stroke_width=stroke_w, aa=True, stroke_cap="round")
+        track_paint = make_paint(color=track_rgba, style="stroke", stroke_width=stroke_w, aa=True, stroke_cap="round")
+        if active_paint is None and track_paint is None:
+            return
+
+        phase = self.phase % 1.0
+        time_ms = phase * _CIRCULAR_ANIMATION_DURATION_MS
+        global_rotation = (time_ms / _CIRCULAR_ANIMATION_DURATION_MS) * _CIRCULAR_GLOBAL_ROTATION_DEGREES_TARGET
+        additional_rotation = _circular_additional_rotation_degrees(time_ms)
+        sweep = _circular_progress_fraction(time_ms) * 360.0
+        gap_deg = 0.0
+        if radius > 0.0 and track_active_space > 0.0:
+            adjusted_gap = track_active_space + stroke_w
+            gap_deg = min(360.0, (adjusted_gap / (2.0 * math.pi * radius)) * 360.0)
+
+        gap_sweep = min(sweep, gap_deg)
+        rotation = global_rotation + additional_rotation
+        track_start = rotation + sweep + gap_sweep
+        track_sweep = max(0.0, 360.0 - sweep - (gap_sweep * 2.0))
+
+        arc_rect = make_rect(
+            cx - radius,
+            cy - radius,
+            radius * 2.0,
+            radius * 2.0,
+        )
+        if arc_rect is None:
+            return
+
+        if hasattr(canvas, "drawArc"):
+            if track_paint is not None and track_sweep > 0.0:
+                canvas.drawArc(arc_rect, track_start, track_sweep, False, track_paint)
+            if active_paint is not None and sweep > 0.0:
+                canvas.drawArc(arc_rect, rotation, sweep, False, active_paint)
+
+
+__all__ = [
+    "LinearProgressIndicator",
+    "IndeterminateLinearProgressIndicator",
+    "CircularProgressIndicator",
+    "IndeterminateCircularProgressIndicator",
+]

--- a/src/nuiitivet/material/styles/__init__.py
+++ b/src/nuiitivet/material/styles/__init__.py
@@ -10,6 +10,11 @@ from .chip_style import ChipStyle
 from .dialog_style import DialogStyle
 from .icon_style import IconStyle
 from .loading_indicator_style import LoadingIndicatorStyle
+from .progress_indicator_style import (
+    CircularProgressIndicatorStyle,
+    LinearProgressIndicatorStyle,
+    ProgressIndicatorStyle,
+)
 from .menu_style import MenuStyle
 from .navigation_rail_style import NavigationRailStyle
 from .radio_button_style import RadioButtonStyle
@@ -32,6 +37,9 @@ __all__ = [
     "DialogStyle",
     "IconStyle",
     "LoadingIndicatorStyle",
+    "ProgressIndicatorStyle",
+    "LinearProgressIndicatorStyle",
+    "CircularProgressIndicatorStyle",
     "MenuStyle",
     "NavigationRailStyle",
     "RadioButtonStyle",

--- a/src/nuiitivet/material/styles/progress_indicator_style.py
+++ b/src/nuiitivet/material/styles/progress_indicator_style.py
@@ -1,0 +1,150 @@
+"""Progress indicator style definitions (Material Design 3)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from nuiitivet.animation.motion import Motion
+from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_EFFECTS
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.theme.types import ColorSpec
+
+if TYPE_CHECKING:
+    from nuiitivet.theme import Theme
+
+
+TProgressStyle = TypeVar("TProgressStyle", bound="ProgressIndicatorStyle")
+
+
+@dataclass(frozen=True)
+class ProgressIndicatorStyle:
+    """Shared style tokens for progress indicators."""
+
+    active_indicator_color: ColorSpec = ColorRole.PRIMARY
+    track_color: ColorSpec = ColorRole.SECONDARY_CONTAINER
+    stop_indicator_color: ColorSpec = ColorRole.PRIMARY
+
+    disabled_active_alpha: float = 0.38
+    disabled_track_alpha: float = 0.12
+
+    def copy_with(self: TProgressStyle, **changes: Any) -> TProgressStyle:
+        """Create a new style instance with specified fields changed."""
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class LinearProgressIndicatorStyle(ProgressIndicatorStyle):
+    """Linear progress indicator geometry and motion tokens."""
+
+    track_thickness: float = 4.0
+    with_wave_height: float = 10.0
+    stop_indicator_size: float = 4.0
+    track_active_space: float = 4.0
+    stop_indicator_trailing_space: float = 0.0
+
+    wave_amplitude: float = 3.0
+    wave_wavelength: float = 40.0
+    indeterminate_wave_wavelength: float = 20.0
+
+    motion: Motion = EXPRESSIVE_DEFAULT_EFFECTS
+
+    @classmethod
+    def default(cls) -> "LinearProgressIndicatorStyle":
+        """Create the default linear progress style."""
+        return cls()
+
+    @classmethod
+    def flat(cls) -> "LinearProgressIndicatorStyle":
+        """Create a flat linear progress style preset."""
+        return cls(
+            with_wave_height=4.0,
+            wave_amplitude=0.0,
+        )
+
+    @classmethod
+    def from_theme(cls, theme: "Theme", variant: str = "default") -> "LinearProgressIndicatorStyle":
+        """Get linear progress style from theme.
+
+        Args:
+            theme: Theme to load style from.
+            variant: Variant name ("default" or "flat").
+
+        Returns:
+            LinearProgressIndicatorStyle resolved from theme or fallback preset.
+        """
+        from nuiitivet.material.theme.theme_data import MaterialThemeData
+
+        theme_data = theme.extension(MaterialThemeData)
+        v = (variant or "").lower()
+
+        if theme_data is not None:
+            base = theme_data.linear_progress_indicator_style
+            if v == "flat":
+                return base.copy_with(with_wave_height=base.track_thickness, wave_amplitude=0.0)
+            return base
+
+        if v == "flat":
+            return cls.flat()
+        return cls.default()
+
+
+@dataclass(frozen=True)
+class CircularProgressIndicatorStyle(ProgressIndicatorStyle):
+    """Circular progress indicator geometry and motion tokens."""
+
+    size: float = 40.0
+    with_wave_size: float = 48.0
+    track_thickness: float = 4.0
+    track_active_space: float = 4.0
+
+    wave_amplitude: float = 1.6
+    wave_wavelength: float = 15.0
+
+    motion: Motion = EXPRESSIVE_DEFAULT_EFFECTS
+
+    @classmethod
+    def default(cls) -> "CircularProgressIndicatorStyle":
+        """Create the default circular progress style."""
+        return cls()
+
+    @classmethod
+    def flat(cls) -> "CircularProgressIndicatorStyle":
+        """Create a flat circular progress style preset."""
+        return cls(
+            with_wave_size=40.0,
+            wave_amplitude=0.0,
+        )
+
+    @classmethod
+    def from_theme(cls, theme: "Theme", variant: str = "default") -> "CircularProgressIndicatorStyle":
+        """Get circular progress style from theme.
+
+        Args:
+            theme: Theme to load style from.
+            variant: Variant name ("default" or "flat").
+
+        Returns:
+            CircularProgressIndicatorStyle resolved from theme or fallback preset.
+        """
+        from nuiitivet.material.theme.theme_data import MaterialThemeData
+
+        theme_data = theme.extension(MaterialThemeData)
+        v = (variant or "").lower()
+
+        if theme_data is not None:
+            base = theme_data.circular_progress_indicator_style
+            if v == "flat":
+                return base.copy_with(with_wave_size=base.size, wave_amplitude=0.0)
+            return base
+
+        if v == "flat":
+            return cls.flat()
+        return cls.default()
+
+
+__all__ = [
+    "ProgressIndicatorStyle",
+    "LinearProgressIndicatorStyle",
+    "CircularProgressIndicatorStyle",
+]

--- a/src/nuiitivet/material/theme/theme_data.py
+++ b/src/nuiitivet/material/theme/theme_data.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
     from nuiitivet.material.styles.dialog_style import DialogStyle
     from nuiitivet.material.styles.icon_style import IconStyle
     from nuiitivet.material.styles.loading_indicator_style import LoadingIndicatorStyle
+    from nuiitivet.material.styles.progress_indicator_style import (
+        CircularProgressIndicatorStyle,
+        LinearProgressIndicatorStyle,
+    )
     from nuiitivet.material.styles.radio_button_style import RadioButtonStyle
     from nuiitivet.material.styles.slider_style import SliderStyle
     from nuiitivet.material.styles.switch_style import SwitchStyle
@@ -65,6 +69,10 @@ class MaterialThemeData(ThemeExtension):
     # Loading indicator variants
     _loading_indicator_style: "LoadingIndicatorStyle | None" = None
     _contained_loading_indicator_style: "LoadingIndicatorStyle | None" = None
+
+    # Progress indicator variants
+    _linear_progress_indicator_style: "LinearProgressIndicatorStyle | None" = None
+    _circular_progress_indicator_style: "CircularProgressIndicatorStyle | None" = None
 
     @property
     def filled_button_style(self) -> "ButtonStyle":
@@ -281,6 +289,24 @@ class MaterialThemeData(ThemeExtension):
         from nuiitivet.material.styles.loading_indicator_style import LoadingIndicatorStyle
 
         return LoadingIndicatorStyle.contained()
+
+    @property
+    def linear_progress_indicator_style(self) -> "LinearProgressIndicatorStyle":
+        """Get LinearProgressIndicatorStyle for this theme."""
+        if self._linear_progress_indicator_style is not None:
+            return self._linear_progress_indicator_style
+        from nuiitivet.material.styles.progress_indicator_style import LinearProgressIndicatorStyle
+
+        return LinearProgressIndicatorStyle.default()
+
+    @property
+    def circular_progress_indicator_style(self) -> "CircularProgressIndicatorStyle":
+        """Get CircularProgressIndicatorStyle for this theme."""
+        if self._circular_progress_indicator_style is not None:
+            return self._circular_progress_indicator_style
+        from nuiitivet.material.styles.progress_indicator_style import CircularProgressIndicatorStyle
+
+        return CircularProgressIndicatorStyle.default()
 
     def copy_with(self, **kwargs: Any) -> "MaterialThemeData":
         """Create a copy of this theme data with the given fields replaced."""

--- a/src/nuiitivet/rendering/skia/color.py
+++ b/src/nuiitivet/rendering/skia/color.py
@@ -48,7 +48,13 @@ def rgba_to_skia_color(rgba: Tuple[int, int, int, int]):
         return rgba
 
 
-def make_paint(color=None, style: str = "fill", stroke_width: float = 1.0, aa: bool = True):
+def make_paint(
+    color=None,
+    style: str = "fill",
+    stroke_width: float = 1.0,
+    aa: bool = True,
+    stroke_cap: str | None = None,
+):
     """Create and return a configured skia.Paint (or None if unavailable)."""
     skia = get_skia(raise_if_missing=False)
     if skia is None:
@@ -77,6 +83,29 @@ def make_paint(color=None, style: str = "fill", stroke_width: float = 1.0, aa: b
                 "skia_paint_set_stroke_width_exc",
                 "skia.Paint.setStrokeWidth failed",
             )
+
+        if style == "stroke" and stroke_cap:
+            cap_name = str(stroke_cap).strip().lower()
+            cap_attr = {
+                "butt": "kButt_Cap",
+                "round": "kRound_Cap",
+                "square": "kSquare_Cap",
+            }.get(cap_name)
+            if cap_attr is not None:
+                cap_const = getattr(skia.Paint, cap_attr, None)
+                if cap_const is None:
+                    cap_enum = getattr(skia.Paint, "Cap", None)
+                    if cap_enum is not None:
+                        cap_const = getattr(cap_enum, cap_attr, None)
+                if cap_const is not None:
+                    try:
+                        paint.setStrokeCap(cap_const)
+                    except Exception:
+                        exception_once(
+                            _logger,
+                            "skia_paint_set_stroke_cap_exc",
+                            "skia.Paint.setStrokeCap failed",
+                        )
 
         if color is not None:
             try:

--- a/src/samples/progress_indicators_demo.py
+++ b/src/samples/progress_indicators_demo.py
@@ -1,0 +1,86 @@
+"""Progress indicators demo for MD3 widgets."""
+
+from __future__ import annotations
+
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.container import Container
+from nuiitivet.layout.row import Row
+from nuiitivet.material import (
+    CircularProgressIndicator,
+    IndeterminateCircularProgressIndicator,
+    IndeterminateLinearProgressIndicator,
+    LinearProgressIndicator,
+    MaterialApp,
+    Slider,
+    Switch,
+    Text,
+)
+from nuiitivet.material.styles import CircularProgressIndicatorStyle, LinearProgressIndicatorStyle
+from nuiitivet.observable import Observable
+
+
+def main() -> None:
+    linear_value = Observable(0.35)
+    circular_value = Observable(0.65)
+    disabled = Observable(False)
+
+    content = Column(
+        children=[
+            Text("Progress Indicators Demo"),
+            Row(
+                children=[
+                    Switch(checked=disabled),
+                    Text(disabled.map(lambda v: f"Disabled: {'ON' if v else 'OFF'}")),
+                ],
+                gap=12,
+            ),
+            Text(linear_value.map(lambda v: f"Linear value: {v:.2f}")),
+            Slider(
+                value=linear_value,
+                length=320,
+                on_change=lambda value: setattr(linear_value, "value", value),
+            ),
+            LinearProgressIndicator(
+                value=linear_value,
+                disabled=disabled,
+                width=320,
+                style=LinearProgressIndicatorStyle.flat(),
+            ),
+            IndeterminateLinearProgressIndicator(
+                disabled=disabled,
+                width=320,
+                style=LinearProgressIndicatorStyle.flat(),
+            ),
+            Text(circular_value.map(lambda v: f"Circular value: {v:.2f}"), padding=(0, 8, 0, 0)),
+            Slider(
+                value=circular_value,
+                length=320,
+                on_change=lambda value: setattr(circular_value, "value", value),
+            ),
+            Row(
+                children=[
+                    CircularProgressIndicator(
+                        value=circular_value,
+                        disabled=disabled,
+                        size=40,
+                        style=CircularProgressIndicatorStyle.flat(),
+                    ),
+                    IndeterminateCircularProgressIndicator(
+                        disabled=disabled,
+                        size=40,
+                        style=CircularProgressIndicatorStyle.flat(),
+                    ),
+                ],
+                gap=24,
+            ),
+        ],
+        gap=12,
+        cross_alignment="start",
+    )
+
+    app = MaterialApp(content=Container(child=content, padding=24))
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_progress_indicator_style.py
+++ b/tests/test_progress_indicator_style.py
@@ -1,0 +1,92 @@
+"""Tests for progress indicator styles and theme integration."""
+
+from dataclasses import replace
+
+from nuiitivet.material.styles import (
+    CircularProgressIndicatorStyle,
+    LinearProgressIndicatorStyle,
+    ProgressIndicatorStyle,
+)
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.theme_data import MaterialThemeData
+
+
+def test_progress_indicator_style_defaults():
+    style = ProgressIndicatorStyle()
+    assert style.active_indicator_color == ColorRole.PRIMARY
+    assert style.track_color == ColorRole.SECONDARY_CONTAINER
+    assert style.stop_indicator_color == ColorRole.PRIMARY
+    assert style.disabled_active_alpha == 0.38
+    assert style.disabled_track_alpha == 0.12
+
+
+def test_linear_progress_style_presets():
+    default = LinearProgressIndicatorStyle.default()
+    flat = LinearProgressIndicatorStyle.flat()
+
+    assert default.track_thickness == 4.0
+    assert default.with_wave_height == 10.0
+    assert default.wave_amplitude == 3.0
+
+    assert flat.track_thickness == 4.0
+    assert flat.with_wave_height == 4.0
+    assert flat.wave_amplitude == 0.0
+
+
+def test_circular_progress_style_presets():
+    default = CircularProgressIndicatorStyle.default()
+    flat = CircularProgressIndicatorStyle.flat()
+
+    assert default.size == 40.0
+    assert default.with_wave_size == 48.0
+    assert default.wave_amplitude == 1.6
+
+    assert flat.size == 40.0
+    assert flat.with_wave_size == 40.0
+    assert flat.wave_amplitude == 0.0
+
+
+def test_progress_style_copy_with():
+    base = LinearProgressIndicatorStyle.default()
+    custom = base.copy_with(active_indicator_color=ColorRole.TERTIARY, track_thickness=6.0)
+
+    assert custom.active_indicator_color == ColorRole.TERTIARY
+    assert custom.track_thickness == 6.0
+    assert custom.with_wave_height == base.with_wave_height
+
+
+def test_theme_with_custom_progress_styles():
+    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    mat = light.extension(MaterialThemeData)
+    assert mat is not None
+
+    custom_linear = LinearProgressIndicatorStyle.default().copy_with(track_thickness=6.0)
+    custom_circular = CircularProgressIndicatorStyle.default().copy_with(track_thickness=5.0)
+
+    custom_theme = replace(
+        light,
+        extensions=[
+            mat.copy_with(
+                _linear_progress_indicator_style=custom_linear,
+                _circular_progress_indicator_style=custom_circular,
+            )
+        ],
+    )
+    custom_mat = custom_theme.extension(MaterialThemeData)
+    assert custom_mat is not None
+
+    assert custom_mat.linear_progress_indicator_style.track_thickness == 6.0
+    assert custom_mat.circular_progress_indicator_style.track_thickness == 5.0
+
+
+def test_progress_style_from_theme_variants():
+    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+
+    linear_default = LinearProgressIndicatorStyle.from_theme(light)
+    linear_flat = LinearProgressIndicatorStyle.from_theme(light, "flat")
+    circular_default = CircularProgressIndicatorStyle.from_theme(light)
+
+    assert linear_default.track_thickness == 4.0
+    assert linear_flat.wave_amplitude == 0.0
+    assert circular_default.track_thickness == 4.0

--- a/tests/test_progress_indicators.py
+++ b/tests/test_progress_indicators.py
@@ -1,0 +1,534 @@
+"""Tests for progress indicator widgets."""
+
+from dataclasses import replace
+import math
+from typing import Any
+
+from nuiitivet.observable import Observable
+from nuiitivet.material import (
+    CircularProgressIndicator,
+    IndeterminateCircularProgressIndicator,
+    IndeterminateLinearProgressIndicator,
+    LinearProgressIndicator,
+)
+from nuiitivet.material.styles import CircularProgressIndicatorStyle, LinearProgressIndicatorStyle
+from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.theme_data import MaterialThemeData
+from nuiitivet.theme import manager
+
+
+def test_linear_progress_value_clamped():
+    p = LinearProgressIndicator(value=2.5)
+    assert p.value == 1.0
+
+    p.value = -1.0
+    assert p.value == 0.0
+
+
+def test_circular_progress_value_clamped():
+    p = CircularProgressIndicator(value=-2.0)
+    assert p.value == 0.0
+
+    p.value = 3.0
+    assert p.value == 1.0
+
+
+def test_determinate_progress_supports_observable_value():
+    value = Observable(0.1)
+    linear = LinearProgressIndicator(value=value)
+    circular = CircularProgressIndicator(value=value)
+
+    linear.on_mount()
+    circular.on_mount()
+    try:
+        assert linear.value == 0.1
+        assert circular.value == 0.1
+
+        value.value = 0.8
+
+        assert linear.value == 0.8
+        assert circular.value == 0.8
+    finally:
+        linear.on_unmount()
+        circular.on_unmount()
+
+
+def test_progress_supports_observable_disabled():
+    disabled = Observable(False)
+    p = LinearProgressIndicator(value=0.5, disabled=disabled)
+
+    p.on_mount()
+    try:
+        assert p.disabled is False
+        disabled.value = True
+        assert p.disabled is True
+    finally:
+        p.on_unmount()
+
+
+def test_indeterminate_api_has_no_value_parameter():
+    linear = IndeterminateLinearProgressIndicator()
+    circular = IndeterminateCircularProgressIndicator()
+
+    assert not hasattr(linear, "value")
+    assert not hasattr(circular, "value")
+
+
+def test_progress_widgets_resolve_theme_styles():
+    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    mat = light.extension(MaterialThemeData)
+    assert mat is not None
+
+    custom_linear = LinearProgressIndicatorStyle.default().copy_with(track_thickness=7.0)
+    custom_circular = CircularProgressIndicatorStyle.default().copy_with(track_thickness=6.0)
+
+    custom_theme = replace(
+        light,
+        extensions=[
+            mat.copy_with(
+                _linear_progress_indicator_style=custom_linear,
+                _circular_progress_indicator_style=custom_circular,
+            )
+        ],
+    )
+
+    old_theme = manager.current
+    try:
+        manager.set_theme(custom_theme)
+
+        linear = LinearProgressIndicator(value=0.5)
+        circular = CircularProgressIndicator(value=0.5)
+
+        assert linear.style.track_thickness == 7.0
+        assert circular.style.track_thickness == 6.0
+    finally:
+        manager.set_theme(old_theme)
+
+
+def test_circular_progress_uses_style_size_when_size_is_omitted():
+    style = CircularProgressIndicatorStyle.default().copy_with(size=52.0)
+
+    determinate = CircularProgressIndicator(value=0.5, style=style)
+    indeterminate = IndeterminateCircularProgressIndicator(style=style)
+
+    assert determinate.preferred_size() == (52, 52)
+    assert indeterminate.preferred_size() == (52, 52)
+
+
+def test_circular_progress_explicit_size_overrides_style_size():
+    style = CircularProgressIndicatorStyle.default().copy_with(size=52.0)
+
+    determinate = CircularProgressIndicator(value=0.5, size=40, style=style)
+    indeterminate = IndeterminateCircularProgressIndicator(size=40, style=style)
+
+    assert determinate.preferred_size() == (40, 40)
+    assert indeterminate.preferred_size() == (40, 40)
+
+
+class _CanvasCapture:
+    def __init__(self) -> None:
+        self.arcs: list[tuple[float, float]] = []
+
+    def drawArc(self, _rect: Any, start: float, sweep: float, _use_center: bool, _paint: Any) -> None:
+        self.arcs.append((start, sweep))
+
+
+def test_linear_determinate_track_active_space_keeps_100_percent_full_width(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    draws: list[tuple[float, float, float, float]] = []
+
+    monkeypatch.setattr(mod, "make_paint", lambda **_kwargs: object())
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+    monkeypatch.setattr(mod, "draw_round_rect", lambda _c, rect, _r, _p: draws.append(rect))
+
+    style = LinearProgressIndicatorStyle.default().copy_with(track_active_space=4.0)
+    widget = LinearProgressIndicator(value=1.0, width=100, style=style)
+    widget.paint(canvas=object(), x=0, y=0, width=100, height=4)
+
+    # At 100%, only active segment is rendered and must span full width.
+    assert len(draws) == 1
+    assert draws[0][2] == 100.0
+
+
+def test_circular_determinate_track_active_space_keeps_100_percent_full_sweep(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    monkeypatch.setattr(mod, "make_paint", lambda **_kwargs: object())
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+
+    canvas = _CanvasCapture()
+    style = CircularProgressIndicatorStyle.default().copy_with(track_active_space=4.0)
+    widget = CircularProgressIndicator(value=1.0, size=40, style=style)
+    widget.paint(canvas=canvas, x=0, y=0, width=40, height=40)
+
+    assert canvas.arcs
+    # Determinate progress at 100% should render a full circle.
+    assert canvas.arcs[-1][1] == 360.0
+
+
+def test_linear_determinate_track_active_space_creates_boundary_gap(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    draws: list[tuple[float, float, float, float]] = []
+
+    monkeypatch.setattr(mod, "make_paint", lambda **_kwargs: object())
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+    monkeypatch.setattr(mod, "draw_round_rect", lambda _c, rect, _r, _p: draws.append(rect))
+
+    style = LinearProgressIndicatorStyle.default().copy_with(track_active_space=4.0)
+    widget = LinearProgressIndicator(value=0.5, width=100, style=style)
+    widget.paint(canvas=object(), x=0, y=0, width=100, height=4)
+
+    # Active and remaining track are rendered as separate segments with a gap.
+    assert len(draws) >= 2
+    active = draws[0]
+    remaining = draws[1]
+    active_end = active[0] + active[2]
+    remaining_start = remaining[0]
+    assert (remaining_start - active_end) == 4.0
+
+
+def test_circular_determinate_track_active_space_creates_boundary_gap(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    monkeypatch.setattr(mod, "make_paint", lambda **_kwargs: object())
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+
+    canvas = _CanvasCapture()
+    style = CircularProgressIndicatorStyle.default().copy_with(track_active_space=4.0)
+    widget = CircularProgressIndicator(value=0.5, size=40, style=style)
+    widget.paint(canvas=canvas, x=0, y=0, width=40, height=40)
+
+    # Active and remaining track are split into two arcs.
+    assert len(canvas.arcs) == 2
+    active_sweep = canvas.arcs[0][1]
+    track_sweep = canvas.arcs[1][1]
+    assert active_sweep < 180.0
+    assert track_sweep < 180.0
+
+
+def test_circular_determinate_gap_compensates_round_stroke_caps(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    monkeypatch.setattr(mod, "make_paint", lambda **_kwargs: object())
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+
+    canvas = _CanvasCapture()
+    style = CircularProgressIndicatorStyle.default().copy_with(track_active_space=4.0, track_thickness=4.0)
+    widget = CircularProgressIndicator(value=0.5, size=40, style=style)
+    widget.paint(canvas=canvas, x=0, y=0, width=40, height=40)
+
+    assert len(canvas.arcs) == 2
+    active_sweep = canvas.arcs[0][1]
+    track_sweep = canvas.arcs[1][1]
+    actual_gap_deg = 360.0 - (active_sweep + track_sweep)
+
+    radius = (40.0 - 4.0) / 2.0
+    circumference = 2.0 * math.pi * radius
+    expected_gap_deg = ((4.0 + 4.0) / circumference) * 360.0
+
+    # Determinate circular now keeps one gap at each boundary (2 total).
+    assert math.isclose(actual_gap_deg, expected_gap_deg * 2.0, rel_tol=0.0, abs_tol=1e-6)
+
+
+def test_circular_determinate_keeps_gap_at_start_point(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    monkeypatch.setattr(mod, "make_paint", lambda **_kwargs: object())
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+
+    canvas = _CanvasCapture()
+    style = CircularProgressIndicatorStyle.default().copy_with(track_active_space=4.0, track_thickness=4.0)
+    widget = CircularProgressIndicator(value=0.5, size=40, style=style)
+    widget.paint(canvas=canvas, x=0, y=0, width=40, height=40)
+
+    assert len(canvas.arcs) == 2
+    active_start, active_sweep = canvas.arcs[0]
+    track_start, track_sweep = canvas.arcs[1]
+
+    radius = (40.0 - 4.0) / 2.0
+    circumference = 2.0 * math.pi * radius
+    expected_gap_deg = ((4.0 + 4.0) / circumference) * 360.0
+
+    # Gap at active->track boundary.
+    active_end = active_start + active_sweep
+    gap_boundary = (track_start - active_end) % 360.0
+    # Gap at start point (track end -> active start).
+    track_end = track_start + track_sweep
+    gap_at_start = (active_start - track_end) % 360.0
+
+    assert math.isclose(gap_boundary, expected_gap_deg, rel_tol=0.0, abs_tol=1e-6)
+    assert math.isclose(gap_at_start, expected_gap_deg, rel_tol=0.0, abs_tol=1e-6)
+
+
+def test_circular_determinate_uses_round_stroke_caps(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    paint_calls: list[dict[str, Any]] = []
+
+    def _capture_make_paint(**kwargs: Any) -> object:
+        paint_calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(mod, "make_paint", _capture_make_paint)
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+
+    canvas = _CanvasCapture()
+    widget = CircularProgressIndicator(value=0.5, size=40)
+    widget.paint(canvas=canvas, x=0, y=0, width=40, height=40)
+
+    stroke_calls = [call for call in paint_calls if call.get("style") == "stroke"]
+    assert len(stroke_calls) == 2
+    assert all(call.get("stroke_cap") == "round" for call in stroke_calls)
+
+
+def test_indeterminate_circular_uses_round_stroke_caps(monkeypatch):
+    from nuiitivet.material import progress_indicators as mod
+
+    paint_calls: list[dict[str, Any]] = []
+
+    def _capture_make_paint(**kwargs: Any) -> object:
+        paint_calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(mod, "make_paint", _capture_make_paint)
+    monkeypatch.setattr(mod, "make_rect", lambda x, y, w, h: (x, y, w, h))
+
+    canvas = _CanvasCapture()
+    widget = IndeterminateCircularProgressIndicator(size=40)
+    widget.paint(canvas=canvas, x=0, y=0, width=40, height=40)
+
+    stroke_calls = [call for call in paint_calls if call.get("style") == "stroke"]
+    assert len(stroke_calls) == 2
+    assert all(call.get("stroke_cap") == "round" for call in stroke_calls)
+
+
+def test_indeterminate_linear_uses_jetpack_cycle_duration():
+    widget = IndeterminateLinearProgressIndicator()
+    assert widget._animation_motion_duration() == 1.75
+
+
+def test_indeterminate_linear_head_tail_match_jetpack_reference_over_full_cycle():
+    from nuiitivet.material import progress_indicators as mod
+
+    duration = int(mod._LINEAR_ANIMATION_DURATION_MS)
+
+    def _clamp01(value: float) -> float:
+        return max(0.0, min(1.0, float(value)))
+
+    def _cubic_bezier_transform(t: float, x1: float, y1: float, x2: float, y2: float) -> float:
+        t = _clamp01(t)
+        if t <= 0.0:
+            return 0.0
+        if t >= 1.0:
+            return 1.0
+
+        def sample_x(u: float) -> float:
+            return ((3.0 * x1 - 3.0 * x2 + 1.0) * u * u * u) + ((3.0 * x2 - 6.0 * x1) * u * u) + ((3.0 * x1) * u)
+
+        def sample_y(u: float) -> float:
+            return ((3.0 * y1 - 3.0 * y2 + 1.0) * u * u * u) + ((3.0 * y2 - 6.0 * y1) * u * u) + ((3.0 * y1) * u)
+
+        def sample_dx(u: float) -> float:
+            return ((9.0 * x1 - 9.0 * x2 + 3.0) * u * u) + ((6.0 * x2 - 12.0 * x1) * u) + (3.0 * x1)
+
+        u = t
+        for _ in range(8):
+            x = sample_x(u) - t
+            dx = sample_dx(u)
+            if abs(dx) < 1e-6:
+                break
+            u = _clamp01(u - (x / dx))
+
+        if abs(sample_x(u) - t) > 1e-5:
+            low = 0.0
+            high = 1.0
+            u = t
+            for _ in range(12):
+                x = sample_x(u)
+                if x < t:
+                    low = u
+                else:
+                    high = u
+                u = (low + high) * 0.5
+
+        return sample_y(u)
+
+    def _keyframe_fraction(time_ms: float, *, delay_ms: float, duration_ms: float) -> float:
+        if time_ms <= delay_ms:
+            return 0.0
+        end_ms = delay_ms + duration_ms
+        if time_ms >= end_ms:
+            return 1.0
+        local = _clamp01((time_ms - delay_ms) / max(duration_ms, 1e-9))
+        return _cubic_bezier_transform(local, 0.3, 0.0, 0.8, 0.15)
+
+    def _expected(time_ms: float) -> tuple[float, float, float, float]:
+        t = float(time_ms) % mod._LINEAR_ANIMATION_DURATION_MS
+        first_head = _keyframe_fraction(
+            t,
+            delay_ms=mod._LINEAR_FIRST_HEAD_DELAY_MS,
+            duration_ms=mod._LINEAR_FIRST_HEAD_DURATION_MS,
+        )
+        first_tail = _keyframe_fraction(
+            t,
+            delay_ms=mod._LINEAR_FIRST_TAIL_DELAY_MS,
+            duration_ms=mod._LINEAR_FIRST_TAIL_DURATION_MS,
+        )
+        second_head = _keyframe_fraction(
+            t,
+            delay_ms=mod._LINEAR_SECOND_HEAD_DELAY_MS,
+            duration_ms=mod._LINEAR_SECOND_HEAD_DURATION_MS,
+        )
+        second_tail = _keyframe_fraction(
+            t,
+            delay_ms=mod._LINEAR_SECOND_TAIL_DELAY_MS,
+            duration_ms=mod._LINEAR_SECOND_TAIL_DURATION_MS,
+        )
+        return (first_head, first_tail, second_head, second_tail)
+
+    # Check all integer ms in a full cycle to ensure shape and timing match Jetpack reference.
+    for t in range(duration):
+        actual = mod._linear_indeterminate_segment_fractions(float(t))
+        expected = _expected(float(t))
+        assert math.isclose(actual[0], expected[0], rel_tol=0.0, abs_tol=1e-6)
+        assert math.isclose(actual[1], expected[1], rel_tol=0.0, abs_tol=1e-6)
+        assert math.isclose(actual[2], expected[2], rel_tol=0.0, abs_tol=1e-6)
+        assert math.isclose(actual[3], expected[3], rel_tol=0.0, abs_tol=1e-6)
+
+
+def test_indeterminate_circular_uses_jetpack_cycle_duration():
+    widget = IndeterminateCircularProgressIndicator()
+    assert widget._animation_motion_duration() == 6.0
+
+
+def test_indeterminate_circular_head_angle_does_not_reverse_within_cycle():
+    from nuiitivet.material import progress_indicators as mod
+
+    duration = int(mod._CIRCULAR_ANIMATION_DURATION_MS)
+
+    def _head_degrees(time_ms: float) -> float:
+        rotation = (time_ms / mod._CIRCULAR_ANIMATION_DURATION_MS) * mod._CIRCULAR_GLOBAL_ROTATION_DEGREES_TARGET
+        rotation += mod._circular_additional_rotation_degrees(time_ms)
+        return rotation + (mod._circular_progress_fraction(time_ms) * 360.0)
+
+    # Exclude the cycle wrap frame and verify forward motion within one cycle.
+    for t in range(duration - 1):
+        assert _head_degrees(float(t + 1)) >= _head_degrees(float(t))
+
+
+def test_indeterminate_circular_head_tail_match_jetpack_reference_over_full_cycle():
+    from nuiitivet.material import progress_indicators as mod
+
+    duration = int(mod._CIRCULAR_ANIMATION_DURATION_MS)
+
+    def _clamp01(value: float) -> float:
+        return max(0.0, min(1.0, float(value)))
+
+    def _cubic_bezier_transform(t: float, x1: float, y1: float, x2: float, y2: float) -> float:
+        t = _clamp01(t)
+        if t <= 0.0:
+            return 0.0
+        if t >= 1.0:
+            return 1.0
+
+        def sample_x(u: float) -> float:
+            return ((3.0 * x1 - 3.0 * x2 + 1.0) * u * u * u) + ((3.0 * x2 - 6.0 * x1) * u * u) + ((3.0 * x1) * u)
+
+        def sample_y(u: float) -> float:
+            return ((3.0 * y1 - 3.0 * y2 + 1.0) * u * u * u) + ((3.0 * y2 - 6.0 * y1) * u * u) + ((3.0 * y1) * u)
+
+        def sample_dx(u: float) -> float:
+            return ((9.0 * x1 - 9.0 * x2 + 3.0) * u * u) + ((6.0 * x2 - 12.0 * x1) * u) + (3.0 * x1)
+
+        u = t
+        for _ in range(8):
+            x = sample_x(u) - t
+            dx = sample_dx(u)
+            if abs(dx) < 1e-6:
+                break
+            u = _clamp01(u - (x / dx))
+
+        if abs(sample_x(u) - t) > 1e-5:
+            low = 0.0
+            high = 1.0
+            u = t
+            for _ in range(12):
+                x = sample_x(u)
+                if x < t:
+                    low = u
+                else:
+                    high = u
+                u = (low + high) * 0.5
+
+        return sample_y(u)
+
+    def _jetpack_additional_rotation_degrees(time_ms: float) -> float:
+        t = float(time_ms) % mod._CIRCULAR_ANIMATION_DURATION_MS
+
+        def decelerate(v: float) -> float:
+            return _cubic_bezier_transform(v, 0.05, 0.7, 0.1, 1.0)
+
+        # Mirrors ProgressIndicator.kt keyframes (material3).
+        points = (
+            (0.0, 0.0, "hold"),
+            (300.0, 90.0, "decelerate"),
+            (1500.0, 90.0, "hold"),
+            (1800.0, 180.0, "linear"),
+            (3000.0, 180.0, "hold"),
+            (3300.0, 270.0, "linear"),
+            (4500.0, 270.0, "hold"),
+            (4800.0, 360.0, "linear"),
+            (6000.0, 360.0, "hold"),
+        )
+
+        for i in range(len(points) - 1):
+            start_t, start_v, _ = points[i]
+            end_t, end_v, mode = points[i + 1]
+            if t <= end_t:
+                if mode == "hold" or end_t <= start_t:
+                    return start_v
+                local = _clamp01((t - start_t) / (end_t - start_t))
+                if mode == "decelerate":
+                    local = decelerate(local)
+                return start_v + ((end_v - start_v) * local)
+        return 360.0
+
+    def _jetpack_progress_fraction(time_ms: float) -> float:
+        t = float(time_ms) % mod._CIRCULAR_ANIMATION_DURATION_MS
+        half = mod._CIRCULAR_ANIMATION_DURATION_MS / 2.0
+
+        def standard(v: float) -> float:
+            return _cubic_bezier_transform(v, 0.2, 0.0, 0.0, 1.0)
+
+        if t <= half:
+            local = _clamp01(t / max(half, 1e-9))
+            return mod._CIRCULAR_INDETERMINATE_MIN_PROGRESS + (
+                (mod._CIRCULAR_INDETERMINATE_MAX_PROGRESS - mod._CIRCULAR_INDETERMINATE_MIN_PROGRESS) * standard(local)
+            )
+
+        # Return leg is linear in Jetpack keyframes.
+        local = _clamp01((t - half) / max(half, 1e-9))
+        return mod._CIRCULAR_INDETERMINATE_MAX_PROGRESS + (
+            (mod._CIRCULAR_INDETERMINATE_MIN_PROGRESS - mod._CIRCULAR_INDETERMINATE_MAX_PROGRESS) * local
+        )
+
+    def _actual_tail(time_ms: float) -> float:
+        rotation = (float(time_ms) / mod._CIRCULAR_ANIMATION_DURATION_MS) * mod._CIRCULAR_GLOBAL_ROTATION_DEGREES_TARGET
+        return rotation + mod._circular_additional_rotation_degrees(float(time_ms))
+
+    def _actual_head(time_ms: float) -> float:
+        return _actual_tail(float(time_ms)) + (mod._circular_progress_fraction(float(time_ms)) * 360.0)
+
+    def _expected_tail(time_ms: float) -> float:
+        rotation = (float(time_ms) / mod._CIRCULAR_ANIMATION_DURATION_MS) * mod._CIRCULAR_GLOBAL_ROTATION_DEGREES_TARGET
+        return rotation + _jetpack_additional_rotation_degrees(float(time_ms))
+
+    def _expected_head(time_ms: float) -> float:
+        return _expected_tail(float(time_ms)) + (_jetpack_progress_fraction(float(time_ms)) * 360.0)
+
+    # Check all integer ms in a full cycle to ensure shape and timing match Jetpack reference.
+    for t in range(duration):
+        assert math.isclose(_actual_tail(float(t)), _expected_tail(float(t)), rel_tol=0.0, abs_tol=1e-4)
+        assert math.isclose(_actual_head(float(t)), _expected_head(float(t)), rel_tol=0.0, abs_tol=1e-4)


### PR DESCRIPTION
## Summary
Implement Material Design 3 standard progress indicators:
- LinearProgressIndicator (determinate/indeterminate)
- CircularProgressIndicator (determinate/indeterminate)

## What Changed
- Added LinearProgressIndicator widget with value-based and animated modes
- Added CircularProgressIndicator widget with value-based and animated modes
- Added/updated style classes for progress indicators
- Added unit tests for rendering, behavior, and animation-related logic

## Validation
- Ran unit tests for new progress indicator widgets
- Confirmed expected behavior for determinate and indeterminate modes

## Issue
Closes #30