### PR TITLE
feat(material): add SideSheet and BottomSheet widgets (#29)

### DIFF
--- a/src/nuiitivet/animation/transition_pattern.py
+++ b/src/nuiitivet/animation/transition_pattern.py
@@ -18,6 +18,8 @@ class TransitionVisuals:
     scale_y: float | None = None
     translate_x: float | None = None
     translate_y: float | None = None
+    translate_x_fraction: float | None = None
+    translate_y_fraction: float | None = None
 
     # Allows merging visuals from multiple patterns
     def merge(self, other: TransitionVisuals) -> TransitionVisuals:
@@ -27,6 +29,12 @@ class TransitionVisuals:
             scale_y=other.scale_y if other.scale_y is not None else self.scale_y,
             translate_x=other.translate_x if other.translate_x is not None else self.translate_x,
             translate_y=other.translate_y if other.translate_y is not None else self.translate_y,
+            translate_x_fraction=(
+                other.translate_x_fraction if other.translate_x_fraction is not None else self.translate_x_fraction
+            ),
+            translate_y_fraction=(
+                other.translate_y_fraction if other.translate_y_fraction is not None else self.translate_y_fraction
+            ),
         )
 
 
@@ -117,6 +125,35 @@ class ScalePattern:
         sx = self.start_scale_x + (self.end_scale_x - self.start_scale_x) * progress
         sy = self.start_scale_y + (self.end_scale_y - self.start_scale_y) * progress
         return TransitionVisuals(scale_x=sx, scale_y=sy)
+
+    def __or__(self, other: TransitionPattern) -> TransitionPattern:
+        return CompositePattern(self, other)
+
+
+class FractionalSlidePattern:
+    """Controls translation as a fraction of the widget's allocated size.
+
+    A value of +1.0 means one full width (for x) or height (for y) offset.
+    This allows sheet transitions to slide in/out by exactly their own size,
+    regardless of the actual pixel dimensions.
+    """
+
+    def __init__(
+        self,
+        start_x: float = 0.0,
+        start_y: float = 0.0,
+        end_x: float = 0.0,
+        end_y: float = 0.0,
+    ) -> None:
+        self.start_x = start_x
+        self.start_y = start_y
+        self.end_x = end_x
+        self.end_y = end_y
+
+    def resolve(self, progress: float) -> TransitionVisuals:
+        fx = self.start_x + (self.end_x - self.start_x) * progress
+        fy = self.start_y + (self.end_y - self.start_y) * progress
+        return TransitionVisuals(translate_x_fraction=fx, translate_y_fraction=fy)
 
     def __or__(self, other: TransitionPattern) -> TransitionPattern:
         return CompositePattern(self, other)

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -43,6 +43,12 @@ if TYPE_CHECKING:
     from .overlay import MaterialOverlay
     from .toolbar import DockedToolbar, FloatingToolbar, ToolbarOrientation
     from .tooltip import Tooltip, RichTooltip
+    from .styles.sheet_style import SideSheetStyle, BottomSheetStyle
+    from .sheet import SideSheet, BottomSheet
+    from .transition_spec import (
+        MaterialSideSheetTransitionSpec,
+        MaterialBottomSheetTransitionSpec,
+    )
 
 __all__ = [
     "MaterialApp",
@@ -105,6 +111,12 @@ __all__ = [
     "Tooltip",
     "RichTooltip",
     "MaterialTransitions",
+    "MaterialSideSheetTransitionSpec",
+    "MaterialBottomSheetTransitionSpec",
+    "SideSheetStyle",
+    "BottomSheetStyle",
+    "SideSheet",
+    "BottomSheet",
     "FadeIn",
     "FadeOut",
     "ScaleIn",
@@ -176,6 +188,12 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "RichTooltip": ("tooltip", "RichTooltip"),
     "MaterialLoadingIndicatorIntent": ("overlay_intents", "MaterialLoadingIndicatorIntent"),
     "MaterialTransitions": ("transition_spec", "MaterialTransitions"),
+    "MaterialSideSheetTransitionSpec": ("transition_spec", "MaterialSideSheetTransitionSpec"),
+    "MaterialBottomSheetTransitionSpec": ("transition_spec", "MaterialBottomSheetTransitionSpec"),
+    "SideSheetStyle": ("styles.sheet_style", "SideSheetStyle"),
+    "BottomSheetStyle": ("styles.sheet_style", "BottomSheetStyle"),
+    "SideSheet": ("sheet", "SideSheet"),
+    "BottomSheet": ("sheet", "BottomSheet"),
     "FadeIn": ("transitions", "FadeIn"),
     "FadeOut": ("transitions", "FadeOut"),
     "ScaleIn": ("transitions", "ScaleIn"),

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -18,7 +18,6 @@ from nuiitivet.overlay.overlay_position import OverlayPosition
 from nuiitivet.widgeting.widget import Widget
 from .overlay_visual_state import MaterialOverlayLayerComposer
 from .sheet import BottomSheet, SideSheet
-from .styles.sheet_style import SideSheetStyle
 from .transition_spec import (
     MaterialTransitions,
     MaterialBottomSheetTransitionSpec,

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -17,9 +17,13 @@ from nuiitivet.overlay.overlay_handle import OverlayHandle
 from nuiitivet.overlay.overlay_position import OverlayPosition
 from nuiitivet.widgeting.widget import Widget
 from .overlay_visual_state import MaterialOverlayLayerComposer
+from .sheet import BottomSheet, SideSheet
+from .styles.sheet_style import SideSheetStyle
 from .transition_spec import (
     MaterialTransitions,
+    MaterialBottomSheetTransitionSpec,
     MaterialDialogTransitionSpec,
+    MaterialSideSheetTransitionSpec,
     MaterialSnackbarTransitionSpec,
 )
 
@@ -137,10 +141,7 @@ class MaterialOverlay(Overlay):
             resolved = self._intent_resolver.resolve(dialog)
 
         if isinstance(resolved, Route):
-            # If explicit transition is provided, override the route's spec.
-            # Only if the resolved route is mutable or we can replace the spec.
-            # Route.transition_spec is not read-only property, but just an attribute?
-            # Let's assume we can/should overwrite it if an explicit one is given.
+            # Route.transition_spec is a plain dataclass field; assignment is valid.
             if transition is not None:
                 resolved.transition_spec = transition
             return resolved
@@ -205,3 +206,74 @@ class MaterialOverlay(Overlay):
         else:
             resolved = self._intent_resolver.resolve(indicator)
         return MaterialOverlay._LoadingContext(self, resolved)
+
+    def side_sheet(
+        self,
+        sheet: SideSheet,
+        *,
+        dismiss_on_outside_tap: bool = True,
+        transition: MaterialSideSheetTransitionSpec | None = None,
+    ) -> OverlayHandle[Any]:
+        """Display a modal side sheet.
+
+        The sheet's position, corner radii, and transition direction are derived
+        from ``sheet.side``.  Visual styling (background, size, corner radius) is
+        fully owned by the :class:`SideSheet` widget.
+
+        Args:
+            sheet: SideSheet widget that defines content, headline, and styling.
+            dismiss_on_outside_tap: Whether tapping the scrim dismisses the sheet.
+                Defaults to ``True``.
+            transition: Custom slide transition.
+                Defaults to ``MaterialTransitions.side_sheet(side=sheet.side)``.
+        """
+        if transition is None:
+            transition = MaterialTransitions.side_sheet(side=sheet.side)
+
+        alignment = "top-right" if sheet.side == "right" else "top-left"
+
+        route = DialogRoute(
+            builder=lambda: sheet,
+            transition_spec=transition,
+            barrier_dismissible=bool(dismiss_on_outside_tap),
+        )
+
+        return self.show_modal(
+            route,
+            dismiss_on_outside_tap=bool(dismiss_on_outside_tap),
+            position=OverlayPosition.alignment(alignment),
+        )
+
+    def bottom_sheet(
+        self,
+        sheet: BottomSheet,
+        *,
+        dismiss_on_outside_tap: bool = True,
+        transition: MaterialBottomSheetTransitionSpec | None = None,
+    ) -> OverlayHandle[Any]:
+        """Display a modal bottom sheet sliding up from the bottom edge.
+
+        Visual styling (background, size, corner radius) is fully owned by the
+        :class:`BottomSheet` widget.
+
+        Args:
+            sheet: BottomSheet widget that defines content, headline, and styling.
+            dismiss_on_outside_tap: Whether tapping the scrim dismisses the sheet.
+                Defaults to ``True``.
+            transition: Custom slide transition.
+                Defaults to ``MaterialTransitions.bottom_sheet()``.
+        """
+        if transition is None:
+            transition = MaterialTransitions.bottom_sheet()
+
+        route = DialogRoute(
+            builder=lambda: sheet,
+            transition_spec=transition,
+            barrier_dismissible=bool(dismiss_on_outside_tap),
+        )
+
+        return self.show_modal(
+            route,
+            dismiss_on_outside_tap=bool(dismiss_on_outside_tap),
+            position=OverlayPosition.alignment("bottom-center"),
+        )

--- a/src/nuiitivet/material/overlay_visual_state.py
+++ b/src/nuiitivet/material/overlay_visual_state.py
@@ -17,6 +17,26 @@ from nuiitivet.widgeting.widget import Widget
 from .transition_visual_spec import resolve_material_transition_visual_spec
 
 
+def _resolve_content_translation(state: "OverlayVisualState", content: Widget) -> tuple[float, float]:
+    """Resolve pixel translation, incorporating any fractional components.
+
+    Fractional values are multiplied by the content widget's current allocated
+    dimensions.  Uses ``layout_rect`` first (available after the layout pass)
+    and falls back to ``preferred_size`` for the very first frame.
+    """
+    tx, ty = state.content_translation
+    fx, fy = state.content_translation_fraction
+    if fx != 0.0 or fy != 0.0:
+        rect = getattr(content, "layout_rect", None)
+        if rect is not None:
+            _, _, w, h = rect
+        else:
+            w, h = content.preferred_size()
+        tx += fx * float(w)
+        ty += fy * float(h)
+    return (tx, ty)
+
+
 @dataclass(frozen=True, slots=True)
 class OverlayVisualState:
     """Material visual parameters for one overlay transition frame."""
@@ -24,6 +44,7 @@ class OverlayVisualState:
     content_opacity: float
     content_scale: tuple[float, float]
     content_translation: tuple[float, float]
+    content_translation_fraction: tuple[float, float]
     barrier_opacity: float | None
 
 
@@ -45,6 +66,7 @@ class MaterialOverlayVisualMapper:
             content_opacity=float(visual.content_opacity),
             content_scale=visual.content_scale,
             content_translation=visual.content_translation,
+            content_translation_fraction=visual.content_translation_fraction,
             barrier_opacity=visual.barrier_opacity,
         )
 
@@ -61,7 +83,9 @@ class MaterialOverlayLayerComposer(OverlayLayerComposer):
 
         content_opacity_obs = combine(visual_obs).compute(lambda state: state.content_opacity)
         content_scale_obs = combine(visual_obs).compute(lambda state: state.content_scale)
-        content_translation_obs = combine(visual_obs).compute(lambda state: state.content_translation)
+        content_translation_obs = combine(visual_obs).compute(
+            lambda state: _resolve_content_translation(state, context.content)
+        )
         barrier_opacity_obs = combine(visual_obs).compute(
             lambda state: 1.0 if state.barrier_opacity is None else state.barrier_opacity
         )

--- a/src/nuiitivet/material/sheet.py
+++ b/src/nuiitivet/material/sheet.py
@@ -1,0 +1,245 @@
+"""Material Design 3 modal side sheet and bottom sheet widgets."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Literal, Optional, Union
+
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.row import Row
+from nuiitivet.material.buttons import IconButton
+from nuiitivet.material.styles.sheet_style import BottomSheetStyle, SideSheetStyle
+from nuiitivet.material.styles.text_style import TextStyle
+from nuiitivet.material.text import Text
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.widgeting.widget import ComposableWidget, Widget
+from nuiitivet.widgets.box import Box
+
+_logger = logging.getLogger(__name__)
+
+
+class SideSheet(ComposableWidget):
+    """Modal side sheet container widget.
+
+    Renders an M3-compliant header (optional Back button, Headline, Close button) above
+    *content*.  Pass this widget to ``MaterialOverlay.side_sheet()``.
+
+    The header layout is fixed by M3 spec::
+
+        [ Back (optional) ]  [ Headline ]  [ Close ]
+
+    Note:
+        The Back button is visible only when *show_back_button* is truthy **and**
+        *on_back* is not ``None``.  Providing ``show_back_button=True`` alone
+        without *on_back* will silently suppress the button.
+
+    Args:
+        content: Widget to display below the header.
+        headline: Header title text (str or Observable[str]). Required by M3.
+        side: Edge the sheet slides in from (``"right"`` or ``"left"``).
+            Defaults to ``"right"``.
+        on_back: Callback invoked when the Back icon button is pressed.
+            Back button visibility is controlled separately by *show_back_button*.
+        show_back_button: Whether to show the Back icon button.
+            Accepts ``bool`` or ``Observable[bool]`` for dynamic toggling
+            (e.g. driven by in-sheet navigation state). Defaults to ``False``.
+            The button is only rendered when this is truthy **and** *on_back* is
+            not ``None``.
+        style: Container style. Defaults to :class:`SideSheetStyle`.
+    """
+
+    def __init__(
+        self,
+        content: Widget,
+        *,
+        headline: Union[str, ReadOnlyObservableProtocol[str]],
+        side: Literal["right", "left"] = "right",
+        on_back: Optional[Callable[[], None]] = None,
+        show_back_button: Union[bool, ReadOnlyObservableProtocol[bool]] = False,
+        on_close: Optional[Callable[[], None]] = None,
+        style: Optional[SideSheetStyle] = None,
+    ) -> None:
+        """Initialize SideSheet.
+
+        Args:
+            content: Widget to display below the header.
+            headline: Header title text (str or Observable[str]).
+            side: Edge the sheet slides in from. Defaults to ``"right"``.
+            on_back: Callback for the Back icon button press.
+            show_back_button: Back button visibility (bool or Observable[bool]).
+                Defaults to ``False``. Rendered only when truthy **and** *on_back*
+                is not ``None``.
+            on_close: Callback for the Close icon button press.
+            style: Container style. Defaults to :class:`SideSheetStyle`.
+        """
+        _style = style if style is not None else SideSheetStyle()
+        super().__init__(height=_style.height)
+        self._content = content
+        self._headline = headline
+        self.side = side
+        self._on_back = on_back
+        self._show_back_button = show_back_button
+        self._on_close = on_close
+        self._user_style = style
+
+    @property
+    def style(self) -> SideSheetStyle:
+        """Return resolved sheet style."""
+        return self._user_style if self._user_style is not None else SideSheetStyle()
+
+    def _resolve_show_back(self) -> bool:
+        if isinstance(self._show_back_button, ReadOnlyObservableProtocol):
+            return bool(self._show_back_button.value)
+        return bool(self._show_back_button)
+
+    def on_mount(self) -> None:
+        """Mount and subscribe to show_back_button observable if provided."""
+        super().on_mount()
+        if isinstance(self._show_back_button, ReadOnlyObservableProtocol):
+            sub = self._show_back_button.subscribe(lambda _: self.rebuild())
+            self.bind(sub)
+
+    def build(self) -> Widget:
+        """Build the sheet: outer Box with header Row and content Column."""
+        resolved_style = self.style
+
+        # Header row: [Back slot] [Headline (flex)] [Close]
+        # The back-button slot is always reserved (same width as IconButton default)
+        # so the headline stays at a consistent horizontal position regardless of
+        # whether the back button is visible.
+        _BACK_SIZE = 40  # matches IconButton default size
+
+        if self._resolve_show_back() and self._on_back is not None:
+            back_slot: Widget = IconButton("arrow_back", on_click=self._on_back)
+        else:
+            back_slot = Box(width=_BACK_SIZE, height=_BACK_SIZE)
+
+        header = Row(
+            [
+                back_slot,
+                Box(
+                    Text(
+                        self._headline,
+                        style=TextStyle(font_size=22, color=ColorRole.ON_SURFACE_VARIANT),
+                    ),
+                    width="100%",
+                    padding=(8, 0, 8, 0),
+                ),
+                # TODO(#38): when IOverlayAware is available, wire None → handle.close()
+                IconButton("close", on_click=self._on_close),
+            ],
+            width="100%",
+            height=72,
+            padding=(4, 0, 4, 0),
+            cross_alignment="center",
+        )
+
+        # Apply per-corner radius: round only the inner (away-from-edge) corners.
+        cr = float(resolved_style.corner_radius)
+        if self.side == "right":
+            corner_radius = (cr, 0.0, 0.0, cr)  # tl, tr, br, bl
+        else:
+            corner_radius = (0.0, cr, cr, 0.0)  # tl, tr, br, bl
+
+        return Box(
+            Column(
+                [header, self._content],
+                width="100%",
+            ),
+            width=resolved_style.width,
+            height=resolved_style.height,
+            corner_radius=corner_radius,
+            background_color=resolved_style.background_color,
+            alignment="top-left",
+        )
+
+
+class BottomSheet(ComposableWidget):
+    """Modal bottom sheet container widget.
+
+    Renders an M3-compliant header (Headline, Close button) above *content*.
+    Pass this widget to ``MaterialOverlay.bottom_sheet()``.
+
+    The header layout is fixed by M3 spec::
+
+        [ Headline ]  [ Close ]
+
+    Args:
+        content: Widget to display below the header.
+        headline: Header title text (str or Observable[str]). Required by M3.
+        on_close: Callback invoked when the Close icon button is pressed.
+            If ``None``, the button will trigger ``IOverlayAware.close()``
+            automatically once Issue #38 is resolved.
+        style: Container size, background, and shape options.
+            Defaults to :class:`BottomSheetStyle`.
+    """
+
+    def __init__(
+        self,
+        content: Widget,
+        *,
+        headline: Union[str, ReadOnlyObservableProtocol[str]],
+        on_close: Optional[Callable[[], None]] = None,
+        style: Optional[BottomSheetStyle] = None,
+    ) -> None:
+        """Initialize BottomSheet.
+
+        Args:
+            content: Widget to display below the header.
+            headline: Header title text (str or Observable[str]).
+            on_close: Callback for the Close icon button press.
+            style: Container style. Defaults to :class:`BottomSheetStyle`.
+        """
+        _style = style if style is not None else BottomSheetStyle()
+        super().__init__(width=_style.width)
+        self._content = content
+        self._headline = headline
+        self._on_close = on_close
+        self._user_style = style
+
+    @property
+    def style(self) -> BottomSheetStyle:
+        """Return resolved sheet style."""
+        return self._user_style if self._user_style is not None else BottomSheetStyle()
+
+    def build(self) -> Widget:
+        """Build the sheet: outer Box with header Row and content Column."""
+        resolved_style = self.style
+
+        header = Row(
+            [
+                Box(
+                    Text(
+                        self._headline,
+                        style=TextStyle(font_size=22, color=ColorRole.ON_SURFACE_VARIANT),
+                    ),
+                    width="100%",
+                    padding=(8, 0, 8, 0),
+                ),
+                # TODO(#38): when IOverlayAware is available, wire None → handle.close()
+                IconButton("close", on_click=self._on_close),
+            ],
+            width="100%",
+            height=72,
+            padding=(4, 0, 4, 0),
+            cross_alignment="center",
+        )
+
+        # Round only the top corners.
+        cr = float(resolved_style.corner_radius)
+        corner_radius = (cr, cr, 0.0, 0.0)  # tl, tr, br, bl
+
+        return Box(
+            Column(
+                [header, self._content],
+                width="100%",
+            ),
+            width=resolved_style.width,
+            height=resolved_style.height,
+            corner_radius=corner_radius,
+            background_color=resolved_style.background_color,
+        )
+
+
+__all__ = ["SideSheet", "BottomSheet"]

--- a/src/nuiitivet/material/styles/sheet_style.py
+++ b/src/nuiitivet/material/styles/sheet_style.py
@@ -1,0 +1,53 @@
+"""Sheet style definitions for modal side sheets and bottom sheets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.rendering.sizing import SizingLike
+from nuiitivet.theme.types import ColorSpec
+
+
+@dataclass(frozen=True)
+class SideSheetStyle:
+    """Immutable container style for a modal side sheet.
+
+    The framework wraps caller-supplied content in a container sized by this style.
+    ``height`` defaults to ``"100%"`` so the sheet spans the full screen height.
+    ``corner_radius`` is applied to the inner (away-from-edge) corners only.
+    ``background_color`` defaults to ``ColorRole.SURFACE_CONTAINER_LOW`` per M3 spec.
+    """
+
+    width: SizingLike = 400
+    height: SizingLike = "100%"
+    corner_radius: float = 16.0
+    background_color: ColorSpec = ColorRole.SURFACE_CONTAINER_LOW
+
+    def copy_with(self, **changes) -> "SideSheetStyle":
+        """Return a copy with the given fields replaced."""
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class BottomSheetStyle:
+    """Immutable container style for a modal bottom sheet.
+
+    The framework wraps caller-supplied content in a container sized by this style.
+    ``width`` defaults to ``"100%"`` so the sheet spans the full screen width.
+    ``height=None`` means the container sizes to its content.
+    ``corner_radius`` is applied to the top corners only.
+    ``background_color`` defaults to ``ColorRole.SURFACE_CONTAINER_LOW`` per M3 spec.
+    """
+
+    width: SizingLike = "100%"
+    height: SizingLike = None
+    corner_radius: float = 28.0
+    background_color: ColorSpec = ColorRole.SURFACE_CONTAINER_LOW
+
+    def copy_with(self, **changes) -> "BottomSheetStyle":
+        """Return a copy with the given fields replaced."""
+        return replace(self, **changes)
+
+
+__all__ = ["SideSheetStyle", "BottomSheetStyle"]

--- a/src/nuiitivet/material/theme/color_role.py
+++ b/src/nuiitivet/material/theme/color_role.py
@@ -55,6 +55,7 @@ class ColorRole(Enum):
     INVERSE_ON_SURFACE = "inverseOnSurface"
     SURFACE_VARIANT = "surfaceVariant"
     ON_SURFACE_VARIANT = "onSurfaceVariant"
+    SURFACE_CONTAINER_LOW = "surfaceContainerLow"
     SURFACE_CONTAINER_HIGHEST = "surfaceContainerHighest"
 
     OUTLINE = "outline"

--- a/src/nuiitivet/material/theme/palette.py
+++ b/src/nuiitivet/material/theme/palette.py
@@ -80,6 +80,7 @@ def _use_mcu_corepalette(seed_hex: str) -> Optional[Tuple[Dict[ColorRole, str], 
                 ColorRole.INVERSE_ON_SURFACE: "inverse_on_surface",
                 ColorRole.SURFACE_VARIANT: "surface_variant",
                 ColorRole.ON_SURFACE_VARIANT: "on_surface_variant",
+                ColorRole.SURFACE_CONTAINER_LOW: "surface_container_low",
                 ColorRole.SURFACE_CONTAINER_HIGHEST: "surface_container_highest",
                 ColorRole.OUTLINE: "outline",
                 ColorRole.OUTLINE_VARIANT: "outline_variant",
@@ -122,6 +123,10 @@ def _use_mcu_corepalette(seed_hex: str) -> Optional[Tuple[Dict[ColorRole, str], 
                     dark_roles[role] = "#{:02X}{:02X}{:02X}".format(*vals)
 
             # Fallback for missing roles
+            if ColorRole.SURFACE_CONTAINER_LOW not in light_roles:
+                light_roles[ColorRole.SURFACE_CONTAINER_LOW] = light_roles.get(ColorRole.SURFACE, "#F7F2FA")
+            if ColorRole.SURFACE_CONTAINER_LOW not in dark_roles:
+                dark_roles[ColorRole.SURFACE_CONTAINER_LOW] = dark_roles.get(ColorRole.SURFACE, "#1D1B20")
             if ColorRole.SURFACE_CONTAINER_HIGHEST not in light_roles:
                 light_roles[ColorRole.SURFACE_CONTAINER_HIGHEST] = light_roles.get(ColorRole.SURFACE_VARIANT, "#E7E0EC")
             if ColorRole.SURFACE_CONTAINER_HIGHEST not in dark_roles:
@@ -232,6 +237,7 @@ def _use_mcu_corepalette(seed_hex: str) -> Optional[Tuple[Dict[ColorRole, str], 
             (ColorRole.ON_SURFACE, (cp.neutral, 10)),
             (ColorRole.SURFACE_VARIANT, (cp.neutral_variant if hasattr(cp, "neutral_variant") else cp.neutral, 94)),
             (ColorRole.ON_SURFACE_VARIANT, (cp.neutral_variant if hasattr(cp, "neutral_variant") else cp.neutral, 30)),
+            (ColorRole.SURFACE_CONTAINER_LOW, (cp.neutral, 96)),
             (ColorRole.SURFACE_CONTAINER_HIGHEST, (cp.neutral, 90)),
             (ColorRole.OUTLINE, (cp.neutral_variant if hasattr(cp, "neutral_variant") else cp.neutral, 60)),
             (ColorRole.OUTLINE_VARIANT, (cp.neutral_variant if hasattr(cp, "neutral_variant") else cp.neutral, 80)),
@@ -251,7 +257,9 @@ def _use_mcu_corepalette(seed_hex: str) -> Optional[Tuple[Dict[ColorRole, str], 
         for role, (pal, tonev) in mapping:
             try:
                 # map some tones differently for dark
-                if role == ColorRole.SURFACE_CONTAINER_HIGHEST:
+                if role == ColorRole.SURFACE_CONTAINER_LOW:
+                    dark_tone = 10
+                elif role == ColorRole.SURFACE_CONTAINER_HIGHEST:
                     dark_tone = 22
                 elif role == ColorRole.OUTLINE_VARIANT:
                     dark_tone = 30
@@ -336,6 +344,7 @@ def _hsl_roles_from_seed(seed_hex: str) -> Tuple[Dict[ColorRole, str], Dict[Colo
         ColorRole.ON_SURFACE: 0.10,
         ColorRole.SURFACE_VARIANT: 0.94,
         ColorRole.ON_SURFACE_VARIANT: 0.30,
+        ColorRole.SURFACE_CONTAINER_LOW: 0.96,
         ColorRole.SURFACE_CONTAINER_HIGHEST: 0.90,
         ColorRole.OUTLINE: 0.60,
         ColorRole.OUTLINE_VARIANT: 0.80,
@@ -364,6 +373,7 @@ def _hsl_roles_from_seed(seed_hex: str) -> Tuple[Dict[ColorRole, str], Dict[Colo
         ColorRole.ON_SURFACE: 0.94,
         ColorRole.SURFACE_VARIANT: 0.24,
         ColorRole.ON_SURFACE_VARIANT: 0.88,
+        ColorRole.SURFACE_CONTAINER_LOW: 0.10,
         ColorRole.SURFACE_CONTAINER_HIGHEST: 0.22,
         ColorRole.OUTLINE: 0.72,
         ColorRole.OUTLINE_VARIANT: 0.30,

--- a/src/nuiitivet/material/transition_spec.py
+++ b/src/nuiitivet/material/transition_spec.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from typing import Literal
+
 from nuiitivet.animation.transition_definition import TransitionDefinition
-from nuiitivet.animation.transition_pattern import FadePattern, ScalePattern, SlidePattern
+from nuiitivet.animation.transition_pattern import FadePattern, FractionalSlidePattern, ScalePattern, SlidePattern
 from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_EFFECTS
 
 
@@ -56,6 +58,35 @@ def _default_snackbar_exit() -> TransitionDefinition:
     )
 
 
+def _default_side_sheet_enter() -> TransitionDefinition:
+    # Default: right-side sheet slides in from right edge (1.0 = full width)
+    return TransitionDefinition(
+        motion=EXPRESSIVE_DEFAULT_EFFECTS,
+        pattern=FractionalSlidePattern(start_x=1.0, end_x=0.0),
+    )
+
+
+def _default_side_sheet_exit() -> TransitionDefinition:
+    return TransitionDefinition(
+        motion=EXPRESSIVE_DEFAULT_EFFECTS,
+        pattern=FractionalSlidePattern(start_x=0.0, end_x=1.0),
+    )
+
+
+def _default_bottom_sheet_enter() -> TransitionDefinition:
+    return TransitionDefinition(
+        motion=EXPRESSIVE_DEFAULT_EFFECTS,
+        pattern=FractionalSlidePattern(start_y=1.0, end_y=0.0),
+    )
+
+
+def _default_bottom_sheet_exit() -> TransitionDefinition:
+    return TransitionDefinition(
+        motion=EXPRESSIVE_DEFAULT_EFFECTS,
+        pattern=FractionalSlidePattern(start_y=0.0, end_y=1.0),
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class MaterialPageTransitionSpec:
     """Material default transition token for page navigation."""
@@ -78,6 +109,22 @@ class MaterialSnackbarTransitionSpec:
 
     enter: TransitionDefinition = field(default_factory=_default_snackbar_enter)
     exit: TransitionDefinition = field(default_factory=_default_snackbar_exit)
+
+
+@dataclass(frozen=True, slots=True)
+class MaterialSideSheetTransitionSpec:
+    """Material transition token for modal side sheets."""
+
+    enter: TransitionDefinition = field(default_factory=_default_side_sheet_enter)
+    exit: TransitionDefinition = field(default_factory=_default_side_sheet_exit)
+
+
+@dataclass(frozen=True, slots=True)
+class MaterialBottomSheetTransitionSpec:
+    """Material transition token for modal bottom sheets."""
+
+    enter: TransitionDefinition = field(default_factory=_default_bottom_sheet_enter)
+    exit: TransitionDefinition = field(default_factory=_default_bottom_sheet_exit)
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,13 +162,66 @@ class _MaterialTransitionPresets:
             exit=exit or _default_snackbar_exit(),
         )
 
+    def side_sheet(
+        self,
+        side: Literal["right", "left"] = "right",
+        enter: TransitionDefinition | None = None,
+        exit: TransitionDefinition | None = None,
+    ) -> MaterialSideSheetTransitionSpec:
+        """Create a Material side sheet transition token.
+
+        Args:
+            side: Which edge the sheet slides in from.
+            enter: Custom enter transition definition.
+            exit: Custom exit transition definition.
+        """
+        sign = 1.0 if side == "right" else -1.0
+        return MaterialSideSheetTransitionSpec(
+            enter=enter
+            or TransitionDefinition(
+                motion=EXPRESSIVE_DEFAULT_EFFECTS,
+                pattern=FractionalSlidePattern(start_x=sign, end_x=0.0),
+            ),
+            exit=exit
+            or TransitionDefinition(
+                motion=EXPRESSIVE_DEFAULT_EFFECTS,
+                pattern=FractionalSlidePattern(start_x=0.0, end_x=sign),
+            ),
+        )
+
+    def bottom_sheet(
+        self,
+        enter: TransitionDefinition | None = None,
+        exit: TransitionDefinition | None = None,
+    ) -> MaterialBottomSheetTransitionSpec:
+        """Create a Material bottom sheet transition token.
+
+        Args:
+            enter: Custom enter transition definition.
+            exit: Custom exit transition definition.
+        """
+        return MaterialBottomSheetTransitionSpec(
+            enter=enter
+            or TransitionDefinition(
+                motion=EXPRESSIVE_DEFAULT_EFFECTS,
+                pattern=FractionalSlidePattern(start_y=1.0, end_y=0.0),
+            ),
+            exit=exit
+            or TransitionDefinition(
+                motion=EXPRESSIVE_DEFAULT_EFFECTS,
+                pattern=FractionalSlidePattern(start_y=0.0, end_y=1.0),
+            ),
+        )
+
 
 MaterialTransitions = _MaterialTransitionPresets()
 
 
 __all__ = [
+    "MaterialBottomSheetTransitionSpec",
     "MaterialDialogTransitionSpec",
     "MaterialPageTransitionSpec",
+    "MaterialSideSheetTransitionSpec",
     "MaterialSnackbarTransitionSpec",
     "MaterialTransitions",
 ]

--- a/src/nuiitivet/material/transition_visual_spec.py
+++ b/src/nuiitivet/material/transition_visual_spec.py
@@ -14,6 +14,8 @@ from .transition_spec import (
     MaterialDialogTransitionSpec,
     MaterialPageTransitionSpec,
     MaterialSnackbarTransitionSpec,
+    MaterialSideSheetTransitionSpec,
+    MaterialBottomSheetTransitionSpec,
 )
 
 
@@ -24,6 +26,7 @@ class MaterialTransitionVisualSpec:
     content_opacity: float
     content_scale: tuple[float, float]
     content_translation: tuple[float, float]
+    content_translation_fraction: tuple[float, float]
     barrier_opacity: float | None
 
 
@@ -41,6 +44,7 @@ def resolve_material_transition_visual_spec(
             content_opacity=1.0,
             content_scale=(1.0, 1.0),
             content_translation=(0.0, 0.0),
+            content_translation_fraction=(0.0, 0.0),
             barrier_opacity=None,
         )
 
@@ -74,6 +78,16 @@ def resolve_material_transition_visual_spec(
         # Snakebars don't have a barrier (or pass-through)
         barrier = None
 
+    elif isinstance(transition_spec, (MaterialSideSheetTransitionSpec, MaterialBottomSheetTransitionSpec)):
+        if phase is TransitionPhase.ENTER:
+            definition = transition_spec.enter
+            barrier = p
+        elif phase is TransitionPhase.EXIT:
+            definition = transition_spec.exit
+            barrier = 1.0 - p
+        else:
+            barrier = 1.0
+
     if definition is not None:
         visuals = definition.pattern.resolve(p)
 
@@ -82,11 +96,14 @@ def resolve_material_transition_visual_spec(
         scale_y = visuals.scale_y if visuals.scale_y is not None else 1.0
         trans_x = visuals.translate_x if visuals.translate_x is not None else 0.0
         trans_y = visuals.translate_y if visuals.translate_y is not None else 0.0
+        trans_fx = visuals.translate_x_fraction if visuals.translate_x_fraction is not None else 0.0
+        trans_fy = visuals.translate_y_fraction if visuals.translate_y_fraction is not None else 0.0
 
         return MaterialTransitionVisualSpec(
             content_opacity=opacity,
             content_scale=(scale_x, scale_y),
             content_translation=(trans_x, trans_y),
+            content_translation_fraction=(trans_fx, trans_fy),
             barrier_opacity=barrier,
         )
 
@@ -95,6 +112,7 @@ def resolve_material_transition_visual_spec(
         content_opacity=1.0,
         content_scale=(1.0, 1.0),
         content_translation=(0.0, 0.0),
+        content_translation_fraction=(0.0, 0.0),
         barrier_opacity=barrier,
     )
 

--- a/src/samples/sheet_demo.py
+++ b/src/samples/sheet_demo.py
@@ -1,0 +1,173 @@
+"""Modal SideSheet and BottomSheet demo.
+
+Covers:
+- Right-side sheet (default style)
+- Left-side sheet (custom width)
+- Bottom sheet with fixed height
+- Bottom sheet with content-driven height (default)
+- Non-dismissible side sheet with on_close callback
+- Side sheet with dynamic Back button driven by MutableObservable
+"""
+
+from __future__ import annotations
+
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.container import Container
+from nuiitivet.layout.row import Row
+from nuiitivet.material import (
+    Divider,
+    FilledButton,
+    MaterialApp,
+    MaterialOverlay,
+    OutlinedButton,
+    Text,
+)
+from nuiitivet.material.sheet import BottomSheet, SideSheet
+from nuiitivet.material.styles.sheet_style import BottomSheetStyle, SideSheetStyle
+from nuiitivet.material.styles.text_style import TextStyle
+from nuiitivet.observable import Observable
+from nuiitivet.widgets.box import Box
+
+
+# ---------------------------------------------------------------------------
+# Sheet content builders
+# ---------------------------------------------------------------------------
+
+
+def _sheet_content(label: str) -> Box:
+    return Box(
+        Column(
+            children=[
+                Text(label, style=TextStyle(font_size=16)),
+                Divider(),
+                Text("Item 1"),
+                Text("Item 2"),
+                Text("Item 3"),
+                Text("Tap outside (scrim) to dismiss."),
+            ],
+            gap=12,
+            cross_alignment="start",
+        ),
+        padding=24,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    def open_right_sheet() -> None:
+        """Right-side sheet — default SideSheetStyle (width=400)."""
+        MaterialOverlay.root().side_sheet(
+            SideSheet(_sheet_content("Right Side Sheet"), headline="Settings"),
+        )
+
+    def open_left_sheet() -> None:
+        """Left-side sheet — custom width."""
+        MaterialOverlay.root().side_sheet(
+            SideSheet(
+                _sheet_content("Left Side Sheet"),
+                headline="Navigation",
+                side="left",
+                style=SideSheetStyle(width=320),
+            ),
+        )
+
+    def open_bottom_sheet_fixed() -> None:
+        """Bottom sheet — fixed height."""
+        MaterialOverlay.root().bottom_sheet(
+            BottomSheet(
+                _sheet_content("Bottom Sheet (height=280)"),
+                headline="Filter",
+                style=BottomSheetStyle(height=280),
+            ),
+        )
+
+    def open_bottom_sheet_auto() -> None:
+        """Bottom sheet — content-driven height (default)."""
+        MaterialOverlay.root().bottom_sheet(
+            BottomSheet(
+                _sheet_content("Bottom Sheet (content-driven)"),
+                headline="Filter",
+            ),
+        )
+
+    def open_non_dismissible_sheet() -> None:
+        """Right-side sheet — dismiss_on_outside_tap=False, close via on_close callback."""
+        handle = MaterialOverlay.root().side_sheet(
+            SideSheet(
+                _sheet_content("Non-Dismissible Sheet"),
+                headline="Edit",
+                on_close=lambda: handle.close(None),
+            ),
+            dismiss_on_outside_tap=False,
+        )
+
+    def open_dynamic_back_sheet() -> None:
+        """Side sheet with dynamic Back button driven by MutableObservable."""
+        _show_back: Observable[bool] = Observable(False)
+
+        def go_back() -> None:
+            _show_back.value = False
+
+        def navigate_detail() -> None:
+            _show_back.value = True
+
+        content = Box(
+            Column(
+                children=[
+                    Divider(),
+                    Text("Press the button below to simulate navigation."),
+                    OutlinedButton("Go to detail →", on_click=navigate_detail),
+                ],
+                gap=12,
+                cross_alignment="start",
+            ),
+            padding=24,
+        )
+
+        MaterialOverlay.root().side_sheet(
+            SideSheet(
+                content,
+                headline="Settings",
+                on_back=go_back,
+                show_back_button=_show_back,
+            ),
+        )
+
+    content = Container(
+        child=Column(
+            children=[
+                Text("Sheet Demo", style=TextStyle(font_size=22)),
+                Divider(),
+                Row(
+                    children=[
+                        FilledButton("Right Sheet (default)", on_click=open_right_sheet),
+                        FilledButton("Left Sheet (w=320)", on_click=open_left_sheet),
+                    ],
+                    gap=12,
+                ),
+                Row(
+                    children=[
+                        FilledButton("Bottom Sheet (h=280)", on_click=open_bottom_sheet_fixed),
+                        FilledButton("Bottom Sheet (auto)", on_click=open_bottom_sheet_auto),
+                    ],
+                    gap=12,
+                ),
+                FilledButton("Non-dismissible Sheet", on_click=open_non_dismissible_sheet),
+                FilledButton("Dynamic Back Button", on_click=open_dynamic_back_sheet),
+            ],
+            gap=20,
+            cross_alignment="start",
+        ),
+        padding=32,
+    )
+
+    app = MaterialApp(content=content, width=600, height=420)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bottom_sheet.py
+++ b/tests/test_bottom_sheet.py
@@ -1,0 +1,154 @@
+"""Tests for BottomSheet widget and MaterialOverlay.bottom_sheet()."""
+
+import pytest
+
+from nuiitivet.material.sheet import BottomSheet
+from nuiitivet.material.styles.sheet_style import BottomSheetStyle
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.material.transition_spec import MaterialBottomSheetTransitionSpec, MaterialTransitions
+from nuiitivet.theme.manager import manager
+from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.widgets.box import Box
+
+
+@pytest.fixture(autouse=True)
+def material_theme():
+    manager.set_theme(MaterialTheme.light("#6750A4"))
+
+
+# ---------------------------------------------------------------------------
+# BottomSheetStyle tests
+# ---------------------------------------------------------------------------
+
+
+def test_bottom_sheet_style_defaults():
+    style = BottomSheetStyle()
+    assert style.width == "100%"
+    assert style.height is None
+    assert style.corner_radius == 28.0
+    assert style.background_color == ColorRole.SURFACE_CONTAINER_LOW
+
+
+def test_bottom_sheet_style_copy_with():
+    style = BottomSheetStyle().copy_with(height=480, corner_radius=20.0)
+    assert style.width == "100%"
+    assert style.height == 480
+    assert style.corner_radius == 20.0
+
+
+def test_bottom_sheet_style_is_immutable():
+    style = BottomSheetStyle()
+    with pytest.raises((AttributeError, TypeError)):
+        style.height = 200  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# MaterialBottomSheetTransitionSpec tests
+# ---------------------------------------------------------------------------
+
+
+def test_bottom_sheet_transition_spec_defaults():
+    spec = MaterialBottomSheetTransitionSpec()
+    assert spec.enter is not None
+    assert spec.exit is not None
+
+
+def test_material_transitions_bottom_sheet():
+    spec = MaterialTransitions.bottom_sheet()
+    assert isinstance(spec, MaterialBottomSheetTransitionSpec)
+    # Enter pattern should slide from positive y fraction (bottom)
+    visuals = spec.enter.pattern.resolve(0.0)
+    assert visuals.translate_y_fraction is not None
+    assert visuals.translate_y_fraction > 0
+
+
+def test_material_transitions_bottom_sheet_exit_direction():
+    spec = MaterialTransitions.bottom_sheet()
+    # Exit pattern should slide to positive y fraction (back down)
+    visuals_start = spec.exit.pattern.resolve(0.0)
+    visuals_end = spec.exit.pattern.resolve(1.0)
+    assert visuals_start.translate_y_fraction == pytest.approx(0.0)
+    assert visuals_end.translate_y_fraction == pytest.approx(1.0)
+
+
+def test_material_transitions_bottom_sheet_custom_exit():
+    from nuiitivet.animation.transition_definition import TransitionDefinition
+    from nuiitivet.animation.transition_pattern import FadePattern
+    from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_EFFECTS
+
+    custom_exit = TransitionDefinition(
+        motion=EXPRESSIVE_DEFAULT_EFFECTS,
+        pattern=FadePattern(start_alpha=1.0, end_alpha=0.0),
+    )
+    spec = MaterialTransitions.bottom_sheet(exit=custom_exit)
+    assert spec.exit is custom_exit
+
+
+# ---------------------------------------------------------------------------
+# MaterialOverlay.bottom_sheet() API tests
+# ---------------------------------------------------------------------------
+
+
+def test_bottom_sheet_defaults():
+    """BottomSheet stores headline and defaults correctly."""
+    content = Box(width=200, height=100)
+    sheet = BottomSheet(content, headline="Filters")
+    assert sheet._headline == "Filters"
+    assert sheet._on_close is None
+
+
+def test_bottom_sheet_style_property_default():
+    """BottomSheet.style returns BottomSheetStyle() when no style given."""
+    sheet = BottomSheet(Box(), headline="Filters")
+    assert sheet.style == BottomSheetStyle()
+
+
+def test_bottom_sheet_style_property_custom():
+    """BottomSheet.style returns user-provided style."""
+    custom = BottomSheetStyle(height=400)
+    sheet = BottomSheet(Box(), headline="Filters", style=custom)
+    assert sheet.style is custom
+
+
+def test_bottom_sheet_build_returns_box():
+    """BottomSheet.build() returns a Box as the outer container."""
+    sheet = BottomSheet(Box(), headline="Filters")
+    built = sheet.build()
+    assert isinstance(built, Box)
+
+
+def test_bottom_sheet_top_corner_radius():
+    """BottomSheet.build() rounds only the top corners."""
+    sheet = BottomSheet(Box(), headline="Filters", style=BottomSheetStyle(corner_radius=28.0))
+    built = sheet.build()
+    assert isinstance(built, Box)
+    cr = 28.0
+    assert built.corner_radius == (cr, cr, 0.0, 0.0)
+
+
+def test_bottom_sheet_build_width():
+    """BottomSheet.build() outer Box has full width from style."""
+    sheet = BottomSheet(Box(), headline="Filters", style=BottomSheetStyle(width="100%"))
+    built = sheet.build()
+    assert isinstance(built, Box)
+
+
+def test_bottom_sheet_transition_auto_uses_height():
+    """Default transition slides by exactly the sheet's own height (fraction = 1.0)."""
+    spec = MaterialTransitions.bottom_sheet()
+    visuals_start = spec.enter.pattern.resolve(0.0)
+    assert visuals_start.translate_y_fraction == pytest.approx(1.0)
+
+
+def test_bottom_sheet_transition_fallback_for_none_height():
+    """Fractional slide is dimension-independent: works regardless of height value."""
+    spec = MaterialTransitions.bottom_sheet()
+    visuals_end = spec.exit.pattern.resolve(1.0)
+    assert visuals_end.translate_y_fraction == pytest.approx(1.0)
+
+
+def test_bottom_sheet_transition_fallback_for_string_height():
+    """Fractional slide works even when height is '50%' or content-driven."""
+    spec = MaterialTransitions.bottom_sheet()
+    visuals_mid = spec.enter.pattern.resolve(0.5)
+    assert visuals_mid.translate_y_fraction == pytest.approx(0.5)

--- a/tests/test_side_sheet.py
+++ b/tests/test_side_sheet.py
@@ -1,0 +1,218 @@
+"""Tests for SideSheet widget and MaterialOverlay.side_sheet()."""
+
+import pytest
+
+from nuiitivet.material.sheet import SideSheet
+from nuiitivet.material.styles.sheet_style import SideSheetStyle
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.material.transition_spec import MaterialSideSheetTransitionSpec, MaterialTransitions
+from nuiitivet.theme.manager import manager
+from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.widgets.box import Box
+
+
+@pytest.fixture(autouse=True)
+def material_theme():
+    manager.set_theme(MaterialTheme.light("#6750A4"))
+
+
+# ---------------------------------------------------------------------------
+# SideSheetStyle tests
+# ---------------------------------------------------------------------------
+
+
+def test_side_sheet_style_defaults():
+    style = SideSheetStyle()
+    assert style.width == 400
+    assert style.height == "100%"
+    assert style.corner_radius == 16.0
+    assert style.background_color == ColorRole.SURFACE_CONTAINER_LOW
+
+
+def test_side_sheet_style_copy_with():
+    style = SideSheetStyle().copy_with(width=320, corner_radius=8.0)
+    assert style.width == 320
+    assert style.height == "100%"
+    assert style.corner_radius == 8.0
+
+
+def test_side_sheet_style_is_immutable():
+    style = SideSheetStyle()
+    with pytest.raises((AttributeError, TypeError)):
+        style.width = 100  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# MaterialSideSheetTransitionSpec tests
+# ---------------------------------------------------------------------------
+
+
+def test_side_sheet_transition_spec_defaults():
+    spec = MaterialSideSheetTransitionSpec()
+    assert spec.enter is not None
+    assert spec.exit is not None
+
+
+def test_material_transitions_side_sheet_right():
+    spec = MaterialTransitions.side_sheet(side="right")
+    assert isinstance(spec, MaterialSideSheetTransitionSpec)
+    visuals = spec.enter.pattern.resolve(0.0)
+    assert visuals.translate_x_fraction is not None
+    assert visuals.translate_x_fraction > 0
+
+
+def test_material_transitions_side_sheet_left():
+    spec = MaterialTransitions.side_sheet(side="left")
+    assert isinstance(spec, MaterialSideSheetTransitionSpec)
+    visuals = spec.enter.pattern.resolve(0.0)
+    assert visuals.translate_x_fraction is not None
+    assert visuals.translate_x_fraction < 0
+
+
+def test_material_transitions_side_sheet_custom_enter():
+    from nuiitivet.animation.transition_definition import TransitionDefinition
+    from nuiitivet.animation.transition_pattern import FadePattern
+    from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_EFFECTS
+
+    custom_enter = TransitionDefinition(
+        motion=EXPRESSIVE_DEFAULT_EFFECTS,
+        pattern=FadePattern(start_alpha=0.0, end_alpha=1.0),
+    )
+    spec = MaterialTransitions.side_sheet(enter=custom_enter)
+    assert spec.enter is custom_enter
+
+
+# ---------------------------------------------------------------------------
+# SideSheet widget tests
+# ---------------------------------------------------------------------------
+
+
+def test_side_sheet_defaults():
+    """SideSheet stores headline and defaults correctly."""
+    content = Box(width=100, height=100)
+    sheet = SideSheet(content, headline="Settings")
+    assert sheet.side == "right"
+    assert sheet._headline == "Settings"
+    assert sheet._on_back is None
+    assert sheet._on_close is None
+
+
+def test_side_sheet_style_property_default():
+    """SideSheet.style returns SideSheetStyle() when no style given."""
+    sheet = SideSheet(Box(), headline="Settings")
+    assert sheet.style == SideSheetStyle()
+
+
+def test_side_sheet_style_property_custom():
+    """SideSheet.style returns user-provided style."""
+    custom = SideSheetStyle(width=320)
+    sheet = SideSheet(Box(), headline="Settings", style=custom)
+    assert sheet.style is custom
+
+
+def test_side_sheet_left_side():
+    """SideSheet stores side='left' correctly."""
+    sheet = SideSheet(Box(), headline="Nav", side="left")
+    assert sheet.side == "left"
+
+
+def test_side_sheet_right_corner_radius():
+    """Right-side sheet applies left (inner) corner radius only."""
+    style = SideSheetStyle(corner_radius=16.0)
+    cr = style.corner_radius
+    corner_radius = (cr, 0.0, 0.0, cr)  # tl, tr, br, bl
+    assert corner_radius == (16.0, 0.0, 0.0, 16.0)
+
+
+def test_side_sheet_left_corner_radius():
+    """Left-side sheet applies right (inner) corner radius only."""
+    style = SideSheetStyle(corner_radius=16.0)
+    cr = style.corner_radius
+    corner_radius = (0.0, cr, cr, 0.0)  # tl, tr, br, bl
+    assert corner_radius == (0.0, 16.0, 16.0, 0.0)
+
+
+def test_side_sheet_build_returns_box():
+    """SideSheet.build() returns a Box as the outer container."""
+    content = Box(width=200, height=100)
+    sheet = SideSheet(content, headline="Settings")
+    built = sheet.build()
+    assert isinstance(built, Box)
+
+
+def test_side_sheet_build_right_corner_radius():
+    """SideSheet.build() applies correct corner radii for right side."""
+    sheet = SideSheet(Box(), headline="Settings", side="right", style=SideSheetStyle(corner_radius=16.0))
+    built = sheet.build()
+    assert isinstance(built, Box)
+    cr = 16.0
+    assert built.corner_radius == (cr, 0.0, 0.0, cr)
+
+
+def test_side_sheet_build_left_corner_radius():
+    """SideSheet.build() applies correct corner radii for left side."""
+    sheet = SideSheet(Box(), headline="Nav", side="left", style=SideSheetStyle(corner_radius=16.0))
+    built = sheet.build()
+    assert isinstance(built, Box)
+    cr = 16.0
+    assert built.corner_radius == (0.0, cr, cr, 0.0)
+
+
+def test_side_sheet_build_width_height():
+    """SideSheet.build() outer Box has width and height from style."""
+    sheet = SideSheet(Box(), headline="Settings", style=SideSheetStyle(width=360, height="100%"))
+    built = sheet.build()
+    assert isinstance(built, Box)
+    assert built.width_sizing.value == 360
+
+
+def test_side_sheet_show_back_false_by_default():
+    """show_back_button defaults to False — Back button absent in header."""
+    sheet = SideSheet(Box(), headline="Settings")
+    assert sheet._resolve_show_back() is False
+
+
+def test_side_sheet_show_back_true():
+    """show_back_button=True — _resolve_show_back returns True."""
+    sheet = SideSheet(Box(), headline="Settings", show_back_button=True)
+    assert sheet._resolve_show_back() is True
+
+
+def test_side_sheet_show_back_observable():
+    """show_back_button=Observable — _resolve_show_back reflects observable value."""
+    from nuiitivet.observable import Observable
+
+    obs = Observable(False)
+    sheet = SideSheet(Box(), headline="Settings", show_back_button=obs)
+    assert sheet._resolve_show_back() is False
+    obs.value = True
+    assert sheet._resolve_show_back() is True
+
+
+def test_side_sheet_transition_auto_uses_width():
+    """Default transition slides by exactly the sheet's own width (fraction = 1.0)."""
+    spec = MaterialTransitions.side_sheet(side="right")
+    visuals_start = spec.enter.pattern.resolve(0.0)
+    assert visuals_start.translate_x_fraction == pytest.approx(1.0)
+
+
+def test_side_sheet_transition_fallback_for_non_int_width():
+    """Fractional slide is dimension-independent: no fallback calculation needed."""
+    spec = MaterialTransitions.side_sheet(side="right")
+    visuals_end = spec.exit.pattern.resolve(1.0)
+    assert visuals_end.translate_x_fraction == pytest.approx(1.0)
+
+
+def test_side_sheet_back_button_suppressed_without_on_back():
+    """Back button is silently suppressed when show_back_button=True but on_back is None.
+
+    This documents the guarded condition in build():
+        if self._resolve_show_back() and self._on_back is not None
+    """
+    sheet = SideSheet(Box(), headline="Settings", show_back_button=True, on_back=None)
+    # Flag is truthy, but callback is absent — button must NOT appear.
+    assert sheet._resolve_show_back() is True
+    assert sheet._on_back is None
+    # build() must succeed without AttributeError from a missing callback.
+    built = sheet.build()
+    assert isinstance(built, Box)


### PR DESCRIPTION
## Overview

Implements MD3 modal SideSheet and BottomSheet widgets as described in issue #29.

## Changes

### New
- `SideSheet` widget — modal side sheet with slide-in/out animation from the right edge
- `BottomSheet` widget — modal bottom sheet with slide-up/down animation
- `SideSheetStyle` / `BottomSheetStyle` — style dataclasses with `SURFACE_CONTAINER_LOW` as default background
- `MaterialOverlay.side_sheet()` / `MaterialOverlay.bottom_sheet()` API

### Modified
- `ColorRole`: add `SURFACE_CONTAINER_LOW` (light: tone 96, dark: tone 10)
- `Palette`: add mapping and fallback for `SURFACE_CONTAINER_LOW`
- `TransitionSpec` / `TransitionPattern`: add sheet slide transitions
- `TransitionVisualSpec` / `OverlayVisualState`: extend for sheet animation states

### Other
- Add sample: `samples/sheet_demo.py`
- Add tests: `test_side_sheet.py`, `test_bottom_sheet.py`

## Related

Closes #29