### PR TITLE
feat(app): add resizable parameter to App and MaterialApp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "material-color-utilities<=0.2.6",
-  "pyglet>=2.1.11",
+  "pyglet>=2.1.14",
   "pyopengl>=3.1.10",
   "skia-python>=138.0",
 ]

--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -133,6 +133,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
         caption=caption,
         style=style,
         vsync=False,
+        resizable=getattr(app, "resizable", True),
     )
 
     # Check scale immediately and resize if needed

--- a/src/nuiitivet/material/app.py
+++ b/src/nuiitivet/material/app.py
@@ -42,6 +42,7 @@ class MaterialApp(App):
         theme: Optional[Any] = None,
         title_bar: Optional[TitleBar] = None,
         window_position: WindowPosition | None = None,
+        resizable: bool = True,
     ) -> "MaterialApp":
         """Create a MaterialApp with a root Navigator and Overlay.
 
@@ -55,6 +56,7 @@ class MaterialApp(App):
             theme: The MaterialTheme to use. Defaults to Light theme.
             title_bar: Custom window title bar.
             window_position: Initial window position.
+            resizable: Whether the window can be resized. Defaults to True.
 
         Returns:
             Configured MaterialApp instance.
@@ -112,6 +114,7 @@ class MaterialApp(App):
                 background=background,
                 theme=theme,
                 window_position=window_position,
+                resizable=resizable,
             ),
         )
 
@@ -126,6 +129,7 @@ class MaterialApp(App):
         theme: Optional[Any] = None,
         title_bar: Optional[TitleBar] = None,
         window_position: WindowPosition | None = None,
+        resizable: bool = True,
     ) -> None:
         """Initialize a MaterialApp with a single root widget.
 
@@ -138,6 +142,7 @@ class MaterialApp(App):
             theme: The MaterialTheme to use. Defaults to Light theme.
             title_bar: Custom window title bar.
             window_position: Initial window position.
+            resizable: Whether the window can be resized. Defaults to True.
         """
         if theme is None:
             theme = MaterialTheme.light("#6750A4")
@@ -165,4 +170,5 @@ class MaterialApp(App):
             overlay_factory=_overlay_factory,
             navigator_factory=_navigator_factory,
             window_position=window_position,
+            resizable=resizable,
         )

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -178,6 +178,7 @@ class App:
         theme: Optional[Any] = None,
         window_position: WindowPosition | None = None,
         window_auto_size_target: Widget | None = None,
+        resizable: bool = True,
     ) -> None:
         if not isinstance(root, Widget):
             raise TypeError("App.root must be a Widget instance.")
@@ -243,6 +244,7 @@ class App:
         self.width = self._resolve_window_sizing(width, preferred=int(pref_w), fallback=640)
         self.height = self._resolve_window_sizing(height, preferred=int(pref_h), fallback=480)
         self.window_position = window_position
+        self.resizable = resizable
 
         if title_bar is None:
             title_bar = DefaultTitleBar()
@@ -426,6 +428,7 @@ class App:
         background: ColorSpec = PlainColorRole.SURFACE,
         theme: Optional[Any] = None,
         window_position: WindowPosition | None = None,
+        resizable: bool = True,
     ) -> "App":
         """Create an App with a root Navigator and Overlay.
 
@@ -466,6 +469,7 @@ class App:
             theme=theme,
             window_position=window_position,
             window_auto_size_target=initial_route_widget,
+            resizable=resizable,
         )
         return self
 
@@ -481,6 +485,7 @@ class App:
         navigator_factory: NavigatorFactory | None = None,
         theme: Optional[Any] = None,
         window_position: WindowPosition | None = None,
+        resizable: bool = True,
     ):
         """Initialize App with a root Navigator and Overlay."""
         if not isinstance(content, Widget):
@@ -506,6 +511,7 @@ class App:
             theme=theme,
             window_position=window_position,
             window_auto_size_target=initial_route_widget,
+            resizable=resizable,
         )
 
     def _debug_record_invalidate(self) -> None:

--- a/tests/test_app_initialization_patterns.py
+++ b/tests/test_app_initialization_patterns.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.stack import Stack
+from nuiitivet.material.app import MaterialApp
 from nuiitivet.navigation import Navigator
 from nuiitivet.overlay import Overlay
 from nuiitivet.runtime.app import App, AppScope
@@ -87,3 +88,82 @@ def test_app_auto_window_size_measures_unmounted_composable_children() -> None:
 
     assert app.width == 232
     assert app.height == 82
+
+
+def test_app_resizable_default_true() -> None:
+    app = App(content=_FlagWidget())
+
+    assert app.resizable is True
+
+
+def test_app_resizable_explicit_false() -> None:
+    app = App(content=_FlagWidget(), resizable=False)
+
+    assert app.resizable is False
+
+
+def test_app_navigation_resizable_default_true() -> None:
+    prev_nav = Navigator._root  # type: ignore[attr-defined]
+    prev_overlay = Overlay._root_overlay  # type: ignore[attr-defined]
+    try:
+        Navigator._root = None  # type: ignore[attr-defined]
+        Overlay._root_overlay = None  # type: ignore[attr-defined]
+
+        app = App.navigation(
+            routes={_HomeIntent: lambda i: _FlagWidget(label=i.label)},
+            initial_route=_HomeIntent(label="home"),
+        )
+
+        assert app.resizable is True
+    finally:
+        Navigator._root = prev_nav  # type: ignore[attr-defined]
+        Overlay._root_overlay = prev_overlay  # type: ignore[attr-defined]
+
+
+def test_app_navigation_resizable_explicit_false() -> None:
+    prev_nav = Navigator._root  # type: ignore[attr-defined]
+    prev_overlay = Overlay._root_overlay  # type: ignore[attr-defined]
+    try:
+        Navigator._root = None  # type: ignore[attr-defined]
+        Overlay._root_overlay = None  # type: ignore[attr-defined]
+
+        app = App.navigation(
+            routes={_HomeIntent: lambda i: _FlagWidget(label=i.label)},
+            initial_route=_HomeIntent(label="home"),
+            resizable=False,
+        )
+
+        assert app.resizable is False
+    finally:
+        Navigator._root = prev_nav  # type: ignore[attr-defined]
+        Overlay._root_overlay = prev_overlay  # type: ignore[attr-defined]
+
+
+def test_material_app_resizable_default_true() -> None:
+    prev_nav = Navigator._root  # type: ignore[attr-defined]
+    prev_overlay = Overlay._root_overlay  # type: ignore[attr-defined]
+    try:
+        Navigator._root = None  # type: ignore[attr-defined]
+        Overlay._root_overlay = None  # type: ignore[attr-defined]
+
+        app = MaterialApp(content=_FlagWidget())
+
+        assert app.resizable is True
+    finally:
+        Navigator._root = prev_nav  # type: ignore[attr-defined]
+        Overlay._root_overlay = prev_overlay  # type: ignore[attr-defined]
+
+
+def test_material_app_resizable_explicit_false() -> None:
+    prev_nav = Navigator._root  # type: ignore[attr-defined]
+    prev_overlay = Overlay._root_overlay  # type: ignore[attr-defined]
+    try:
+        Navigator._root = None  # type: ignore[attr-defined]
+        Overlay._root_overlay = None  # type: ignore[attr-defined]
+
+        app = MaterialApp(content=_FlagWidget(), resizable=False)
+
+        assert app.resizable is False
+    finally:
+        Navigator._root = prev_nav  # type: ignore[attr-defined]
+        Overlay._root_overlay = prev_overlay  # type: ignore[attr-defined]

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "material-color-utilities", specifier = "<=0.2.6" },
-    { name = "pyglet", specifier = ">=2.1.11" },
+    { name = "pyglet", specifier = ">=2.1.14" },
     { name = "pyopengl", specifier = ">=3.1.10" },
     { name = "skia-python", specifier = ">=138.0" },
 ]
@@ -1089,11 +1089,11 @@ wheels = [
 
 [[package]]
 name = "pyglet"
-version = "2.1.12"
+version = "2.1.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/6c/4bf476a1522d8293565f801ef305f2932148950b552df866a771c884ddaf/pyglet-2.1.12.tar.gz", hash = "sha256:bd7a750b2a5beaf0d2dd4bf4052d96e711ecd00ad29dada889b1f8374285b5f6", size = 6594600, upload-time = "2026-01-07T11:45:23.453Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/a6/ffd78b2d05a820ced85baa11210b8e5d0db0d951767021150be0a231df00/pyglet-2.1.14.tar.gz", hash = "sha256:feb3fba05a85f50f793688d88ddfbcdc57044d971f2d8d2107eb7578eb4af51e", size = 6595146, upload-time = "2026-04-05T08:24:35.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/eb/872c18852bc1b9f39e7a14e992ebdc0bb6535227b2828a2bb737f6aa81b3/pyglet-2.1.12-py3-none-any.whl", hash = "sha256:875052fcfe1fbdd32272b0f57c4b3da908e727da7c98cf29485f10672607d327", size = 1032686, upload-time = "2026-01-07T11:45:18.585Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d4/789d34a4674a4ccc0b65ad54d0f963f873d39000c3ebed0880574d5437e5/pyglet-2.1.14-py3-none-any.whl", hash = "sha256:70febf03f206607103e1f9806527019c589002626937aecdca4d095ce0a4b9b0", size = 1032928, upload-time = "2026-04-05T08:24:29.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements #44 — adds a `resizable` parameter to `App` and `MaterialApp` to enable standard OS window resizing via the native title bar.

The upstream pyglet crash (macOS Cocoa callback, pyglet/pyglet#1410) that caused this issue to be pending is fixed in pyglet 2.1.14. This PR also bumps the minimum required version accordingly.

## Changes

- Add `resizable: bool = True` parameter to `App.__init__`, `App.navigation`, and `App._init_common`; stored as `self.resizable`
- Add `resizable` parameter to `MaterialApp.__init__` and `MaterialApp.navigation`
- Pass `resizable` to `pyglet.window.Window` in the backend runner
- Bump minimum pyglet version: `>=2.1.11` → `>=2.1.14`
- Add tests for default and explicit `resizable` values (`App`, `MaterialApp`)

## Notes

- Default is `True` — windows are resizable by default
- `CustomTitleBar` (borderless) with `resizable=True` has no effect; this is by design and left to the caller

## Testing

```
pytest   → 1121 passed
mypy     → no issues
flake8   → no issues
```

Closes #44