### PR TITLE
feat(material): add ButtonGroup widget

### DIFF
--- a/docs/md3/button-groups.md
+++ b/docs/md3/button-groups.md
@@ -1,0 +1,127 @@
+<!-- markdownlint-disable MD060 -->
+
+# Button Groups MD3 Specs
+
+Source: <https://m3.material.io/components/button-groups/specs>
+Collected: 2026-04-07
+
+## Summary
+
+- Tokens and specs provide 10 non-deprecated token sets: 5 `standard` sizes and 5 `connected` sizes.
+- Standard sets define per-size container height, between-space, and pressed-width motion tokens.
+- Connected sets define per-size container height, 2dp between-space, fully rounded container shape, and inner-corner tokens.
+- Measurements specify standard inner padding by size and fixed connected padding of 2dp at all sizes.
+- XS and S connected groups must keep a 48dp minimum width and 48x48dp target area.
+
+## Tokens & Specs
+
+### Token sets discovered
+
+| Token set                              | Notes                                                 |
+|----------------------------------------|-------------------------------------------------------|
+| Button group standard - Size - Xsmall  | Non-deprecated token-set option under Tokens & specs. |
+| Button group standard - Size - Small   | Non-deprecated token-set option under Tokens & specs. |
+| Button group standard - Size - Medium  | Non-deprecated token-set option under Tokens & specs. |
+| Button group standard - Size - Large   | Non-deprecated token-set option under Tokens & specs. |
+| Button group standard - Size - Xlarge  | Non-deprecated token-set option under Tokens & specs. |
+| Button group connected - Size - Xsmall | Non-deprecated token-set option under Tokens & specs. |
+| Button group connected - Size - Small  | Non-deprecated token-set option under Tokens & specs. |
+| Button group connected - Size - Medium | Non-deprecated token-set option under Tokens & specs. |
+| Button group connected - Size - Large  | Non-deprecated token-set option under Tokens & specs. |
+| Button group connected - Size - Xlarge | Non-deprecated token-set option under Tokens & specs. |
+
+### Extracted tokens
+
+| Token set                              | Group            | Label                                                    | Token                                                                           | Value         | Notes                    |
+|----------------------------------------|------------------|----------------------------------------------------------|---------------------------------------------------------------------------------|---------------|--------------------------|
+| Button group standard - Size - Xsmall  | Size             | Button group xsmall container height                     | md.comp.button-group.standard.xsmall.container.height                           | 32dp          |                          |
+| Button group standard - Size - Xsmall  | Size             | Button group xsmall between space                        | md.comp.button-group.standard.xsmall.between-space                              | 18dp          |                          |
+| Button group standard - Size - Xsmall  | Motion (pressed) | Button group xsmall pressed motion spring dampening      | md.comp.button-group.standard.xsmall.pressed.item.width.motion.spring.dampening | 0.9           |                          |
+| Button group standard - Size - Xsmall  | Motion (pressed) | Button group xsmall pressed motion spring stiffness      | md.comp.button-group.standard.xsmall.pressed.item.width.motion.spring.stiffness | 1400          |                          |
+| Button group standard - Size - Xsmall  | Size (pressed)   | Button group xsmall pressed width multiplier             | md.comp.button-group.standard.xsmall.pressed.item.width.multiplier              | 15%           |                          |
+| Button group standard - Size - Small   | Size             | Button group small container height                      | md.comp.button-group.standard.small.container.height                            | 40dp          |                          |
+| Button group standard - Size - Small   | Size             | Button group small between space                         | md.comp.button-group.standard.small.between-space                               | 12dp          |                          |
+| Button group standard - Size - Small   | Motion (pressed) | Button group small pressed motion spring dampening       | md.comp.button-group.standard.small.pressed.item.width.motion.spring.dampening  | 0.9           |                          |
+| Button group standard - Size - Small   | Motion (pressed) | Button group small pressed motion spring stiffness       | md.comp.button-group.standard.small.pressed.item.width.motion.spring.stiffness  | 1400          |                          |
+| Button group standard - Size - Small   | Size (pressed)   | Button group small pressed width multiplier              | md.comp.button-group.standard.small.pressed.item.width.multiplier               | 15%           |                          |
+| Button group standard - Size - Medium  | Size             | Button group medium container height                     | md.comp.button-group.standard.medium.container.height                           | 56dp          |                          |
+| Button group standard - Size - Medium  | Size             | Button group medium between space                        | md.comp.button-group.standard.medium.between-space                              | 8dp           |                          |
+| Button group standard - Size - Medium  | Motion (pressed) | Button group medium pressed motion spring dampening      | md.comp.button-group.standard.medium.pressed.item.width.motion.spring.dampening | 0.9           |                          |
+| Button group standard - Size - Medium  | Motion (pressed) | Button group medium pressed motion spring stiffness      | md.comp.button-group.standard.medium.pressed.item.width.motion.spring.stiffness | 1400          |                          |
+| Button group standard - Size - Medium  | Size (pressed)   | Button group medium pressed width multiplier             | md.comp.button-group.standard.medium.pressed.item.width.multiplier              | 15%           |                          |
+| Button group standard - Size - Large   | Size             | Button group large container height                      | md.comp.button-group.standard.large.container.height                            | 96dp          |                          |
+| Button group standard - Size - Large   | Size             | Button group large between space                         | md.comp.button-group.standard.large.between-space                               | 8dp           |                          |
+| Button group standard - Size - Large   | Motion (pressed) | Button group large pressed motion spring dampening       | md.comp.button-group.standard.large.pressed.item.width.motion.spring.dampening  | 0.9           |                          |
+| Button group standard - Size - Large   | Motion (pressed) | Button group large pressed motion spring stiffness       | md.comp.button-group.standard.large.pressed.item.width.motion.spring.stiffness  | 1400          |                          |
+| Button group standard - Size - Large   | Size (pressed)   | Button group large pressed width multiplier              | md.comp.button-group.standard.large.pressed.item.width.multiplier               | 15%           |                          |
+| Button group standard - Size - Xlarge  | Size             | Button group xlarge container height                     | md.comp.button-group.standard.xlarge.container.height                           | 136dp         |                          |
+| Button group standard - Size - Xlarge  | Size             | Button group xlarge between space                        | md.comp.button-group.standard.xlarge.between-space                              | 8dp           |                          |
+| Button group standard - Size - Xlarge  | Motion (pressed) | Button group xlarge pressed motion spring dampening      | md.comp.button-group.standard.xlarge.pressed.item.width.motion.spring.dampening | 0.9           |                          |
+| Button group standard - Size - Xlarge  | Motion (pressed) | Button group xlarge pressed motion spring stiffness      | md.comp.button-group.standard.xlarge.pressed.item.width.motion.spring.stiffness | 1400          |                          |
+| Button group standard - Size - Xlarge  | Size (pressed)   | Button group xlarge pressed width multiplier             | md.comp.button-group.standard.xlarge.pressed.item.width.multiplier              | 15%           |                          |
+| Button group connected - Size - Xsmall | Size             | Button group connected xsmall container height           | md.comp.button-group.connected.xsmall.container.height                          | 32dp          |                          |
+| Button group connected - Size - Xsmall | Size             | Button group connected xsmall space between buttons      | md.comp.button-group.connected.xsmall.between-space                             | 2dp           |                          |
+| Button group connected - Size - Xsmall | Shape            | Button group connected xsmall container shape            | md.comp.button-group.connected.xsmall.container.shape                           | Fully rounded | Text shown in token row. |
+| Button group connected - Size - Xsmall | Shape            | Button group connected xsmall inner corner size          | md.comp.button-group.connected.xsmall.inner-corner.corner-size                  | 8dp           |                          |
+| Button group connected - Size - Xsmall | Shape (pressed)  | Button group connected xsmall pressed inner corner size  | md.comp.button-group.connected.xsmall.pressed.inner-corner.corner-size          | 4dp           |                          |
+| Button group connected - Size - Xsmall | Shape (selected) | Button group connected xsmall selected inner corner size | md.comp.button-group.connected.xsmall.selected.inner-corner.corner-size         | 50%           |                          |
+| Button group connected - Size - Small  | Size             | Button group connected small container height            | md.comp.button-group.connected.small.container.height                           | 40dp          |                          |
+| Button group connected - Size - Small  | Size             | Button group connected small space between buttons       | md.comp.button-group.connected.small.between-space                              | 2dp           |                          |
+| Button group connected - Size - Small  | Shape            | Button group connected small container shape             | md.comp.button-group.connected.small.container.shape                            | Fully rounded | Text shown in token row. |
+| Button group connected - Size - Small  | Shape            | Button group connected small inner corner size           | md.comp.button-group.connected.small.inner-corner.corner-size                   | 8dp           |                          |
+| Button group connected - Size - Small  | Shape (pressed)  | Button group connected small pressed inner corner size   | md.comp.button-group.connected.small.pressed.inner-corner.corner-size           | 4dp           |                          |
+| Button group connected - Size - Small  | Shape (selected) | Button group connected small selected inner corner size  | md.comp.button-group.connected.small.selected.inner-corner.corner-size          | 50%           |                          |
+| Button group connected - Size - Medium | Size             | Button group connected medium container height           | md.comp.button-group.connected.medium.container.height                          | 56dp          |                          |
+| Button group connected - Size - Medium | Size             | Button group connected medium space between buttons      | md.comp.button-group.connected.medium.between-space                             | 2dp           |                          |
+| Button group connected - Size - Medium | Shape            | Button group connected medium container shape            | md.comp.button-group.connected.medium.container.shape                           | Fully rounded | Text shown in token row. |
+| Button group connected - Size - Medium | Shape            | Button group connected medium inner corner size          | md.comp.button-group.connected.medium.inner-corner.corner-size                  | 8dp           |                          |
+| Button group connected - Size - Medium | Shape (pressed)  | Button group connected medium pressed inner corner size  | md.comp.button-group.connected.medium.pressed.inner-corner.corner-size          | 4dp           |                          |
+| Button group connected - Size - Medium | Shape (selected) | Button group connected medium selected inner corner size | md.comp.button-group.connected.medium.selected.inner-corner.corner-size         | 50%           |                          |
+| Button group connected - Size - Large  | Size             | Button group connected large container height            | md.comp.button-group.connected.large.container.height                           | 96dp          |                          |
+| Button group connected - Size - Large  | Size             | Button group connected large space between buttons       | md.comp.button-group.connected.large.between-space                              | 2dp           |                          |
+| Button group connected - Size - Large  | Shape            | Button group connected large container shape             | md.comp.button-group.connected.large.container.shape                            | Fully rounded | Text shown in token row. |
+| Button group connected - Size - Large  | Shape            | Button group connected large inner corner size           | md.comp.button-group.connected.large.inner-corner.corner-size                   | 16dp          |                          |
+| Button group connected - Size - Large  | Shape (pressed)  | Button group connected large pressed inner corner size   | md.comp.button-group.connected.large.pressed.inner-corner.corner-size           | 12dp          |                          |
+| Button group connected - Size - Large  | Shape (selected) | Button group connected large selected inner corner size  | md.comp.button-group.connected.large.selected.inner-corner.corner-size          | 50%           |                          |
+| Button group connected - Size - Xlarge | Size             | Button group connected xlarge container height           | md.comp.button-group.connected.xlarge.container.height                          | 136dp         |                          |
+| Button group connected - Size - Xlarge | Size             | Button group connected xlarge space between buttons      | md.comp.button-group.connected.xlarge.between-space                             | 2dp           |                          |
+| Button group connected - Size - Xlarge | Shape            | Button group connected xlarge container shape            | md.comp.button-group.connected.xlarge.container.shape                           | Fully rounded | Text shown in token row. |
+| Button group connected - Size - Xlarge | Shape            | Button group connected xlarge inner corner size          | md.comp.button-group.connected.xlarge.inner-corner.corner-size                  | 20dp          |                          |
+| Button group connected - Size - Xlarge | Shape (pressed)  | Button group connected xlarge pressed inner corner size  | md.comp.button-group.connected.xlarge.pressed.inner-corner.corner-size          | 16dp          |                          |
+| Button group connected - Size - Xlarge | Shape (selected) | Button group connected xlarge selected inner corner size | md.comp.button-group.connected.xlarge.selected.inner-corner.corner-size         | 50%           |                          |
+
+## Measurements
+
+| Category                        | Item                           | Value                                           | Notes                                     |
+|---------------------------------|--------------------------------|-------------------------------------------------|-------------------------------------------|
+| Configurations                  | Sizes                          | XS, S, M, L, XL                                 | Listed in Configurations section.         |
+| Configurations                  | Default shape                  | Round, square                                   | Listed in Configurations section.         |
+| Configurations                  | Selection modes                | Single-select, multi-select, selection-required | Listed in Configurations section.         |
+| Standard button group           | Inner padding XS               | 18dp                                            | Figure callout under Measurements.        |
+| Standard button group           | Inner padding S                | 12dp                                            | Figure callout under Measurements.        |
+| Standard button group           | Inner padding M                | 8dp                                             | Figure callout under Measurements.        |
+| Standard button group           | Inner padding L                | 8dp                                             | Figure callout under Measurements.        |
+| Standard button group           | Inner padding XL               | 8dp                                             | Figure callout under Measurements.        |
+| Standard button group           | Minimum accessible target size | 48dp                                            | Explicit statement in prose.              |
+| Connected button group          | Inner padding (all sizes)      | 2dp                                             | Explicit statement in prose.              |
+| Connected button group (round)  | Inner corner XS                | 4dp                                             | Figure callout under Measurements.        |
+| Connected button group (round)  | Inner corner S                 | 8dp                                             | Figure callout under Measurements.        |
+| Connected button group (round)  | Inner corner M                 | 8dp                                             | Figure callout under Measurements.        |
+| Connected button group (round)  | Inner corner L                 | 16dp                                            | Figure callout under Measurements.        |
+| Connected button group (round)  | Inner corner XL                | 20dp                                            | Figure callout under Measurements.        |
+| Connected button group (square) | Outer corner XS                | 4dp                                             | Figure callout under Measurements.        |
+| Connected button group (square) | Outer corner S                 | 8dp                                             | Figure callout under Measurements.        |
+| Connected button group (square) | Outer corner M                 | 8dp                                             | Figure callout under Measurements.        |
+| Connected button group (square) | Outer corner L                 | 16dp                                            | Figure callout under Measurements.        |
+| Connected button group (square) | Outer corner XL                | 20dp                                            | Figure callout under Measurements.        |
+| Minimum widths                  | Connected XS minimum width     | 48dp                                            | Explicit statement in prose.              |
+| Minimum widths                  | Connected S minimum width      | 48dp                                            | Explicit statement in prose.              |
+| Minimum widths                  | Connected XS/S target area     | 48x48dp                                         | Figure + prose in Minimum widths section. |
+
+## Implementation Notes
+
+- Use separate token models for `standard` and `connected` variants; they do not share spacing or corner behavior.
+- For standard groups, apply size-specific `between-space` (18/12/8/8/8dp) plus pressed-width animation tokens (`dampening`, `stiffness`, `width.multiplier`).
+- For connected groups, enforce 2dp between-space at all sizes, fully rounded outer container shape, and size-driven inner-corner values.
+- Preserve selected inner corner value at `50%` across all connected sizes.
+- Enforce 48dp minimum width and target area rules for connected XS/S variants.

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -45,6 +45,17 @@ if TYPE_CHECKING:
     from .tooltip import Tooltip, RichTooltip
     from .styles.sheet_style import SideSheetStyle, BottomSheetStyle
     from .sheet import SideSheet, BottomSheet
+    from .button_group import (
+        GroupButton,
+        ButtonGroupPosition,
+        StandardButtonGroup,
+        ConnectedButtonGroup,
+    )
+    from .styles.button_group_style import (
+        ButtonGroupSize,
+        StandardButtonGroupStyle,
+        ConnectedButtonGroupStyle,
+    )
     from .transition_spec import (
         MaterialSideSheetTransitionSpec,
         MaterialBottomSheetTransitionSpec,
@@ -117,6 +128,13 @@ __all__ = [
     "BottomSheetStyle",
     "SideSheet",
     "BottomSheet",
+    "GroupButton",
+    "ButtonGroupPosition",
+    "ButtonGroupSize",
+    "StandardButtonGroupStyle",
+    "ConnectedButtonGroupStyle",
+    "StandardButtonGroup",
+    "ConnectedButtonGroup",
     "FadeIn",
     "FadeOut",
     "ScaleIn",
@@ -194,6 +212,13 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "BottomSheetStyle": ("styles.sheet_style", "BottomSheetStyle"),
     "SideSheet": ("sheet", "SideSheet"),
     "BottomSheet": ("sheet", "BottomSheet"),
+    "GroupButton": ("button_group", "GroupButton"),
+    "ButtonGroupPosition": ("button_group", "ButtonGroupPosition"),
+    "ButtonGroupSize": ("styles.button_group_style", "ButtonGroupSize"),
+    "StandardButtonGroupStyle": ("styles.button_group_style", "StandardButtonGroupStyle"),
+    "ConnectedButtonGroupStyle": ("styles.button_group_style", "ConnectedButtonGroupStyle"),
+    "StandardButtonGroup": ("button_group", "StandardButtonGroup"),
+    "ConnectedButtonGroup": ("button_group", "ConnectedButtonGroup"),
     "FadeIn": ("transitions", "FadeIn"),
     "FadeOut": ("transitions", "FadeOut"),
     "ScaleIn": ("transitions", "ScaleIn"),

--- a/src/nuiitivet/material/button_group.py
+++ b/src/nuiitivet/material/button_group.py
@@ -1,0 +1,827 @@
+"""Material Design 3 ButtonGroup components.
+
+This module provides:
+- ``GroupButton``: A single interactive segment, shared by both group types.
+- ``_ButtonGroupBase``: Internal base class with shared validation and mount logic.
+- ``StandardButtonGroup``: Action-oriented group; adjacent shape animation ON.
+- ``ConnectedButtonGroup``: Option-selector group; manages single / multi-select.
+- ``ButtonGroupPosition``: Literal type for segment position within a group.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import (
+    Callable,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    TYPE_CHECKING,
+    cast,
+)
+
+from nuiitivet.animation import Animatable
+from nuiitivet.animation.converter import VectorConverter
+from nuiitivet.input.pointer import PointerEvent
+from nuiitivet.material.interactive_widget import InteractiveWidget
+from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
+from nuiitivet.rendering.sizing import Sizing, SizingLike
+from nuiitivet.theme.types import ColorSpec
+from nuiitivet.widgets.box import Box
+
+if TYPE_CHECKING:
+    from nuiitivet.material.styles.button_group_style import (
+        ButtonGroupStyle,
+        ConnectedButtonGroupStyle,
+        StandardButtonGroupStyle,
+    )
+    from nuiitivet.material.symbols import Symbol
+    from nuiitivet.widgeting.widget import Widget
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public type alias
+# ---------------------------------------------------------------------------
+
+ButtonGroupPosition = Literal["start", "middle", "end", "only"]
+"""Position of a segment within a ButtonGroup."""
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Maps position → (tl_kind, tr_kind, br_kind, bl_kind)
+# Tuple order follows Box.corner_radius convention: (tl, tr, br, bl).
+# Each entry is either "outer" (group edge) or "inner" (junction).
+_CORNER_KIND: dict[str, Tuple[str, str, str, str]] = {
+    "start": ("outer", "inner", "inner", "outer"),
+    "middle": ("inner", "inner", "inner", "inner"),
+    "end": ("inner", "outer", "outer", "inner"),
+    "only": ("outer", "outer", "outer", "outer"),
+}
+
+
+class _CornerTupleConverter(VectorConverter[Tuple[float, float, float, float]]):
+    """Animation vector converter for a 4-float corner-radius tuple."""
+
+    def to_vector(self, v: Tuple[float, float, float, float]) -> List[float]:
+        return [float(v[0]), float(v[1]), float(v[2]), float(v[3])]
+
+    def from_vector(self, vector: List[float]) -> Tuple[float, float, float, float]:
+        return (vector[0], vector[1], vector[2], vector[3])
+
+
+_CORNER_CONVERTER = _CornerTupleConverter()
+
+# ---------------------------------------------------------------------------
+# GroupButton
+# ---------------------------------------------------------------------------
+
+
+class GroupButton(InteractiveWidget):
+    """A single interactive segment in a ButtonGroup (Standard or Connected).
+
+    Handles position-aware corner-radius shape morphing via ``EXPRESSIVE_FAST_SPATIAL``
+    motion on press / release.  ``set_position()`` is called exclusively by the
+    containing ``_ButtonGroupBase`` during ``on_mount``; it is not part of the
+    public user API.
+
+    Args:
+        label: Optional text label.  Can be a plain ``str`` or a
+            ``ReadOnlyObservableProtocol[str]`` for dynamic text.
+        icon: Optional icon.  Accepts a ``Symbol``, ``str`` icon name, or
+            ``ReadOnlyObservableProtocol`` wrapping either.
+        selected: Initial selected (toggle) state.  Pass an
+            ``ObservableProtocol[bool]`` to bind to external state.
+        on_change: Callback fired with the new ``bool`` selected state after each
+            toggle.  In ``ConnectedButtonGroup`` this callback is composed with
+            the group-level selection logic.
+        disabled: Whether the item ignores pointer events.
+        width: Optional width sizing.  ``ConnectedButtonGroup`` overrides this to
+            ``Sizing.flex(1)`` to achieve equal-width segments.
+        style: Optional style override.  If omitted the ``filled`` preset is used.
+    """
+
+    def __init__(
+        self,
+        label: "str | ReadOnlyObservableProtocol[str] | None" = None,
+        icon: "Symbol | str | ReadOnlyObservableProtocol | None" = None,
+        *,
+        selected: "bool | ObservableProtocol[bool]" = False,
+        on_change: Optional[Callable[[bool], None]] = None,
+        disabled: "bool | ObservableProtocol[bool]" = False,
+        width: SizingLike = None,
+        style: "Optional[ButtonGroupStyle]" = None,
+    ) -> None:
+        """Initialize GroupButton.
+
+        Args:
+            label: Text label, or an observable string.
+            icon: Icon symbol, string name, or observable icon.
+            selected: Initial selected state, or an observable bool.
+            on_change: Toggle-state change callback.
+            disabled: Disable interaction.
+            width: Width sizing spec.
+            style: Visual style override.
+        """
+        from nuiitivet.material.styles.button_group_style import StandardButtonGroupStyle
+
+        if label is None and icon is None:
+            raise ValueError("GroupButton requires at least one of label or icon")
+
+        self._has_user_style = style is not None
+        self._style: "ButtonGroupStyle" = style or StandardButtonGroupStyle.filled()
+        self._label = label
+        self._icon = icon
+
+        # on_change is interceptable by the containing group
+        self._on_change: Optional[Callable[[bool], None]] = on_change
+
+        # Selected state
+        self._selected_external: "Optional[ObservableProtocol[bool]]" = None
+        if hasattr(selected, "subscribe") and hasattr(selected, "value"):
+            self._selected_external = cast("ObservableProtocol[bool]", selected)
+            self._selected: bool = bool(self._selected_external.value)
+        else:
+            self._selected = bool(selected)
+
+        # Corner animation state
+        self._position: ButtonGroupPosition = "only"
+        self._neighbors: Tuple[Optional["GroupButton"], Optional["GroupButton"]] = (None, None)
+        self._adjacent_animation: bool = True
+        self._persistent_selected_pressed_shape: bool = False
+        self._connected_inner_press_only: bool = False
+        self._own_pressed: bool = False
+        self._left_neighbor_pressed: bool = False
+        self._right_neighbor_pressed: bool = False
+
+        # Store child widget refs for colour updates
+        self._text_widget: "Optional[Widget]" = None
+        self._icon_widget_ref: "Optional[Widget]" = None
+
+        # Compute initial effective colours
+        bg, fg, bc, bw = self._effective_colors()
+
+        # Build content child (stores text/icon refs)
+        content = self._build_content(fg)
+
+        # Initialize corner animation (no motion yet; motion is enabled in
+        # set_position() so the initial position snap is immediate)
+        initial_corners = self._compute_raw_idle_corners(
+            self._style.outer_corner_radius,
+            self._style.outer_corner_radius,  # "only" position: all outer
+        )
+        self._corner_anim: "Animatable[Tuple[float, float, float, float]]" = Animatable.vector(
+            initial_value=initial_corners,
+            converter=_CORNER_CONVERTER,
+            motion=None,  # Enabled after first set_position()
+        )
+
+        super().__init__(
+            child=content,
+            on_click=self._handle_click,
+            on_press=self._handle_press_down,
+            on_release=self._handle_press_up,
+            disabled=disabled,
+            width=width,
+            height=self._style.container_height,
+            padding=(12, 0, 12, 0),
+            background_color=bg,
+            border_color=bc,
+            border_width=bw,
+            corner_radius=initial_corners,
+            state_layer_color=self._style.overlay_color or ColorRole.ON_SURFACE,
+        )
+
+        # Override state-layer opacities from style
+        self._PRESS_OPACITY = self._style.overlay_alpha
+        self._HOVER_OPACITY = self._style.overlay_alpha * 2 / 3
+
+    # ------------------------------------------------------------------
+    # Preferred size
+    # ------------------------------------------------------------------
+
+    def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> Tuple[int, int]:
+        """Return preferred size, enforcing ``min_item_width``.
+
+        Args:
+            max_width: Available width constraint.
+            max_height: Available height constraint.
+
+        Returns:
+            ``(width, height)`` in pixels.
+        """
+        w, _h = super().preferred_size(max_width=max_width, max_height=max_height)
+        return (max(w, self._style.min_item_width), self._style.container_height)
+
+    # ------------------------------------------------------------------
+    # Position injection (called by container on_mount)
+    # ------------------------------------------------------------------
+
+    def set_position(
+        self,
+        position: ButtonGroupPosition,
+        neighbors: Tuple[Optional["GroupButton"], Optional["GroupButton"]],
+        adjacent_animation: bool = True,
+    ) -> None:
+        """Configure this item's position within its group.
+
+        Called exclusively by ``_ButtonGroupBase.on_mount()``.  Snaps the
+        corner radius to the idle value for the given position without
+        animation, then arms the ``EXPRESSIVE_FAST_SPATIAL`` motion for
+        subsequent press interactions.
+
+        Args:
+            position: One of ``"start"``, ``"middle"``, ``"end"``, ``"only"``.
+            neighbors: ``(left_neighbor, right_neighbor)``; either may be ``None``.
+            adjacent_animation: ``True`` for Standard groups (neighbor corners
+                respond); ``False`` for Connected groups.
+        """
+        self._position = position
+        self._neighbors = neighbors
+        self._adjacent_animation = adjacent_animation
+        self._own_pressed = False
+        self._left_neighbor_pressed = False
+        self._right_neighbor_pressed = False
+
+        idle = self._compute_target_corners(False, False, False)
+
+        # Snap the animation to idle (no motion for position init)
+        self._corner_anim.stop()
+        # Directly set internal observable to avoid a spurious animation tick
+        self._corner_anim._value.value = idle  # type: ignore[attr-defined]
+        self._corner_anim._target = idle  # type: ignore[attr-defined]
+        if self._corner_anim._state is not None:  # type: ignore[attr-defined]
+            v = _CORNER_CONVERTER.to_vector(idle)
+            state = self._corner_anim._state  # type: ignore[attr-defined]
+            state.value = v.copy()
+            state.start = v.copy()
+            state.target = v.copy()
+
+        # Enable expressive motion for future press interactions
+        self._corner_anim._motion = EXPRESSIVE_FAST_SPATIAL  # type: ignore[attr-defined]
+        v0 = _CORNER_CONVERTER.to_vector(idle)
+        self._corner_anim._state = EXPRESSIVE_FAST_SPATIAL.create_state(v0, v0)  # type: ignore[attr-defined]
+
+        # Apply immediately to Box's corner_radius (invalidates paint cache)
+        self.corner_radius = idle
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        """Subscribe to corner animation and external selected observable."""
+        super().on_mount()
+
+        # Subscribe to corner animation ticks
+        self.bind(self._corner_anim.subscribe(self._on_corner_value_changed))
+
+        # Subscribe to external selected observable if provided
+        if self._selected_external is not None:
+            sub = self._selected_external.subscribe(lambda v: self._set_selected(bool(v)))
+            self.bind(sub)
+
+    # ------------------------------------------------------------------
+    # Interaction handlers (pointer events)
+    # ------------------------------------------------------------------
+
+    def _handle_press_down(self, event: PointerEvent) -> None:
+        """Start press shape animation and notify adjacent neighbors."""
+        self._own_pressed = True
+        self._update_corner_target()
+        if self._adjacent_animation:
+            left, right = self._neighbors
+            if left is not None:
+                left._on_neighbor_pressed("right", True)
+            if right is not None:
+                right._on_neighbor_pressed("left", True)
+
+    def _handle_press_up(self, event: PointerEvent) -> None:
+        """Restore shape animation on release and notify adjacent neighbors."""
+        self._own_pressed = False
+        self._update_corner_target()
+        if self._adjacent_animation:
+            left, right = self._neighbors
+            if left is not None:
+                left._on_neighbor_pressed("right", False)
+            if right is not None:
+                right._on_neighbor_pressed("left", False)
+
+    def _on_neighbor_pressed(self, side: Literal["left", "right"], pressed: bool) -> None:
+        """React to an adjacent item's press state change.
+
+        Animates the junction corner facing the pressed neighbor.
+        Called exclusively from pointer event handlers; never from ``paint()``.
+
+        Args:
+            side: Which side the pressed neighbor is on.
+            pressed: ``True`` when the neighbor becomes pressed; ``False`` on release.
+        """
+        if side == "left":
+            self._left_neighbor_pressed = pressed
+        else:
+            self._right_neighbor_pressed = pressed
+        self._update_corner_target()
+
+    def _handle_click(self) -> None:
+        """Toggle selected state, fire change and click callbacks."""
+        if self.disabled:
+            return
+        new_selected = not self._selected
+        self._set_selected(new_selected)
+        if self._on_change is not None:
+            self._on_change(new_selected)
+
+    # ------------------------------------------------------------------
+    # State management
+    # ------------------------------------------------------------------
+
+    def _set_selected(self, value: bool) -> None:
+        """Update selected state and refresh visual colours.
+
+        Does NOT call ``_on_change``; callers must do so explicitly when needed.
+
+        Args:
+            value: New selected state.
+        """
+        self._selected = bool(value)
+
+        # Write back to external observable if mutable
+        if self._selected_external is not None:
+            ext = self._selected_external
+            if hasattr(ext, "value") and not isinstance(ext, ReadOnlyObservableProtocol):
+                try:
+                    ext.value = bool(value)  # type: ignore[assignment]
+                except AttributeError:
+                    pass
+
+        bg, fg, bc, _bw = self._effective_colors()
+        self.bgcolor = bg
+        self.border_color = bc
+        self._apply_foreground(fg)
+        self.state.selected = bool(value)
+        self._update_corner_target()
+        self.invalidate()
+
+    # ------------------------------------------------------------------
+    # Corner animation helpers
+    # ------------------------------------------------------------------
+
+    def _update_corner_target(self) -> None:
+        """Recompute and apply the corner animation target."""
+        left_p = self._left_neighbor_pressed if self._adjacent_animation else False
+        right_p = self._right_neighbor_pressed if self._adjacent_animation else False
+        target = self._compute_target_corners(self._own_pressed, left_p, right_p)
+        self._corner_anim.target = target
+
+    def _compute_target_corners(
+        self,
+        own_pressed: bool,
+        left_neighbor_pressed: bool,
+        right_neighbor_pressed: bool,
+    ) -> Tuple[float, float, float, float]:
+        """Compute the 4-corner radius tuple for the given interaction state.
+
+        Corner-tuple order: ``(tl, tr, br, bl)``.
+
+        Args:
+            own_pressed: Whether this item is currently pressed.
+            left_neighbor_pressed: Whether the left neighbor is pressed.
+            right_neighbor_pressed: Whether the right neighbor is pressed.
+
+        Returns:
+            Target ``(tl, tr, br, bl)`` corner radii in logical pixels.
+        """
+        s = self._style
+        kinds = _CORNER_KIND[self._position]  # (tl, tr, br, bl) kinds
+
+        def resolve(kind: str, own: bool, neighbor: bool) -> float:
+            if own:
+                if self._connected_inner_press_only:
+                    # Connected groups: keep outer corners stable while pressed.
+                    # When selected, preserve fully rounded inner corners to avoid
+                    # a temporary rectangular-looking intermediate shape.
+                    if kind == "outer":
+                        return s.outer_corner_radius
+                    if self._selected:
+                        sel = s.selected_inner_corner_radius
+                        return sel if sel > 0 else s.outer_corner_radius
+                    return s.pressed_inner_corner_radius
+                return s.pressed_outer_corner_radius if kind == "outer" else s.pressed_inner_corner_radius
+            if neighbor and kind == "inner":
+                return s.pressed_inner_corner_radius
+            # Standard groups: keep a squarer selected shape after release.
+            if self._selected and self._persistent_selected_pressed_shape:
+                return s.pressed_outer_corner_radius if kind == "outer" else s.pressed_inner_corner_radius
+            # Selected inner corner: fully rounded on inner edges (Connected groups only).
+            if kind == "inner" and self._selected and not self._adjacent_animation:
+                sel = s.selected_inner_corner_radius
+                return sel if sel > 0 else s.outer_corner_radius
+            return s.outer_corner_radius if kind == "outer" else s.inner_corner_radius
+
+        tl = resolve(kinds[0], own_pressed, left_neighbor_pressed)
+        tr = resolve(kinds[1], own_pressed, right_neighbor_pressed)
+        br = resolve(kinds[2], own_pressed, right_neighbor_pressed)
+        bl = resolve(kinds[3], own_pressed, left_neighbor_pressed)
+        return (tl, tr, br, bl)
+
+    @staticmethod
+    def _compute_raw_idle_corners(outer: float, inner: float) -> Tuple[float, float, float, float]:
+        """Return idle corners for the ``"only"`` position (all outer).
+
+        Args:
+            outer: Outer corner radius.
+            inner: Inner corner radius (unused for ``"only"``; kept for symmetry).
+
+        Returns:
+            ``(outer, outer, outer, outer)``
+        """
+        return (outer, outer, outer, outer)
+
+    def _on_corner_value_changed(self, v: Tuple[float, float, float, float]) -> None:
+        """Animation tick callback: apply animated corners to the Box."""
+        # Use Box's setter so paint cache is invalidated with every shape update.
+        self.corner_radius = v
+        self.invalidate()
+
+    # ------------------------------------------------------------------
+    # Visual helpers
+    # ------------------------------------------------------------------
+
+    def _effective_colors(
+        self,
+    ) -> Tuple[Optional[ColorSpec], ColorSpec, Optional[ColorSpec], float]:
+        """Return ``(background, foreground, border_color, border_width)`` for current state.
+
+        Returns:
+            Tuple of effective colour specs for the current selected state.
+        """
+        s = self._style
+        if self._selected:
+            bg: Optional[ColorSpec] = s.selected_background or s.background
+            fg: ColorSpec = s.selected_foreground or s.foreground or ColorRole.ON_SURFACE
+            bc: Optional[ColorSpec] = s.selected_border_color or s.border_color
+        else:
+            bg = s.background
+            fg = s.foreground or ColorRole.ON_SURFACE
+            bc = s.border_color
+        return bg, fg, bc, s.border_width
+
+    def _build_content(self, foreground: ColorSpec) -> "Widget":
+        """Build the content child widget (icon + label composition).
+
+        Stores references to the text and icon widgets for later colour updates.
+
+        Args:
+            foreground: Initial foreground colour for icon and text.
+
+        Returns:
+            A widget representing the item content.
+        """
+        from nuiitivet.material.icon import Icon
+        from nuiitivet.material.text import Text
+        from nuiitivet.material.styles.icon_style import IconStyle
+        from nuiitivet.material.styles.text_style import TextStyle
+        from nuiitivet.layout.row import Row
+
+        icon_size = 20
+
+        icon_w: "Optional[Widget]" = None
+        text_w: "Optional[Widget]" = None
+
+        if self._icon is not None:
+            icon_w = Icon(self._icon, size=icon_size, style=IconStyle(color=foreground))
+            self._icon_widget_ref = icon_w
+
+        if self._label is not None:
+            text_w = Text(
+                self._label,
+                style=TextStyle(color=foreground, font_size=14, text_alignment="center"),
+            )
+            self._text_widget = text_w
+
+        if icon_w is not None and text_w is None:
+            return icon_w
+        if text_w is not None and icon_w is None:
+            return text_w
+        assert icon_w is not None and text_w is not None
+        return Row([icon_w, text_w], gap=8, cross_alignment="center")
+
+    def _apply_foreground(self, foreground: ColorSpec) -> None:
+        """Update the colour of child text and icon widgets.
+
+        Args:
+            foreground: New foreground colour.
+        """
+        from nuiitivet.material.icon import Icon
+        from nuiitivet.material.styles.icon_style import IconStyle
+        from nuiitivet.material.styles.text_style import TextStyle
+
+        if self._text_widget is not None:
+            current = getattr(self._text_widget, "_style", None)
+            if current is not None:
+                self._text_widget._style = current.copy_with(color=foreground)  # type: ignore[attr-defined]
+            else:
+                self._text_widget._style = TextStyle(  # type: ignore[attr-defined]
+                    color=foreground, font_size=14, text_alignment="center"
+                )
+            self._text_widget.invalidate()
+
+        if self._icon_widget_ref is not None and isinstance(self._icon_widget_ref, Icon):
+            current_icon = getattr(self._icon_widget_ref, "_style", None)
+            if current_icon is not None:
+                self._icon_widget_ref._style = current_icon.copy_with(color=foreground)
+            else:
+                self._icon_widget_ref._style = IconStyle(color=foreground)
+            self._icon_widget_ref.invalidate()
+
+
+# ---------------------------------------------------------------------------
+# _ButtonGroupBase
+# ---------------------------------------------------------------------------
+
+
+class _ButtonGroupBase(Box):
+    """Internal base for StandardButtonGroup and ConnectedButtonGroup.
+
+    Validates items, builds the Row layout, and calls ``set_position()`` on
+    each item during ``on_mount()``.
+    """
+
+    def __init__(
+        self,
+        items: Sequence[GroupButton],
+        *,
+        adjacent_animation: bool,
+        persistent_selected_pressed_shape: bool,
+        connected_inner_press_only: bool,
+        group_width: SizingLike,
+        style: "ButtonGroupStyle",
+    ) -> None:
+        """Initialize the shared button group layout.
+
+        Args:
+            items: Between 2 and 5 ``GroupButton`` instances.
+            adjacent_animation: ``True`` to enable neighbor corner animation
+                (Standard); ``False`` to disable it (Connected).
+            persistent_selected_pressed_shape: ``True`` to keep a squarer
+                shape on selected items after release (Standard groups).
+            connected_inner_press_only: ``True`` to keep outer corners
+                stable while pressed, animating only inner corners
+                (Connected groups).
+            group_width: Width sizing passed to the inner ``Row`` and outer
+                ``Box``.  ``None`` for content-fit; ``"100%"`` for full-width.
+            style: Resolved ``ButtonGroupStyle`` for this group.
+        """
+        _validate_items(items)
+
+        self._items: List[GroupButton] = list(items)
+        self._style = style
+        self._adjacent_animation = adjacent_animation
+        self._persistent_selected_pressed_shape = persistent_selected_pressed_shape
+        self._connected_inner_press_only = connected_inner_press_only
+
+        from nuiitivet.layout.row import Row
+
+        row = Row(
+            list(items),
+            gap=style.item_gap,
+            cross_alignment="center",
+            width=group_width,
+            height=style.container_height,
+        )
+
+        super().__init__(child=row, width=group_width)
+
+    def _item_size_tokens(self) -> dict[str, int | float]:
+        """Return size tokens to propagate to items with user-provided styles.
+
+        Subclasses override to include only field names valid for their
+        concrete style type (e.g. ``inner_corner_radius`` is a field only
+        on ``ConnectedButtonGroupStyle``).
+        """
+        return {
+            "container_height": self._style.container_height,
+            "outer_corner_radius": self._style.outer_corner_radius,
+            "pressed_inner_corner_radius": self._style.pressed_inner_corner_radius,
+        }
+
+    def on_mount(self) -> None:
+        """Assign positions, sync size-layout tokens, and set neighbors for all items."""
+        super().on_mount()
+        n = len(self._items)
+        _size_tokens = self._item_size_tokens()
+        for i, item in enumerate(self._items):
+            if n == 1:
+                pos: ButtonGroupPosition = "only"
+            elif i == 0:
+                pos = "start"
+            elif i == n - 1:
+                pos = "end"
+            else:
+                pos = "middle"
+
+            # Propagate group style to items.  Items without a user-provided
+            # style inherit the full group style; items with a custom style
+            # only receive size tokens so they keep their custom colours.
+            if not item._has_user_style:
+                item._style = self._style
+            else:
+                item._style = item._style.copy_with(**_size_tokens)
+            item.height_sizing = Sizing.fixed(self._style.container_height)
+            # Refresh visual properties that were baked in during __init__.
+            bg, fg, bc, bw = item._effective_colors()
+            item.bgcolor = bg
+            item.border_color = bc
+            item.border_width = bw
+            item.state_layer_color = item._style.overlay_color or ColorRole.ON_SURFACE
+            item._PRESS_OPACITY = item._style.overlay_alpha
+            item._HOVER_OPACITY = item._style.overlay_alpha * 2 / 3
+            item._apply_foreground(fg)
+            item.mark_needs_layout()
+            item._persistent_selected_pressed_shape = self._persistent_selected_pressed_shape
+            item._connected_inner_press_only = self._connected_inner_press_only
+
+            left = self._items[i - 1] if i > 0 else None
+            right = self._items[i + 1] if i < n - 1 else None
+            item.set_position(pos, (left, right), adjacent_animation=self._adjacent_animation)
+
+
+def _validate_items(items: Sequence[object]) -> None:
+    """Raise if items fail the ButtonGroup constraints.
+
+    Args:
+        items: Sequence to validate.
+
+    Raises:
+        ValueError: If the number of items is outside [2, 5].
+        TypeError: If any element is not a ``GroupButton``.
+    """
+    if len(items) < 2:
+        raise ValueError(f"ButtonGroup requires at least 2 items, got {len(items)}")
+    if len(items) > 5:
+        raise ValueError(f"ButtonGroup requires at most 5 items, got {len(items)}")
+    for item in items:
+        if not isinstance(item, GroupButton):
+            raise TypeError(f"All items must be GroupButton instances, got {type(item).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# StandardButtonGroup
+# ---------------------------------------------------------------------------
+
+
+class StandardButtonGroup(_ButtonGroupBase):
+    """A ButtonGroup that organises action or toggle segments horizontally.
+
+    Width fits the combined item widths.  Adjacent segments animate their
+    junction corners in response to a neighbor's press (M3 Expressive motion).
+    Item selected states are independent — no group-level enforcement.
+
+    Args:
+        items: Between 2 and 5 ``GroupButton`` instances.
+        style: Visual style.  Use ``StandardButtonGroupStyle.filled()``,
+            ``.tonal()``, or ``.outlined()``, optionally passing a size
+            (e.g. ``StandardButtonGroupStyle.filled("m")``).
+    """
+
+    def __init__(
+        self,
+        items: Sequence[GroupButton],
+        *,
+        style: "Optional[StandardButtonGroupStyle]" = None,
+    ) -> None:
+        """Initialize StandardButtonGroup.
+
+        Args:
+            items: Between 2 and 5 ``GroupButton`` instances.
+            style: Visual style override.  Defaults to
+                ``StandardButtonGroupStyle.filled()`` (size ``"s"``).
+        """
+        from nuiitivet.material.styles.button_group_style import (
+            StandardButtonGroupStyle as _Std,
+        )
+
+        eff_style = style if style is not None else _Std.filled()
+        super().__init__(
+            items,
+            adjacent_animation=False,
+            persistent_selected_pressed_shape=True,
+            connected_inner_press_only=False,
+            group_width=None,  # Fits content
+            style=eff_style,
+        )
+
+
+# ---------------------------------------------------------------------------
+# ConnectedButtonGroup
+# ---------------------------------------------------------------------------
+
+
+class ConnectedButtonGroup(_ButtonGroupBase):
+    """A ButtonGroup that functions as an option selector / view switcher.
+
+    Width expands to fill the containing widget (``width="100%"``).  Items
+    share space equally (``Sizing.flex(1)``).  Only corner shapes animate on
+    press — adjacent segment corners are unaffected.  Selection is always
+    enforced by the group.
+
+    Args:
+        items: Between 2 and 5 ``GroupButton`` instances.
+        select_mode: ``"single"`` ensures at most one item is selected;
+            ``"multi"`` allows any combination.
+        style: Visual style.  Use ``ConnectedButtonGroupStyle.filled()``,
+            ``.tonal()``, or ``.outlined()``, optionally passing a size
+            (e.g. ``ConnectedButtonGroupStyle.filled("m")``).
+    """
+
+    def __init__(
+        self,
+        items: Sequence[GroupButton],
+        *,
+        select_mode: Literal["single", "multi"] = "single",
+        style: "Optional[ConnectedButtonGroupStyle]" = None,
+    ) -> None:
+        """Initialize ConnectedButtonGroup.
+
+        Args:
+            items: Between 2 and 5 ``GroupButton`` instances.
+            select_mode: ``"single"`` or ``"multi"`` selection enforcement.
+            style: Visual style override.  Defaults to
+                ``ConnectedButtonGroupStyle.filled()`` (size ``"s"``).
+        """
+        from nuiitivet.material.styles.button_group_style import (
+            ConnectedButtonGroupStyle as _Con,
+        )
+
+        eff_style = style if style is not None else _Con.filled()
+        self._select_mode = select_mode
+
+        super().__init__(
+            items,
+            adjacent_animation=False,
+            persistent_selected_pressed_shape=False,
+            connected_inner_press_only=True,
+            group_width="100%",
+            style=eff_style,
+        )
+
+    def _item_size_tokens(self) -> dict[str, int | float]:
+        """Include ``inner_corner_radius`` (a real field on Connected style)."""
+        tokens = super()._item_size_tokens()
+        tokens["inner_corner_radius"] = self._style.inner_corner_radius
+        return tokens
+
+    def on_mount(self) -> None:
+        """Assign positions, set flex widths, and wire group selection logic."""
+        super().on_mount()  # Calls _ButtonGroupBase.on_mount → set_position()
+
+        # Equal-width distribution for connected layout
+        for item in self._items:
+            item.width_sizing = Sizing.flex(1)
+            item.mark_needs_layout()
+
+        # Intercept each item's on_change to apply group selection logic
+        for i, item in enumerate(self._items):
+            original_on_change = item._on_change
+
+            def _make_wrapper(
+                item_idx: int,
+                orig_cb: Optional[Callable[[bool], None]],
+            ) -> Callable[[bool], None]:
+                def _wrapper(selected: bool) -> None:
+                    # 1. Item-level callback fires first
+                    if orig_cb is not None:
+                        orig_cb(selected)
+                    # 2. Group selection logic
+                    self._handle_group_selection_change(item_idx, selected)
+
+                return _wrapper
+
+            item._on_change = _make_wrapper(i, original_on_change)
+
+    def _handle_group_selection_change(self, changed_idx: int, selected: bool) -> None:
+        """Apply select_mode logic.
+
+        Args:
+            changed_idx: Index of the item whose state just changed.
+            selected: New selected state of the changed item.
+        """
+        if self._select_mode == "single" and selected:
+            for i, item in enumerate(self._items):
+                if i != changed_idx and item._selected:
+                    item._set_selected(False)
+
+
+__all__ = [
+    "GroupButton",
+    "ButtonGroupPosition",
+    "StandardButtonGroup",
+    "ConnectedButtonGroup",
+]

--- a/src/nuiitivet/material/styles/button_group_style.py
+++ b/src/nuiitivet/material/styles/button_group_style.py
@@ -1,0 +1,422 @@
+"""ButtonGroup style definitions for M3 button groups.
+
+Provides two concrete style classes:
+
+- ``StandardButtonGroupStyle``: For action-oriented groups with independent
+  fully-rounded pill segments.
+- ``ConnectedButtonGroupStyle``: For option-selector / view-switcher groups
+  with junction corners and selection state colours.
+
+Each style offers ``filled()``, ``tonal()``, and ``outlined()`` factory
+classmethods that accept a ``ButtonGroupSize`` to set M3-spec size tokens.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Literal, Optional, TYPE_CHECKING, Union
+
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.theme.types import ColorSpec
+
+if TYPE_CHECKING:
+    from nuiitivet.theme import Theme
+
+# ---------------------------------------------------------------------------
+# Size type
+# ---------------------------------------------------------------------------
+
+ButtonGroupSize = Literal["xs", "s", "m", "l", "xl"]
+"""Size variant for a ButtonGroup, mapping to M3 spec size tokens."""
+
+# ---------------------------------------------------------------------------
+# Size token tables (M3 spec)
+# ---------------------------------------------------------------------------
+
+_STANDARD_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
+    "xs": {
+        "container_height": 32,
+        "item_gap": 18,
+        "outer_corner_radius": 16.0,
+        "pressed_inner_corner_radius": 8.0,
+    },
+    "s": {
+        "container_height": 40,
+        "item_gap": 12,
+        "outer_corner_radius": 20.0,
+        "pressed_inner_corner_radius": 8.0,
+    },
+    "m": {
+        "container_height": 56,
+        "item_gap": 8,
+        "outer_corner_radius": 28.0,
+        "pressed_inner_corner_radius": 8.0,
+    },
+    "l": {
+        "container_height": 96,
+        "item_gap": 8,
+        "outer_corner_radius": 48.0,
+        "pressed_inner_corner_radius": 8.0,
+    },
+    "xl": {
+        "container_height": 136,
+        "item_gap": 8,
+        "outer_corner_radius": 68.0,
+        "pressed_inner_corner_radius": 8.0,
+    },
+}
+
+_CONNECTED_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
+    "xs": {
+        "container_height": 32,
+        "item_gap": 2,
+        "outer_corner_radius": 16.0,
+        "inner_corner_radius": 8.0,
+        "pressed_inner_corner_radius": 4.0,
+    },
+    "s": {
+        "container_height": 40,
+        "item_gap": 2,
+        "outer_corner_radius": 20.0,
+        "inner_corner_radius": 8.0,
+        "pressed_inner_corner_radius": 4.0,
+    },
+    "m": {
+        "container_height": 56,
+        "item_gap": 2,
+        "outer_corner_radius": 28.0,
+        "inner_corner_radius": 8.0,
+        "pressed_inner_corner_radius": 4.0,
+    },
+    "l": {
+        "container_height": 96,
+        "item_gap": 2,
+        "outer_corner_radius": 48.0,
+        "inner_corner_radius": 16.0,
+        "pressed_inner_corner_radius": 12.0,
+    },
+    "xl": {
+        "container_height": 136,
+        "item_gap": 2,
+        "outer_corner_radius": 68.0,
+        "inner_corner_radius": 20.0,
+        "pressed_inner_corner_radius": 16.0,
+    },
+}
+
+
+# ===================================================================
+# StandardButtonGroupStyle
+# ===================================================================
+
+
+@dataclass(frozen=True)
+class StandardButtonGroupStyle:
+    """Immutable style for ``StandardButtonGroup`` (M3-compliant).
+
+    All segments are independent fully-rounded pills.  There is no
+    junction-corner concept; ``inner_corner_radius`` always equals
+    ``outer_corner_radius`` (exposed as a read-only property).
+
+    Use ``filled()``, ``tonal()``, or ``outlined()`` to create a preset,
+    optionally passing a ``ButtonGroupSize``.
+    """
+
+    # Container colours
+    background: Optional[ColorSpec] = None
+    foreground: Optional[ColorSpec] = None
+    border_color: Optional[ColorSpec] = None
+    border_width: float = 0.0
+
+    # Selection colours
+    selected_background: Optional[ColorSpec] = None
+    selected_foreground: Optional[ColorSpec] = None
+
+    # Sizing
+    container_height: int = 40
+    item_gap: int = 12
+    min_item_width: int = 48
+
+    # Shape tokens
+    outer_corner_radius: float = 20.0
+    pressed_outer_corner_radius: float = 8.0
+    pressed_inner_corner_radius: float = 8.0
+
+    # State overlay
+    overlay_color: Optional[ColorSpec] = None
+    overlay_alpha: float = 0.12
+
+    # -- Derived properties (read-only interface for GroupButton) ----------
+
+    @property
+    def inner_corner_radius(self) -> float:
+        """Inner corner radius equals outer (fully-rounded pill)."""
+        return self.outer_corner_radius
+
+    @property
+    def selected_inner_corner_radius(self) -> float:
+        """Not applicable; returns ``0.0``."""
+        return 0.0
+
+    @property
+    def selected_border_color(self) -> Optional[ColorSpec]:
+        """No distinct selected border; falls back to ``border_color``."""
+        return self.border_color
+
+    # -- Mutations ----------------------------------------------------------
+
+    def copy_with(self, **changes: Any) -> "StandardButtonGroupStyle":
+        """Return a copy with the specified fields replaced."""
+        return replace(self, **changes)
+
+    # -- Factory classmethods -----------------------------------------------
+
+    @classmethod
+    def filled(cls, size: ButtonGroupSize = "s") -> "StandardButtonGroupStyle":
+        """Create a filled-variant style.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+        """
+        t = _STANDARD_SIZE_TOKENS[size]
+        return cls(
+            background=ColorRole.SURFACE_CONTAINER_HIGHEST,
+            foreground=ColorRole.ON_SURFACE,
+            border_width=0.0,
+            overlay_color=ColorRole.ON_SURFACE,
+            overlay_alpha=0.08,
+            selected_background=ColorRole.PRIMARY,
+            selected_foreground=ColorRole.ON_PRIMARY,
+            container_height=int(t["container_height"]),
+            item_gap=int(t["item_gap"]),
+            outer_corner_radius=float(t["outer_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+        )
+
+    @classmethod
+    def tonal(cls, size: ButtonGroupSize = "s") -> "StandardButtonGroupStyle":
+        """Create a tonal-variant style.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+        """
+        t = _STANDARD_SIZE_TOKENS[size]
+        return cls(
+            background=ColorRole.SECONDARY_CONTAINER,
+            foreground=ColorRole.ON_SECONDARY_CONTAINER,
+            border_width=0.0,
+            overlay_color=ColorRole.ON_SURFACE,
+            overlay_alpha=0.08,
+            selected_background=ColorRole.SECONDARY,
+            selected_foreground=ColorRole.ON_SECONDARY,
+            container_height=int(t["container_height"]),
+            item_gap=int(t["item_gap"]),
+            outer_corner_radius=float(t["outer_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+        )
+
+    @classmethod
+    def outlined(cls, size: ButtonGroupSize = "s") -> "StandardButtonGroupStyle":
+        """Create an outlined-variant style.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+        """
+        t = _STANDARD_SIZE_TOKENS[size]
+        return cls(
+            background=None,
+            foreground=ColorRole.ON_SURFACE,
+            border_color=ColorRole.OUTLINE,
+            border_width=1.0,
+            overlay_color=ColorRole.PRIMARY,
+            overlay_alpha=0.08,
+            selected_background=ColorRole.INVERSE_SURFACE,
+            selected_foreground=ColorRole.INVERSE_ON_SURFACE,
+            container_height=int(t["container_height"]),
+            item_gap=int(t["item_gap"]),
+            outer_corner_radius=float(t["outer_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+        )
+
+    @classmethod
+    def from_theme(
+        cls,
+        theme: "Theme | None",
+        variant: str,
+        size: ButtonGroupSize = "s",
+    ) -> "StandardButtonGroupStyle":
+        """Create a style from a theme and variant name.
+
+        Args:
+            theme: The active theme (currently unused; colours are role-based).
+            variant: One of ``"filled"``, ``"tonal"``, or ``"outlined"``.
+            size: M3 size token preset.
+        """
+        if variant == "tonal":
+            return cls.tonal(size)
+        if variant == "outlined":
+            return cls.outlined(size)
+        return cls.filled(size)
+
+
+# ===================================================================
+# ConnectedButtonGroupStyle
+# ===================================================================
+
+
+@dataclass(frozen=True)
+class ConnectedButtonGroupStyle:
+    """Immutable style for ``ConnectedButtonGroup`` (M3-compliant).
+
+    Segments are tightly connected with distinct junction corners.
+    Supports selection-state colours and a separate
+    ``selected_inner_corner_radius``.
+
+    Use ``filled()``, ``tonal()``, or ``outlined()`` to create a preset,
+    optionally passing a ``ButtonGroupSize``.
+    """
+
+    # Container colours
+    background: Optional[ColorSpec] = None
+    foreground: Optional[ColorSpec] = None
+    border_color: Optional[ColorSpec] = None
+    border_width: float = 0.0
+
+    # Selection colours
+    selected_background: Optional[ColorSpec] = None
+    selected_foreground: Optional[ColorSpec] = None
+    selected_border_color: Optional[ColorSpec] = None
+
+    # Sizing
+    container_height: int = 40
+    item_gap: int = 2
+    min_item_width: int = 48
+
+    # Shape tokens (idle)
+    outer_corner_radius: float = 20.0
+    inner_corner_radius: float = 8.0
+
+    # Shape tokens (pressed)
+    pressed_outer_corner_radius: float = 8.0
+    pressed_inner_corner_radius: float = 4.0
+
+    # Shape tokens (selected)
+    selected_inner_corner_radius: float = 0.0  # 0.0 = fully rounded (= outer)
+
+    # State overlay
+    overlay_color: Optional[ColorSpec] = None
+    overlay_alpha: float = 0.12
+
+    # -- Mutations ----------------------------------------------------------
+
+    def copy_with(self, **changes: Any) -> "ConnectedButtonGroupStyle":
+        """Return a copy with the specified fields replaced."""
+        return replace(self, **changes)
+
+    # -- Factory classmethods -----------------------------------------------
+
+    @classmethod
+    def filled(cls, size: ButtonGroupSize = "s") -> "ConnectedButtonGroupStyle":
+        """Create a filled-variant style.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+        """
+        t = _CONNECTED_SIZE_TOKENS[size]
+        return cls(
+            background=ColorRole.SURFACE_CONTAINER_HIGHEST,
+            foreground=ColorRole.ON_SURFACE,
+            border_width=0.0,
+            overlay_color=ColorRole.ON_SURFACE,
+            overlay_alpha=0.08,
+            selected_background=ColorRole.PRIMARY,
+            selected_foreground=ColorRole.ON_PRIMARY,
+            container_height=int(t["container_height"]),
+            item_gap=int(t["item_gap"]),
+            outer_corner_radius=float(t["outer_corner_radius"]),
+            inner_corner_radius=float(t["inner_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+        )
+
+    @classmethod
+    def tonal(cls, size: ButtonGroupSize = "s") -> "ConnectedButtonGroupStyle":
+        """Create a tonal-variant style.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+        """
+        t = _CONNECTED_SIZE_TOKENS[size]
+        return cls(
+            background=ColorRole.SECONDARY_CONTAINER,
+            foreground=ColorRole.ON_SECONDARY_CONTAINER,
+            border_width=0.0,
+            overlay_color=ColorRole.ON_SURFACE,
+            overlay_alpha=0.08,
+            selected_background=ColorRole.SECONDARY,
+            selected_foreground=ColorRole.ON_SECONDARY,
+            container_height=int(t["container_height"]),
+            item_gap=int(t["item_gap"]),
+            outer_corner_radius=float(t["outer_corner_radius"]),
+            inner_corner_radius=float(t["inner_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+        )
+
+    @classmethod
+    def outlined(cls, size: ButtonGroupSize = "s") -> "ConnectedButtonGroupStyle":
+        """Create an outlined-variant style.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+        """
+        t = _CONNECTED_SIZE_TOKENS[size]
+        return cls(
+            background=None,
+            foreground=ColorRole.ON_SURFACE,
+            border_color=ColorRole.OUTLINE,
+            border_width=1.0,
+            overlay_color=ColorRole.PRIMARY,
+            overlay_alpha=0.08,
+            selected_background=ColorRole.INVERSE_SURFACE,
+            selected_foreground=ColorRole.INVERSE_ON_SURFACE,
+            selected_border_color=ColorRole.OUTLINE,
+            container_height=int(t["container_height"]),
+            item_gap=int(t["item_gap"]),
+            outer_corner_radius=float(t["outer_corner_radius"]),
+            inner_corner_radius=float(t["inner_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+        )
+
+    @classmethod
+    def from_theme(
+        cls,
+        theme: "Theme | None",
+        variant: str,
+        size: ButtonGroupSize = "s",
+    ) -> "ConnectedButtonGroupStyle":
+        """Create a style from a theme and variant name.
+
+        Args:
+            theme: The active theme (currently unused; colours are role-based).
+            variant: One of ``"filled"``, ``"tonal"``, or ``"outlined"``.
+            size: M3 size token preset.
+        """
+        if variant == "tonal":
+            return cls.tonal(size)
+        if variant == "outlined":
+            return cls.outlined(size)
+        return cls.filled(size)
+
+
+# ===================================================================
+# Union type alias
+# ===================================================================
+
+ButtonGroupStyle = Union[StandardButtonGroupStyle, ConnectedButtonGroupStyle]
+"""Type alias accepted by ``GroupButton`` — either style variant."""
+
+__all__ = [
+    "ButtonGroupSize",
+    "StandardButtonGroupStyle",
+    "ConnectedButtonGroupStyle",
+    "ButtonGroupStyle",
+]

--- a/src/samples/button_group_demo.py
+++ b/src/samples/button_group_demo.py
@@ -1,0 +1,228 @@
+"""ButtonGroup demo - StandardButtonGroup and ConnectedButtonGroup.
+
+This demo shows:
+- StandardButtonGroup: independent toggle segments with adjacent corner animation
+- ConnectedButtonGroup single-select: radio-style option selector
+- ConnectedButtonGroup multi-select: checkbox-style option selector
+- Variant comparison: filled, tonal, outlined
+"""
+
+from __future__ import annotations
+
+from nuiitivet.layout.column import Column
+from nuiitivet.widgets.box import Box
+from nuiitivet.material import Text
+from nuiitivet.material.app import MaterialApp
+from nuiitivet.material.button_group import (
+    GroupButton,
+    ConnectedButtonGroup,
+    StandardButtonGroup,
+)
+from nuiitivet.material.styles.button_group_style import (
+    StandardButtonGroupStyle,
+    ConnectedButtonGroupStyle,
+)
+from nuiitivet.observable import Observable
+
+
+def _heading(text: str) -> Text:
+    return Text(text, padding=(0, 16, 0, 6))
+
+
+def _subheading(text: str) -> Text:
+    return Text(text, padding=(0, 0, 0, 4))
+
+
+# ---------------------------------------------------------------------------
+# Demo state
+# ---------------------------------------------------------------------------
+
+selected_view = Observable("day")
+log_lines: list[str] = []
+log_obs: Observable[str] = Observable("(no events yet)")
+
+_MAX_LOG = 6
+
+
+def _log(msg: str) -> None:
+    log_lines.append(msg)
+    last = log_lines[-_MAX_LOG:]
+    log_obs.value = "\n".join(last)
+
+
+# ---------------------------------------------------------------------------
+# StandardButtonGroup sections
+# ---------------------------------------------------------------------------
+
+
+def _make_standard_filled() -> StandardButtonGroup:
+    def _cb(label: str):
+        def _inner(_selected: bool) -> None:
+            _log(f"standard/filled clicked: {label}")
+
+        return _inner
+
+    return StandardButtonGroup(
+        [
+            GroupButton("Day", on_change=_cb("Day")),
+            GroupButton("Week", on_change=_cb("Week")),
+            GroupButton("Month", on_change=_cb("Month")),
+        ],
+    )
+
+
+def _make_standard_tonal_with_icons() -> StandardButtonGroup:
+    def _cb(label: str):
+        def _inner(_selected: bool) -> None:
+            _log(f"standard/tonal clicked: {label}")
+
+        return _inner
+
+    return StandardButtonGroup(
+        [
+            GroupButton(icon="format_align_left", on_change=_cb("left")),
+            GroupButton(icon="format_align_center", on_change=_cb("center")),
+            GroupButton(icon="format_align_right", on_change=_cb("right")),
+            GroupButton(icon="format_align_justify", on_change=_cb("justify")),
+        ],
+        style=StandardButtonGroupStyle.tonal(),
+    )
+
+
+def _make_standard_outlined() -> StandardButtonGroup:
+    def _cb(label: str):
+        def _inner(_selected: bool) -> None:
+            _log(f"standard/outlined clicked: {label}")
+
+        return _inner
+
+    return StandardButtonGroup(
+        [
+            GroupButton("Bold", icon="format_bold", on_change=_cb("Bold")),
+            GroupButton("Italic", icon="format_italic", on_change=_cb("Italic")),
+            GroupButton("Underline", icon="format_underlined", on_change=_cb("Underline")),
+        ],
+        style=StandardButtonGroupStyle.outlined(),
+    )
+
+
+def _make_standard_with_disabled() -> StandardButtonGroup:
+    def _cb(label: str):
+        def _inner(_selected: bool) -> None:
+            _log(f"standard/disabled-demo clicked: {label}")
+
+        return _inner
+
+    return StandardButtonGroup(
+        [
+            GroupButton("Edit", icon="edit", on_change=_cb("Edit")),
+            GroupButton("Copy", icon="content_copy", on_change=_cb("Copy"), disabled=True),
+            GroupButton("Share", icon="share", on_change=_cb("Share")),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# ConnectedButtonGroup sections
+# ---------------------------------------------------------------------------
+
+
+def _make_connected_single() -> ConnectedButtonGroup:
+    def _on_change(indices: list[int]) -> None:
+        names = ["List", "Grid", "Map"]
+        selected_names = [names[i] for i in indices if i < len(names)]
+        _log(f"connected/single selected: {selected_names}")
+
+    return ConnectedButtonGroup(
+        [
+            GroupButton("List", icon="list", selected=True),
+            GroupButton("Grid", icon="grid_view"),
+            GroupButton("Map", icon="map"),
+        ],
+        select_mode="single",
+    )
+
+
+def _make_connected_multi() -> ConnectedButtonGroup:
+    def _on_change(indices: list[int]) -> None:
+        names = ["Wi-Fi", "BT", "NFC"]
+        selected_names = [names[i] for i in indices if i < len(names)]
+        _log(f"connected/multi selected: {selected_names}")
+
+    return ConnectedButtonGroup(
+        [
+            GroupButton("Wi-Fi", icon="wifi"),
+            GroupButton("BT", icon="bluetooth", selected=True),
+            GroupButton("NFC", icon="nfc"),
+        ],
+        select_mode="multi",
+        style=ConnectedButtonGroupStyle.tonal(),
+    )
+
+
+def _make_connected_outlined_single() -> ConnectedButtonGroup:
+    def _on_change(indices: list[int]) -> None:
+        sizes = ["S", "M", "L", "XL", "2XL"]
+        selected_names = [sizes[i] for i in indices if i < len(sizes)]
+        _log(f"connected/outlined selected: {selected_names}")
+
+    return ConnectedButtonGroup(
+        [
+            GroupButton("S"),
+            GroupButton("M", selected=True),
+            GroupButton("L"),
+            GroupButton("XL"),
+            GroupButton("2XL"),
+        ],
+        select_mode="single",
+        style=ConnectedButtonGroupStyle.outlined(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main layout
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    event_log = Text(log_obs, padding=4)
+
+    content = Column(
+        children=[
+            _heading("ButtonGroup Demo"),
+            # ---- Standard ----
+            _subheading("StandardButtonGroup — filled (text labels)"),
+            _make_standard_filled(),
+            _subheading("StandardButtonGroup — tonal (icon-only)"),
+            _make_standard_tonal_with_icons(),
+            _subheading("StandardButtonGroup — outlined (icon + label)"),
+            _make_standard_outlined(),
+            _subheading("StandardButtonGroup — with disabled item"),
+            _make_standard_with_disabled(),
+            # ---- Connected ----
+            _heading("ConnectedButtonGroup"),
+            _subheading("Single-select — filled (view switcher)"),
+            _make_connected_single(),
+            _subheading("Multi-select — tonal (toggles)"),
+            _make_connected_multi(),
+            _subheading("Single-select — outlined (5 items)"),
+            _make_connected_outlined_single(),
+            # ---- Event log ----
+            _heading("Event Log"),
+            Box(
+                child=event_log,
+                padding=8,
+                background_color="#EEEEEE",
+            ),
+        ],
+        gap=8,
+        cross_alignment="start",
+    )
+
+    root = Box(child=content, padding=24)
+    app = MaterialApp(content=root)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_button_group.py
+++ b/tests/test_button_group.py
@@ -1,0 +1,490 @@
+"""Tests for GroupButton, StandardButtonGroup, and ConnectedButtonGroup."""
+
+from __future__ import annotations
+
+from typing import List, Union
+
+import pytest
+
+from nuiitivet.input.pointer import PointerEventType
+from nuiitivet.material.button_group import (
+    GroupButton,
+    ButtonGroupPosition,
+    ConnectedButtonGroup,
+    StandardButtonGroup,
+)
+from nuiitivet.material.styles.button_group_style import (
+    StandardButtonGroupStyle,
+    ConnectedButtonGroupStyle,
+)
+from nuiitivet.observable import Observable
+from tests.helpers.pointer import send_pointer_event_for_test
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_obs(initial: bool):
+    class _Tmp:
+        x = Observable(initial)
+
+    return _Tmp().x
+
+
+def _make_item(
+    label: str = "A",
+    *,
+    selected: bool = False,
+    on_change=None,
+    disabled: bool = False,
+    style=None,
+) -> GroupButton:
+    return GroupButton(
+        label,
+        selected=selected,
+        on_change=on_change,
+        disabled=disabled,
+        style=style,
+    )
+
+
+def _make_items(n: int) -> List[GroupButton]:
+    return [_make_item(str(i)) for i in range(n)]
+
+
+def _mount_group(group) -> None:
+    """Simulate mounting the group and all children."""
+
+    class _FakeApp:
+        def invalidate(self) -> None:
+            pass
+
+        def request_focus(self, node) -> None:
+            pass
+
+    group.mount(_FakeApp())
+
+
+def _click(item: GroupButton) -> None:
+    send_pointer_event_for_test(item, PointerEventType.PRESS)
+    send_pointer_event_for_test(item, PointerEventType.RELEASE)
+
+
+# ===========================================================================
+# Common — validation
+# ===========================================================================
+
+
+def test_validation_min_items():
+    with pytest.raises(ValueError, match="at least 2"):
+        StandardButtonGroup([_make_item()])
+
+
+def test_validation_min_items_boundary():
+    group = StandardButtonGroup(_make_items(2))
+    assert group is not None
+
+
+def test_validation_max_items():
+    with pytest.raises(ValueError, match="at most 5"):
+        StandardButtonGroup(_make_items(6))
+
+
+def test_validation_max_items_boundary():
+    group = StandardButtonGroup(_make_items(5))
+    assert group is not None
+
+
+def test_validation_item_type():
+    with pytest.raises(TypeError, match="GroupButton"):
+        StandardButtonGroup(["not an item", _make_item()])  # type: ignore[list-item]
+
+
+# ===========================================================================
+# Common — position assignment
+# ===========================================================================
+
+
+def test_position_assignment_two_items():
+    items = _make_items(2)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+    assert items[0]._position == "start"
+    assert items[1]._position == "end"
+
+
+def test_position_assignment_three_items():
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+    assert items[0]._position == "start"
+    assert items[1]._position == "middle"
+    assert items[2]._position == "end"
+
+
+def test_position_assignment_five_items():
+    items = _make_items(5)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+    assert items[0]._position == "start"
+    assert items[1]._position == "middle"
+    assert items[2]._position == "middle"
+    assert items[3]._position == "middle"
+    assert items[4]._position == "end"
+
+
+# ===========================================================================
+# Common — corner radius at idle state
+# ===========================================================================
+
+
+def _idle_corners(
+    style: Union[StandardButtonGroupStyle, ConnectedButtonGroupStyle],
+    position: ButtonGroupPosition,
+):
+    """Expected idle corners for a given position."""
+    o = style.outer_corner_radius
+    i = style.inner_corner_radius
+    return {
+        "start": (o, i, i, o),
+        "middle": (i, i, i, i),
+        "end": (i, o, o, i),
+        "only": (o, o, o, o),
+    }[position]
+
+
+def test_corner_radius_idle_start():
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+    style = items[0]._style
+    assert items[0].corner_radius == _idle_corners(style, "start")
+
+
+def test_corner_radius_idle_middle():
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+    style = items[1]._style
+    assert items[1].corner_radius == _idle_corners(style, "middle")
+
+
+def test_corner_radius_idle_end():
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+    style = items[2]._style
+    assert items[2].corner_radius == _idle_corners(style, "end")
+
+
+# ===========================================================================
+# Common — press shape animation target
+# ===========================================================================
+
+
+def test_corner_radius_press_animate_target():
+    """Pressing a start item targets the pressed corner values."""
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    item = items[0]  # "start" position
+    s = item._style
+
+    send_pointer_event_for_test(item, PointerEventType.PRESS)
+    assert item._own_pressed is True
+
+    tl, tr, br, bl = item._corner_anim.target
+    assert tl == s.pressed_outer_corner_radius  # outer
+    assert tr == s.pressed_inner_corner_radius  # inner
+    assert br == s.pressed_inner_corner_radius  # inner
+    assert bl == s.pressed_outer_corner_radius  # outer
+
+    send_pointer_event_for_test(item, PointerEventType.RELEASE)
+    assert item._own_pressed is False
+
+
+# ===========================================================================
+# Common — on_change and disabled
+# ===========================================================================
+
+
+def test_on_change_fires():
+    called = []
+    item = _make_item(on_change=lambda selected: called.append(selected))
+    _click(item)
+    assert called == [True]
+
+
+def test_disabled_item_ignores_pointer_events():
+    called = []
+    item = _make_item(disabled=True, on_change=lambda selected: called.append(selected))
+    _click(item)
+    assert called == []
+    assert item.state.pressed is False
+
+
+# ===========================================================================
+# Common — variant style application
+# ===========================================================================
+
+
+def test_variant_filled():
+    item = _make_item(style=StandardButtonGroupStyle.filled())
+    assert item._style.background is not None
+
+
+def test_variant_tonal():
+    item = _make_item(style=StandardButtonGroupStyle.tonal())
+    s = item._style
+    # tonal variant: background should differ from filled
+    assert s.background != StandardButtonGroupStyle.filled().background
+
+
+def test_variant_outlined():
+    item = _make_item(style=StandardButtonGroupStyle.outlined())
+    s = item._style
+    assert s.border_width > 0
+    assert s.border_color is not None
+
+
+# ===========================================================================
+# StandardButtonGroup — neighbor corner animation
+# ===========================================================================
+
+
+def test_standard_no_neighbor_animate_on_press():
+    """Standard group: pressing an item does NOT affect adjacent item corners."""
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    start_item = items[0]  # "start"
+    middle_item = items[1]  # "middle"
+    s = middle_item._style
+
+    # Press start item
+    send_pointer_event_for_test(start_item, PointerEventType.PRESS)
+
+    # Middle should remain at idle corners
+    tl, tr, br, bl = middle_item._corner_anim.target
+    assert tl == s.inner_corner_radius
+    assert bl == s.inner_corner_radius
+    assert tr == s.inner_corner_radius
+    assert br == s.inner_corner_radius
+
+    # Release
+    send_pointer_event_for_test(start_item, PointerEventType.RELEASE)
+    tl2, tr2, br2, bl2 = middle_item._corner_anim.target
+    assert tl2 == s.inner_corner_radius
+    assert bl2 == s.inner_corner_radius
+
+
+def test_standard_item_selected_independent():
+    """Standard group: each item's selected state is independent."""
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    _click(items[0])
+    assert items[0]._selected is True
+    assert items[1]._selected is False
+    assert items[2]._selected is False
+
+    _click(items[1])
+    assert items[0]._selected is True
+    assert items[1]._selected is True
+
+
+def test_standard_selected_keeps_squarer_shape_after_release() -> None:
+    """Standard item keeps selected shape (does not snap back to idle rounded)."""
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    item = items[0]  # start
+    s = item._style
+
+    _click(item)
+    assert item._selected is True
+    assert item._corner_anim.target == (
+        s.pressed_outer_corner_radius,
+        s.pressed_inner_corner_radius,
+        s.pressed_inner_corner_radius,
+        s.pressed_outer_corner_radius,
+    )
+
+
+def test_standard_unselected_returns_to_idle_rounded_shape() -> None:
+    """Standard item returns to idle rounded corners when deselected."""
+    items = _make_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    item = items[0]  # start
+    s = item._style
+
+    _click(item)
+    assert item._selected is True
+
+    _click(item)
+    assert item._selected is False
+    assert item._corner_anim.target == (
+        s.outer_corner_radius,
+        s.inner_corner_radius,
+        s.inner_corner_radius,
+        s.outer_corner_radius,
+    )
+
+
+def test_standard_preferred_size():
+    """Group height matches container_height; item width respects min_item_width."""
+    item = _make_item()
+    _h = item._style.container_height
+    assert item.preferred_size()[1] == _h
+    assert item.preferred_size()[0] >= item._style.min_item_width
+
+
+# ===========================================================================
+# ConnectedButtonGroup — no neighbor animation
+# ===========================================================================
+
+
+def test_connected_no_neighbor_animate():
+    """Connected group: pressing an item does NOT affect adjacent item corners."""
+    items = _make_items(3)
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+
+    start_item = items[0]
+    middle_item = items[1]
+    s = middle_item._style
+
+    send_pointer_event_for_test(start_item, PointerEventType.PRESS)
+
+    # Middle should remain at idle corners
+    tl, tr, br, bl = middle_item._corner_anim.target
+    assert tl == s.inner_corner_radius
+    assert bl == s.inner_corner_radius
+
+    send_pointer_event_for_test(start_item, PointerEventType.RELEASE)
+
+
+def test_connected_press_keeps_outer_corners_rounded() -> None:
+    """Connected press should animate only inner corners, not outer corners."""
+    items = _make_items(3)
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+
+    item = items[0]  # start
+    s = item._style
+
+    send_pointer_event_for_test(item, PointerEventType.PRESS)
+    assert item._corner_anim.target == (
+        s.outer_corner_radius,
+        s.pressed_inner_corner_radius,
+        s.pressed_inner_corner_radius,
+        s.outer_corner_radius,
+    )
+
+    send_pointer_event_for_test(item, PointerEventType.RELEASE)
+
+
+def test_connected_selected_press_keeps_selected_inner_rounding() -> None:
+    """Connected selected item press should keep selected inner rounding."""
+    items = _make_items(3)
+    items[0]._set_selected(True)
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+
+    item = items[0]  # start
+    s = item._style
+    selected_inner = s.selected_inner_corner_radius if s.selected_inner_corner_radius > 0 else s.outer_corner_radius
+
+    send_pointer_event_for_test(item, PointerEventType.PRESS)
+    assert item._corner_anim.target == (
+        s.outer_corner_radius,
+        selected_inner,
+        selected_inner,
+        s.outer_corner_radius,
+    )
+
+    send_pointer_event_for_test(item, PointerEventType.RELEASE)
+
+
+def test_connected_width_full():
+    """Connected group items should have flex(1) width after mount."""
+    from nuiitivet.rendering.sizing import Sizing
+
+    items = _make_items(3)
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+
+    for item in items:
+        assert item.width_sizing == Sizing.flex(1)
+
+
+def test_connected_single_select():
+    """Single-select mode: selecting one item deselects all others."""
+    items = _make_items(3)
+    group = ConnectedButtonGroup(items, select_mode="single")
+    _mount_group(group)
+
+    _click(items[0])
+    assert items[0]._selected is True
+    assert items[1]._selected is False
+    assert items[2]._selected is False
+
+    _click(items[1])
+    assert items[0]._selected is False
+    assert items[1]._selected is True
+    assert items[2]._selected is False
+
+
+def test_connected_multi_select():
+    """Multi-select mode: multiple items can be selected simultaneously."""
+    items = _make_items(3)
+    group = ConnectedButtonGroup(items, select_mode="multi")
+    _mount_group(group)
+
+    _click(items[0])
+    _click(items[2])
+    assert items[0]._selected is True
+    assert items[1]._selected is False
+    assert items[2]._selected is True
+
+
+def test_connected_initial_selected():
+    """Items with selected=True are reflected in the initial group state."""
+    items = [
+        _make_item("A", selected=False),
+        _make_item("B", selected=True),
+        _make_item("C", selected=False),
+    ]
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+
+    assert items[1]._selected is True
+    # In single-mode, no enforcement on construction — initial state is respected
+    assert items[0]._selected is False
+    assert items[2]._selected is False
+
+
+def test_corner_animation_tick_invalidates_paint_cache() -> None:
+    """Corner animation updates must invalidate cached background snapshots."""
+    items = _make_items(3)
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+
+    item = items[1]
+    item._paint_cache_snapshot = object()  # type: ignore[attr-defined]
+
+    item._set_selected(True)
+    item._on_corner_value_changed(item._corner_anim.target)
+    assert item._paint_cache_snapshot is None  # type: ignore[attr-defined]
+
+    item._paint_cache_snapshot = object()  # type: ignore[attr-defined]
+    item._set_selected(False)
+    item._on_corner_value_changed(item._corner_anim.target)
+    assert item._paint_cache_snapshot is None  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Add Material Design 3 ButtonGroup components with two variants:
- **StandardButtonGroup**: Action-oriented group with adjacent shape animation
- **ConnectedButtonGroup**: Option-selector group with single/multi-select support

## Changes

### New files
- `src/nuiitivet/material/button_group.py` — `GroupButton`, `ButtonGroupPosition`, `StandardButtonGroup`, `ConnectedButtonGroup`
- `src/nuiitivet/material/styles/button_group_style.py` — `ButtonGroupSize`, `StandardButtonGroupStyle`, `ConnectedButtonGroupStyle`
- `tests/test_button_group.py` — Unit tests
- `src/samples/button_group_demo.py` — Demo app
- `docs/md3/button-groups.md` — MD3 reference

### Modified files
- `src/nuiitivet/material/__init__.py` — Export new public APIs

Closes #88