### PR TITLE
fix(windows): stabilize window sizing and rendering on DPI-scaled displays

### DIFF
--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import io
 import logging
+import math
 import os
 import sys
 import time
@@ -36,44 +37,37 @@ from .gpu_frame import draw_gpu_frame
 from nuiitivet.observable.runtime import set_clock
 from nuiitivet.common.logging_once import debug_once, exception_once
 
-
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    value = str(raw).strip().lower()
+    if value in ("", "0", "false", "no", "off", "disable", "disabled"):
+        return False
+    if value in ("1", "true", "yes", "on", "enable", "enabled"):
+        return True
+    return True
 
 
 def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
     """Run an interactive window for the given App-like object."""
-
-    def _env_flag(name: str, default: bool = False) -> bool:
-        raw = os.environ.get(name)
-        if raw is None:
-            return default
-        value = str(raw).strip().lower()
-        if value in ("", "0", "false", "no", "off", "disable", "disabled"):
-            return False
-        if value in ("1", "true", "yes", "on", "enable", "enabled"):
-            return True
-        return True
-
-    def _env_float(name: str, default: float) -> float:
-        raw = os.environ.get(name)
-        if raw is None:
-            return float(default)
-        try:
-            return float(str(raw).strip())
-        except Exception:
-            return float(default)
-
-    def _env_str(name: str, default: str = "") -> str:
-        raw = os.environ.get(name)
-        if raw is None:
-            return default
-        return str(raw)
 
     debug_keys = _env_flag("NUIITIVET_DEBUG_KEYS", default=False)
     debug_keys_filter_raw = os.environ.get("NUIITIVET_DEBUG_KEYS_FILTER", "").strip().lower()
     debug_keys_filter = {k.strip() for k in debug_keys_filter_raw.split(",") if k.strip()}
 
     esc_down = False
+    gl_viewport_ok = True
+    auto_force_gl_viewport = False
+    auto_recreate_always = False
+    auto_recreate_probe_used = False
+    last_resize_raw = None
+    last_resize_logical = None
+    auto_recreate_on_draw_used = False
+    auto_recreate_on_draw_hits = 0
 
     # Import here so unit tests can monkeypatch a minimal `pyglet` module
     # for raster-frame helpers without needing `pyglet.app.EventLoop`.
@@ -263,6 +257,38 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
 
         gpu_enabled = gr_context is not None and GL is not None
 
+    def _recreate_gl_context(reason: str) -> None:
+        nonlocal gr_context, gpu_enabled
+        if skia is None or GL is None:
+            return
+        try:
+            gr_context = skia.GrDirectContext.MakeGL()
+            if gr_context is None:
+                gr_context = skia.GrDirectContext.MakeGL(None)
+            gpu_enabled = gr_context is not None and GL is not None
+        except Exception:
+            gpu_enabled = False
+            exception_once(logger, "pyglet_recreate_gl_context_exc", "Failed to recreate GL context")
+
+    def _should_auto_recreate(raw_w: int, raw_h: int, logical_w: int, logical_h: int, scale: float) -> bool:
+        if scale <= 1.0:
+            return False
+        if last_resize_raw is None or last_resize_logical is None:
+            return False
+        prev_raw_w, prev_raw_h = last_resize_raw
+        prev_log_w, prev_log_h = last_resize_logical
+        if prev_raw_w <= 0 or prev_raw_h <= 0 or prev_log_w <= 0 or prev_log_h <= 0:
+            return False
+        RAW_GROW_THRESHOLD = 1.2
+        LOGICAL_SHRINK_THRESHOLD = 0.85
+        raw_area = raw_w * raw_h
+        prev_raw_area = prev_raw_w * prev_raw_h
+        logical_area = logical_w * logical_h
+        prev_logical_area = prev_log_w * prev_log_h
+        raw_grew = raw_area >= int(prev_raw_area * RAW_GROW_THRESHOLD)
+        logical_shrank = logical_area <= int(prev_logical_area * LOGICAL_SHRINK_THRESHOLD)
+        return raw_grew and logical_shrank
+
     # HiDPI scale
     try:
         scale = float(window.get_pixel_ratio())
@@ -277,27 +303,336 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
     _patch_pyglet_cocoa_view()
     _install_ime_patch(window)
 
+    def _get_windows_dpi_scale() -> float:
+        if sys.platform != "win32":
+            return 1.0
+        try:
+            hwnd = getattr(window, "_hwnd", None)
+            if not hwnd:
+                try:
+                    user32 = ctypes.windll.user32
+                    get_system_dpi = getattr(user32, "GetDpiForSystem", None)
+                    if get_system_dpi is None:
+                        return 1.0
+                    dpi = int(get_system_dpi())
+                    if dpi <= 0:
+                        return 1.0
+                    return max(1.0, float(dpi) / 96.0)
+                except Exception:
+                    return 1.0
+            user32 = ctypes.windll.user32
+            get_dpi = getattr(user32, "GetDpiForWindow", None)
+            if get_dpi is not None:
+                dpi = int(get_dpi(hwnd))
+                if dpi > 0:
+                    return max(1.0, float(dpi) / 96.0)
+
+            try:
+                monitor = user32.MonitorFromWindow(hwnd, 2)
+            except Exception:
+                monitor = None
+
+            if monitor:
+                try:
+                    shcore = ctypes.windll.shcore
+                    get_dpi_monitor = getattr(shcore, "GetDpiForMonitor", None)
+                    if get_dpi_monitor is None:
+                        return 1.0
+                    dpi_x = ctypes.c_uint()
+                    dpi_y = ctypes.c_uint()
+                    MDT_EFFECTIVE_DPI = 0
+                    res = int(get_dpi_monitor(monitor, MDT_EFFECTIVE_DPI, ctypes.byref(dpi_x), ctypes.byref(dpi_y)))
+                    if res == 0 and dpi_x.value > 0:
+                        return max(1.0, float(dpi_x.value) / 96.0)
+                except Exception:
+                    return 1.0
+                try:
+                    get_scale_factor = getattr(shcore, "GetScaleFactorForMonitor", None)
+                    if get_scale_factor is None:
+                        return 1.0
+                    scale_factor = ctypes.c_int()
+                    res = int(get_scale_factor(monitor, ctypes.byref(scale_factor)))
+                    if res == 0 and scale_factor.value > 0:
+                        return max(1.0, float(scale_factor.value) / 100.0)
+                except Exception:
+                    return 1.0
+            try:
+                gdi32 = ctypes.windll.gdi32
+                target_hwnd = hwnd if hwnd else 0
+                hdc = user32.GetDC(target_hwnd)
+                LOGPIXELSX = 88
+                dpi = int(gdi32.GetDeviceCaps(hdc, LOGPIXELSX))
+                user32.ReleaseDC(target_hwnd, hdc)
+                if dpi > 0:
+                    return max(1.0, float(dpi) / 96.0)
+            except Exception:
+                return 1.0
+            return 1.0
+        except Exception:
+            return 1.0
+
+    def _update_app_size_from_window(source: str, width: int, height: int) -> None:
+        nonlocal last_resize_raw, last_resize_logical
+        nonlocal auto_recreate_always, auto_recreate_probe_used
+        try:
+            # Get latest scale
+            current_scale = 1.0
+            try:
+                current_scale = float(window.get_pixel_ratio())
+            except Exception:
+                pass
+
+            dpi_scale = None
+            if sys.platform == "win32":
+                dpi_scale = _get_windows_dpi_scale()
+                if current_scale <= 1.0 and dpi_scale and dpi_scale > 1.0:
+                    current_scale = dpi_scale
+
+            fb_w = None
+            fb_h = None
+            try:
+                if hasattr(window, "get_framebuffer_size"):
+                    fb_w, fb_h = window.get_framebuffer_size()
+            except Exception:
+                fb_w = None
+                fb_h = None
+
+            derived_scale = None
+            if fb_w and fb_h and int(width) > 0 and int(height) > 0:
+                try:
+                    derived_scale = max(float(fb_w) / float(width), float(fb_h) / float(height))
+                except Exception:
+                    derived_scale = None
+
+            scale = max(1.0, current_scale)
+            if derived_scale and derived_scale > 1.0:
+                if abs(derived_scale - current_scale) < 0.05:
+                    scale = max(scale, derived_scale)
+
+            # Ignore minimize/hidden 0-size events to avoid collapsing layout.
+            if int(width) <= 0 or int(height) <= 0:
+                return
+
+            # Compute logical size. If framebuffer size is available, detect whether
+            # width/height are already logical or physical.
+            raw_w = int(width)
+            raw_h = int(height)
+            if scale > 1.0:
+                div_w = int(math.ceil(width / scale))
+                div_h = int(math.ceil(height / scale))
+            else:
+                div_w = int(round(width / scale))
+                div_h = int(round(height / scale))
+
+            logical_w = div_w
+            logical_h = div_h
+
+            if fb_w and fb_h and scale > 1.0:
+                try:
+                    phys_candidate = int(raw_w * scale)
+                    # If framebuffer matches width, width is physical.
+                    if abs(fb_w - raw_w) <= abs(fb_w - phys_candidate):
+                        logical_w = div_w
+                        logical_h = div_h
+                    else:
+                        logical_w = raw_w
+                        logical_h = raw_h
+                except Exception:
+                    logical_w = div_w
+                    logical_h = div_h
+            elif sys.platform == "win32" and scale > 1.0:
+                prev_w = int(getattr(app, "width", 0) or 0)
+                prev_h = int(getattr(app, "height", 0) or 0)
+                if prev_w > 0 and prev_h > 0:
+                    raw_delta = abs(raw_w - prev_w) + abs(raw_h - prev_h)
+                    div_delta = abs(div_w - prev_w) + abs(div_h - prev_h)
+                    use_raw = raw_delta <= div_delta
+                else:
+                    use_raw = div_w < 200 or div_h < 200
+                logical_w = raw_w if use_raw else div_w
+                logical_h = raw_h if use_raw else div_h
+
+            # Update app state
+            app.width = int(max(1, logical_w))
+            app.height = int(max(1, logical_h))
+            setattr(app, "_scale", scale)
+
+            if (
+                not auto_recreate_always
+                and gpu_enabled
+                and _should_auto_recreate(raw_w, raw_h, logical_w, logical_h, scale)
+            ):
+                if auto_recreate_probe_used:
+                    auto_recreate_always = True
+                else:
+                    auto_recreate_probe_used = True
+                _recreate_gl_context("auto-resize")
+
+            last_resize_raw = (raw_w, raw_h)
+            last_resize_logical = (app.width, app.height)
+
+        except Exception:
+            exception_once(logger, "pyglet_on_resize_set_size_exc", "Failed to set app.width/app.height")
+
+        try:
+            app.invalidate(immediate=True)
+        except Exception:
+            exception_once(logger, "pyglet_on_resize_invalidate_exc", "app.invalidate raised")
+
     @window.event
     def on_draw():
+        nonlocal gpu_enabled, auto_force_gl_viewport
+        nonlocal auto_recreate_on_draw_used, auto_recreate_on_draw_hits, auto_recreate_always
         try:
             wx, wy = window.get_location()
             IMEManager.get().update_window_info(wx, wy, window.width, window.height)
         except Exception:
             exception_once(logger, "pyglet_on_draw_ime_update_exc", "IME window info update raised")
 
-        nonlocal gpu_enabled
+        try:
+            win_w = int(getattr(window, "width", 0))
+            win_h = int(getattr(window, "height", 0))
+        except Exception:
+            win_w = 0
+            win_h = 0
+        try:
+            cur_scale = float(getattr(app, "_scale", 1.0))
+        except Exception:
+            cur_scale = 1.0
+        scale_changed = False
+        try:
+            latest_scale = float(window.get_pixel_ratio())
+            if abs(latest_scale - cur_scale) >= 0.01:
+                scale_changed = True
+        except Exception:
+            scale_changed = False
+
+        if (win_w and win_h) and (
+            win_w != int(getattr(app, "width", 0)) or win_h != int(getattr(app, "height", 0)) or scale_changed
+        ):
+            _update_app_size_from_window("on_draw", win_w, win_h)
+
         if gpu_enabled and gr_context is not None and GL is not None:
+            fb_w = 0
+            fb_h = 0
             try:
-                ok = bool(draw_gpu_frame(app, gr_context, GL, skia))
+                if hasattr(window, "get_framebuffer_size"):
+                    fb_size = window.get_framebuffer_size()
+                    if fb_size:
+                        fb_w = int(fb_size[0])
+                        fb_h = int(fb_size[1])
             except Exception:
-                exception_once(logger, "pyglet_on_draw_gpu_frame_exc", "draw_gpu_frame raised")
-                ok = False
-            if ok:
-                return
-            gpu_enabled = False
+                fb_w = 0
+                fb_h = 0
+
+            nonlocal gl_viewport_ok
+            if fb_w > 0 and fb_h > 0 and gl_viewport_ok and auto_force_gl_viewport:
+                try:
+                    target_w = fb_w
+                    target_h = fb_h
+                    try:
+                        if hasattr(GL, "glGetIntegerv") and hasattr(GL, "GL_MAX_VIEWPORT_DIMS"):
+                            max_dims = GL.glGetIntegerv(GL.GL_MAX_VIEWPORT_DIMS)
+                            if max_dims is not None and len(max_dims) >= 2:
+                                max_w = int(max_dims[0])
+                                max_h = int(max_dims[1])
+                                if max_w > 0 and max_h > 0:
+                                    target_w = min(target_w, max_w)
+                                    target_h = min(target_h, max_h)
+                    except Exception:
+                        target_w = fb_w
+                        target_h = fb_h
+
+                    target_w = max(1, int(target_w))
+                    target_h = max(1, int(target_h))
+                    if hasattr(GL, "glViewport"):
+                        GL.glViewport(0, 0, target_w, target_h)
+                except Exception:
+                    gl_viewport_ok = False
+                    gpu_enabled = False
+                    exception_once(logger, "pyglet_on_draw_gl_viewport_exc", "Failed to set GL viewport")
+
+            if gpu_enabled:
+                try:
+                    if hasattr(GL, "glGetIntegerv") and hasattr(GL, "GL_VIEWPORT"):
+                        viewport = GL.glGetIntegerv(GL.GL_VIEWPORT)
+                        if viewport is not None and len(viewport) >= 4:
+                            vp_w = int(viewport[2])
+                            vp_h = int(viewport[3])
+                        else:
+                            vp_w = None
+                            vp_h = None
+                    else:
+                        vp_w = None
+                        vp_h = None
+                except Exception:
+                    vp_w = None
+                    vp_h = None
+
+                if (vp_w is None or vp_h is None) and fb_w > 0 and fb_h > 0:
+                    if not auto_force_gl_viewport:
+                        auto_force_gl_viewport = True
+                    if not auto_recreate_on_draw_used:
+                        auto_recreate_on_draw_used = True
+                        auto_recreate_on_draw_hits += 1
+                        if not auto_recreate_always:
+                            auto_recreate_always = True
+                        _recreate_gl_context("auto-draw")
+                if (vp_w is None or vp_h is None) and fb_w > 0 and fb_h > 0 and hasattr(GL, "glViewport"):
+                    try:
+                        GL.glViewport(0, 0, int(fb_w), int(fb_h))
+                        vp_w = int(fb_w)
+                        vp_h = int(fb_h)
+                    except Exception:
+                        pass
+
+                if vp_w and vp_h and vp_w > 0 and vp_h > 0:
+                    try:
+                        win_w = int(getattr(window, "width", 0))
+                        win_h = int(getattr(window, "height", 0))
+                    except Exception:
+                        win_w = 0
+                        win_h = 0
+
+                    if win_w > 0 and win_h > 0:
+                        scale_from_vp = max(float(vp_w) / float(win_w), float(vp_h) / float(win_h))
+                        logical_w = int(win_w)
+                        logical_h = int(win_h)
+                        if sys.platform == "win32" and scale_from_vp <= 1.0:
+                            dpi_scale = _get_windows_dpi_scale()
+                            if dpi_scale > 1.0:
+                                scale_from_vp = dpi_scale
+                                if scale_from_vp > 1.0:
+                                    logical_w = int(max(1, math.ceil(win_w / scale_from_vp)))
+                                    logical_h = int(max(1, math.ceil(win_h / scale_from_vp)))
+                                else:
+                                    logical_w = int(max(1, round(win_w / scale_from_vp)))
+                                    logical_h = int(max(1, round(win_h / scale_from_vp)))
+                        try:
+                            if logical_w != int(getattr(app, "width", 0)) or logical_h != int(
+                                getattr(app, "height", 0)
+                            ):
+                                app.width = int(logical_w)
+                                app.height = int(logical_h)
+                            if abs(float(getattr(app, "_scale", 1.0)) - scale_from_vp) >= 0.01:
+                                setattr(app, "_scale", max(1.0, scale_from_vp))
+                        except Exception:
+                            exception_once(
+                                logger, "pyglet_on_draw_gpu_viewport_sync_exc", "Failed to sync from viewport"
+                            )
+
+                try:
+                    ok = bool(draw_gpu_frame(app, gr_context, GL, skia))
+                except Exception:
+                    exception_once(logger, "pyglet_on_draw_gpu_frame_exc", "draw_gpu_frame raised")
+                    ok = False
+                if ok:
+                    return
+                gpu_enabled = False
 
         if getattr(app, "_dirty", False) or getattr(app, "_last_image", None) is None:
-            if not _draw_raster_frame(app, skia):
+            ok = _draw_raster_frame(app, skia)
+            if not ok and getattr(app, "_last_image", None) is None:
                 return
 
         try:
@@ -313,46 +648,62 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
                 exception_once(logger, "pyglet_on_draw_image_blit_exc", "image.blit raised")
 
     @window.event
-    def on_expose():
+    def on_show():
         try:
-            app.invalidate(immediate=True)
+            setattr(app, "_last_image", None)
         except Exception:
-            exception_once(logger, "pyglet_on_expose_invalidate_exc", "app.invalidate raised")
+            pass
+        try:
+            _update_app_size_from_window("on_show", window.width, window.height)
+        except Exception:
+            exception_once(logger, "pyglet_on_show_resize_exc", "Failed to sync size on show")
+
+    @window.event
+    def on_hide():
+        pass
+
+    @window.event
+    def on_activate():
+        try:
+            setattr(app, "_last_image", None)
+        except Exception:
+            pass
+        try:
+            _update_app_size_from_window("on_activate", window.width, window.height)
+        except Exception:
+            exception_once(logger, "pyglet_on_activate_resize_exc", "Failed to sync size on activate")
+
+    @window.event
+    def on_deactivate():
+        pass
 
     @window.event
     def on_resize(width, height):
+        nonlocal last_resize_raw, auto_recreate_on_draw_used  # noqa: F824
         try:
-            # width/height from pyglet are physical pixels (if DPI aware)
-            # app.width/app.height should be logical pixels.
-
-            # Get latest scale
-            current_scale = 1.0
-            try:
-                current_scale = float(window.get_pixel_ratio())
-            except Exception:
-                pass
-
-            scale = max(1.0, current_scale)
-
-            # Update app state
-            app.width = int(width / scale)
-            app.height = int(height / scale)
-            setattr(app, "_scale", scale)
-
+            next_w = int(width)
+            next_h = int(height)
         except Exception:
-            exception_once(logger, "pyglet_on_resize_set_size_exc", "Failed to set app.width/app.height")
+            next_w = 0
+            next_h = 0
+        if next_w > 0 and next_h > 0 and last_resize_raw is not None:
+            prev_w, prev_h = last_resize_raw
+            if int(prev_w) != next_w or int(prev_h) != next_h:
+                auto_recreate_on_draw_used = False
+        if auto_recreate_always and gpu_enabled:
+            _recreate_gl_context("resize")
+        _update_app_size_from_window("on_resize", width, height)
 
-        try:
-            app.invalidate(immediate=True)
-        except Exception:
-            exception_once(logger, "pyglet_on_resize_invalidate_exc", "app.invalidate raised")
-
-    @window.event
-    def on_mouse_press(x, y, button, modifiers):
+    def _to_logical(x: int, y: int) -> tuple[int, int]:
         scale = max(1.0, float(getattr(app, "_scale", 1.0)))
         x_log = int(x / scale)
         y_log = int(y / scale)
         y_conv = int(getattr(app, "height", 0)) - y_log
+        return x_log, y_conv
+
+    @window.event
+    def on_mouse_press(x, y, button, modifiers):
+        x_log, y_conv = _to_logical(x, y)
         try:
             app._dispatch_mouse_press(x_log, y_conv)
         except Exception:
@@ -360,10 +711,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
 
     @window.event
     def on_mouse_release(x, y, button, modifiers):
-        scale = max(1.0, float(getattr(app, "_scale", 1.0)))
-        x_log = int(x / scale)
-        y_log = int(y / scale)
-        y_conv = int(getattr(app, "height", 0)) - y_log
+        x_log, y_conv = _to_logical(x, y)
         try:
             app._dispatch_mouse_release(x_log, y_conv)
         except Exception:
@@ -371,10 +719,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
 
     @window.event
     def on_mouse_motion(x, y, dx, dy):
-        scale = max(1.0, float(getattr(app, "_scale", 1.0)))
-        x_log = int(x / scale)
-        y_log = int(y / scale)
-        y_conv = int(getattr(app, "height", 0)) - y_log
+        x_log, y_conv = _to_logical(x, y)
         try:
             app._dispatch_mouse_motion(x_log, y_conv)
         except Exception:
@@ -382,10 +727,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
 
     @window.event
     def on_mouse_drag(x, y, dx, dy, buttons, modifiers):
-        scale = max(1.0, float(getattr(app, "_scale", 1.0)))
-        x_log = int(x / scale)
-        y_log = int(y / scale)
-        y_conv = int(getattr(app, "height", 0)) - y_log
+        x_log, y_conv = _to_logical(x, y)
         try:
             app._dispatch_mouse_motion(x_log, y_conv)
         except Exception:
@@ -393,10 +735,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
 
     @window.event
     def on_mouse_scroll(x, y, scroll_x, scroll_y):
-        scale = max(1.0, float(getattr(app, "_scale", 1.0)))
-        x_log = int(x / scale)
-        y_log = int(y / scale)
-        y_conv = int(getattr(app, "height", 0)) - y_log
+        x_log, y_conv = _to_logical(x, y)
         try:
             app._dispatch_mouse_scroll(x_log, y_conv, scroll_x, scroll_y)
         except Exception:

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -1114,6 +1114,17 @@ class App:
                         window.set_fullscreen(False)
                         return
 
+                    try:
+                        if sys.platform == "win32":
+                            import ctypes
+
+                            SW_RESTORE = 9
+                            hwnd = getattr(window, "_hwnd", None)
+                            if hwnd:
+                                ctypes.windll.user32.ShowWindow(hwnd, SW_RESTORE)
+                    except Exception:
+                        exception_once(logger, "app_dispatch_restore_win32_exc", "Windows restore fallback failed")
+
                     # Try to activate (restore from minimize on some platforms)
                     if hasattr(window, "activate"):
                         window.activate()


### PR DESCRIPTION
## Summary

Fixes inconsistent window sizing, GPU rendering corruption, and title bar corner radius loss during window operations (resize, maximize/minimize/restore) on Windows with non-100% display scaling.

Closes #93

## Changes

### runner.py
- Add `_get_windows_dpi_scale()` with multi-source DPI detection fallback (GetDpiForWindow → GetDpiForMonitor → GetScaleFactorForMonitor → GDI)
- Add `_update_app_size_from_window()` to compute logical size from DPI scale and framebuffer size
- Add `_recreate_gl_context()` to detect and recover from GL context loss during window state transitions
- Add `_should_auto_recreate()` heuristic to trigger GL context recreation on anomalous resize patterns
- Handle `on_show` / `on_activate` / `on_resize` events through unified size synchronization
- Extract `_to_logical()` to deduplicate mouse coordinate conversion (5 call sites)
- Extract `_env_flag()` to module level for reuse
- Replace magic numbers with named constants (`RAW_GROW_THRESHOLD`, `LOGICAL_SHRINK_THRESHOLD`)

### app.py
- Use `SW_RESTORE` via Win32 API in `RestoreWindowIntent` to preserve title bar corner radius after maximize/restore
- Remove redundant `import sys` (already imported at module level)