### PR TITLE
feat(material): add theme-namespaced aliases App/Overlay/ThemeFactory (#85)

### DIFF
--- a/docs/guide/dialogs.md
+++ b/docs/guide/dialogs.md
@@ -6,7 +6,7 @@ nuiitivet offers a robust dialog system built on top of the Overlay architecture
 
 ## Basic Usage
 
-The most straightforward way to show a dialog is to create an `AlertDialog` widget and pass it to `MaterialOverlay.root().dialog()`.
+The most straightforward way to show a dialog is to create an `AlertDialog` widget and pass it to `Overlay.root().dialog()`.
 
 The `dialog()` method is **awaitable**, meaning you can wait for the user to close the dialog and receive a result.
 
@@ -17,8 +17,8 @@ class BasicDialogDemo(ComposableWidget):
     result_text: Observable[str] = Observable("Ready")
 
     async def _show_dialog(self):
-        # MaterialOverlay.root() finds the globally unique Overlay
-        overlay = MaterialOverlay.root()
+        # Overlay.root() finds the globally unique Overlay
+        overlay = Overlay.root()
 
         # Create the dialog widget
         dialog = AlertDialog(
@@ -64,7 +64,7 @@ class BasicDialogDemo(ComposableWidget):
 
 ### Key Points
 
-- `MaterialOverlay.root()`: Retrieves the root overlay instance.
+- `Overlay.root()`: Retrieves the root overlay instance.
 - `overlay.dialog(widget)`: Displays the widget as a modal dialog with a scrim.
 - `overlay.close(value, target)`: Closes the dialog associated with `target`. The `value` is wrapped in an `OverlayResult` and returned to the caller of `await overlay.dialog()`.
 
@@ -78,7 +78,7 @@ You are not limited to `AlertDialog`. Any Widget can be shown in the overlay. Th
 class CustomDialogContent(ComposableWidget):
     """A completely custom widget to be used as a dialog."""
     
-    def __init__(self, overlay: MaterialOverlay):
+    def __init__(self, overlay: Overlay):
         super().__init__()
         self.overlay = overlay
         self.counter = Observable(0)
@@ -137,7 +137,7 @@ class CoupledViewModel:
     def __init__(self):
         self.status = Observable("Ready")
 
-    async def process_action(self, overlay: MaterialOverlay):
+    async def process_action(self, overlay: Overlay):
         self.status.value = "Processing..."
         
         # Logic creates UI components directly
@@ -153,7 +153,7 @@ class CoupledViewModel:
 
 class DirectViewModelDemo(ComposableWidget):
     async def _on_run_click(self):
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         await self.vm.process_action(overlay)
 ```
 
@@ -179,7 +179,7 @@ class DecoupledViewModel:
     def __init__(self):
         self.status = Observable("Ready")
 
-    async def process_action(self, overlay: MaterialOverlay):
+    async def process_action(self, overlay: Overlay):
         self.status.value = "Processing..."
         
         # We just create a data description of what we want
@@ -212,19 +212,19 @@ Below, we show how to implement the same "Counter Card" logic using Intents.
        initial_value: int = 0
    ```
 
-2. **Map Intent to Dialog**: Register the connection between the Intent data and its Widget in `MaterialApp`.
+2. **Map Intent to Dialog**: Register the connection between the Intent data and its Widget in `App`.
 
    ```python
    def create_counter_dialog(intent: CounterIntent) -> Widget:
        # This function knows about Widgets, but ViewModel doesn't
        return CustomDialogContent(
-           MaterialOverlay.root(),
+           Overlay.root(),
            initial=intent.initial_value
        )
 
    class IntentDemoApp(ComposableWidget):
        def build(self) -> Widget:
-           return MaterialApp(
+           return App(
                content=HomeView(),
                overlay_routes={
                    CounterIntent: create_counter_dialog
@@ -236,7 +236,7 @@ Below, we show how to implement the same "Counter Card" logic using Intents.
 
    ```python
    class MyViewModel:
-       async def open_counter(self, overlay: MaterialOverlay):
+       async def open_counter(self, overlay: Overlay):
            # Pure logic, using our custom intent
            result = await overlay.dialog(CounterIntent(initial_value=5))
            

--- a/docs/guide/modifier_others.md
+++ b/docs/guide/modifier_others.md
@@ -35,7 +35,7 @@ import nuiitivet.material as md
 from dataclasses import dataclass
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.text_fields import OutlinedTextField
 from nuiitivet.modifiers import will_pop
 from nuiitivet.navigation import Navigator, PageRoute
@@ -83,14 +83,14 @@ class EditScreen(nv.ComposableWidget):
             return True
 
         def _cancel() -> None:
-            MaterialOverlay.root().close(None)
+            Overlay.root().close(None)
 
         def _discard() -> None:
             self._initial_text = str(self.text.value)
-            MaterialOverlay.root().close(None)
+            Overlay.root().close(None)
             Navigator.root().pop()
 
-        MaterialOverlay.root().dialog(
+        Overlay.root().dialog(
             AlertDialog(
                 title="Discard changes?",
                 message="You have unsaved changes.",
@@ -131,7 +131,7 @@ class EditScreen(nv.ComposableWidget):
         )
 
 def main() -> None:
-    md.MaterialApp.navigation(
+    md.App.navigation(
         routes={HomeIntent: lambda _i: PageRoute(builder=HomeScreen)},
         initial_route=HomeIntent(),
     ).run()

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -6,7 +6,7 @@ Nuiitivet provides a robust navigation system for managing screen transitions an
 
 The `Navigator` is a widget that manages a set of child widgets with a stack discipline. It allows you to transition between different screens (or "pages") in your application.
 
-When you use `MaterialApp.navigation()`, a root `Navigator` is automatically created and configured for you. You can access this root navigator from anywhere in your application using `Navigator.root()`.
+When you use `App.navigation()`, a root `Navigator` is automatically created and configured for you. You can access this root navigator from anywhere in your application using `Navigator.root()`.
 
 ## Basic Navigation: Push and Pop
 

--- a/docs/guide/navigation_intent.md
+++ b/docs/guide/navigation_intent.md
@@ -14,9 +14,9 @@ class DetailsIntent:
     item_id: int
 ```
 
-## Configuring MaterialApp.navigation()
+## Configuring App.navigation()
 
-To use Intents, you configure your `MaterialApp` using the `navigation()` method instead of the standard constructor. You provide a mapping of Intent types to route builder functions.
+To use Intents, you configure your `App` using the `navigation()` method instead of the standard constructor. You provide a mapping of Intent types to route builder functions.
 
 ![Navigation Intent](../assets/navigation_intent.png)
 
@@ -25,7 +25,7 @@ import nuiitivet as nv
 
 from dataclasses import dataclass
 
-from nuiitivet.material import MaterialApp, FilledButton, Text
+from nuiitivet.material import App, FilledButton, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.navigation import Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
@@ -72,7 +72,7 @@ class DetailsScreen(ComposableWidget):
             ),
         )
 
-app = MaterialApp.navigation(
+app = App.navigation(
     routes={
         HomeIntent: lambda _: HomeScreen(),
         DetailsIntent: lambda intent: DetailsScreen(intent),

--- a/docs/guide/navigation_route.md
+++ b/docs/guide/navigation_route.md
@@ -4,7 +4,7 @@ While you can push widgets directly to the `Navigator`, using `PageRoute` gives 
 
 ## Customizing Animations
 
-By default, `MaterialApp` applies a standard Material Design transition when navigating between screens. However, you can customize this behavior by providing a `TransitionSpec` to a `PageRoute`.
+By default, `App` applies a standard Material Design transition when navigating between screens. However, you can customize this behavior by providing a `TransitionSpec` to a `PageRoute`.
 
 Nuiitivet provides built-in transition effects such as `FadeIn`, `FadeOut`, `ScaleIn`, `ScaleOut`, `SlideInVertically`, and `SlideOutVertically`. You can combine these effects using the `|` operator to create complex animations.
 

--- a/docs/guide/window_size_position.md
+++ b/docs/guide/window_size_position.md
@@ -1,6 +1,6 @@
 # Window Size and Position
 
-You can control how the window is sized and where it appears on the screen using `WindowSizing` and `WindowPosition`. These are configured when initializing your `App` or `MaterialApp`.
+You can control how the window is sized and where it appears on the screen using `WindowSizing` and `WindowPosition`. These are configured when initializing your `App` or `App`.
 
 ## WindowSizing
 

--- a/docs/guide/window_title_bar.md
+++ b/docs/guide/window_title_bar.md
@@ -2,7 +2,7 @@
 
 The title bar is the top section of the window that typically contains the application title and window controls (minimize, maximize, close). Nuiitivet provides two ways to configure the title bar: `DefaultTitleBar` and `CustomTitleBar`.
 
-You can set the title bar when initializing your application using the `title_bar` parameter in `App` or `MaterialApp`.
+You can set the title bar when initializing your application using the `title_bar` parameter in `App` or `App`.
 
 ## DefaultTitleBar
 

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .badge import BadgeValue, LargeBadge, SmallBadge
     from .app import MaterialApp
+    from .app import MaterialApp as App
     from .divider import Divider
     from .buttons import (
         ElevatedButton,
@@ -41,6 +42,9 @@ if TYPE_CHECKING:
     from .text_fields import FilledTextField, OutlinedTextField, TextField
     from .text import Text
     from .overlay import MaterialOverlay
+    from .overlay import MaterialOverlay as Overlay
+    from .theme.material_theme import MaterialTheme
+    from .theme.material_theme import MaterialTheme as ThemeFactory
     from .toolbar import DockedToolbar, FloatingToolbar, ToolbarOrientation
     from .tooltip import Tooltip, RichTooltip
     from .styles.sheet_style import SideSheetStyle, BottomSheetStyle
@@ -63,6 +67,9 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MaterialApp",
+    "App",
+    "MaterialTheme",
+    "ThemeFactory",
     "SmallBadge",
     "LargeBadge",
     "BadgeValue",
@@ -105,6 +112,7 @@ __all__ = [
     "NavigationRail",
     "RailItem",
     "MaterialOverlay",
+    "Overlay",
     "AlertDialog",
     "LoadingIndicator",
     "LinearProgressIndicator",
@@ -146,6 +154,9 @@ __all__ = [
 
 _EXPORTS: dict[str, tuple[str, str]] = {
     "MaterialApp": ("app", "MaterialApp"),
+    "App": ("app", "MaterialApp"),
+    "MaterialTheme": ("theme", "MaterialTheme"),
+    "ThemeFactory": ("theme", "MaterialTheme"),
     "SmallBadge": ("badge", "SmallBadge"),
     "LargeBadge": ("badge", "LargeBadge"),
     "BadgeValue": ("badge", "BadgeValue"),
@@ -188,6 +199,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "NavigationRail": ("navigation_rail", "NavigationRail"),
     "RailItem": ("navigation_rail", "RailItem"),
     "MaterialOverlay": ("overlay", "MaterialOverlay"),
+    "Overlay": ("overlay", "MaterialOverlay"),
     "AlertDialog": ("dialogs", "AlertDialog"),
     "LoadingIndicator": ("loading_indicator", "LoadingIndicator"),
     "LinearProgressIndicator": ("progress_indicators", "LinearProgressIndicator"),

--- a/src/samples/alignment_demo.py
+++ b/src/samples/alignment_demo.py
@@ -1,4 +1,4 @@
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
@@ -98,7 +98,7 @@ def main():
     # Wrap in Scroller because it will be long
     scrollable_root = root.modifier(scrollable())
 
-    app = MaterialApp(content=scrollable_root)
+    app = App(content=scrollable_root)
     app.run()
 
 

--- a/src/samples/async_demo.py
+++ b/src/samples/async_demo.py
@@ -2,9 +2,9 @@
 
 This sample demonstrates:
 1. Using `async` event handlers (on_click).
-2. Using `async with MaterialOverlay.loading()` while awaiting.
+2. Using `async with Overlay.loading()` while awaiting.
 3. Updating UI (Observable) from within an async handler without blocking.
-4. Awaiting `MaterialOverlay.dialog` results directly.
+4. Awaiting `Overlay.dialog` results directly.
 """
 
 import asyncio
@@ -36,17 +36,17 @@ class AsyncDemoApp(nv.ComposableWidget):
         """Handler for the 'Start Task' button."""
 
         # 1. Show loading dialog using async context manager
-        async with md.MaterialOverlay.root().loading():
+        async with md.Overlay.root().loading():
             await self._heavy_task()
 
         # 2. Show confirmation dialog and await result
-        result = await md.MaterialOverlay.root().dialog(
+        result = await md.Overlay.root().dialog(
             md.AlertDialog(
                 title="Task Finished",
                 message=f"Count reached {self.counter.value}. Reset?",
                 actions=[
-                    md.TextButton("No", on_click=lambda: md.MaterialOverlay.root().close(False)),
-                    md.TextButton("Yes", on_click=lambda: md.MaterialOverlay.root().close(True)),
+                    md.TextButton("No", on_click=lambda: md.Overlay.root().close(False)),
+                    md.TextButton("Yes", on_click=lambda: md.Overlay.root().close(True)),
                 ],
             )
         )
@@ -56,9 +56,9 @@ class AsyncDemoApp(nv.ComposableWidget):
             self.counter.value = 0
             self.progress.value = 0.0
             self.status.value = "Reset"
-            md.MaterialOverlay.root().snackbar("Counter reset!")
+            md.Overlay.root().snackbar("Counter reset!")
         else:
-            md.MaterialOverlay.root().snackbar("Kept current count")
+            md.Overlay.root().snackbar("Kept current count")
 
     async def on_concurrent_test(self) -> None:
         """Demonstrate that UI is responsive during async sleep."""
@@ -69,7 +69,7 @@ class AsyncDemoApp(nv.ComposableWidget):
         await asyncio.sleep(3)
 
         self.status.value = "Wait finished!"
-        md.MaterialOverlay.root().snackbar("3 seconds passed")
+        md.Overlay.root().snackbar("3 seconds passed")
 
     def on_start_task_click(self) -> None:
         from nuiitivet.widgeting.callbacks import invoke_event_handler
@@ -140,7 +140,7 @@ class AsyncDemoApp(nv.ComposableWidget):
 if __name__ == "__main__":
     print("Starting Async Demo...")
     # Initialize the app with our demo widget
-    app = md.MaterialApp(content=AsyncDemoApp())
+    app = md.App(content=AsyncDemoApp())
     print("App initialized. Running...")
     app.run()
     print("App finished.")

--- a/src/samples/badge_demo.py
+++ b/src/samples/badge_demo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Icon, LargeBadge, SmallBadge, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 
 
 def _badge_item(title: str, icon) -> Column:
@@ -43,7 +43,7 @@ def main() -> None:
         cross_alignment="start",
     )
 
-    app = MaterialApp(content=content)
+    app = App(content=content)
     app.run()
 
 

--- a/src/samples/button_group_demo.py
+++ b/src/samples/button_group_demo.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.button_group import (
     GroupButton,
     ConnectedButtonGroup,
@@ -220,7 +220,7 @@ def main() -> None:
     )
 
     root = Box(child=content, padding=24)
-    app = MaterialApp(content=root)
+    app = App(content=root)
     app.run()
 
 

--- a/src/samples/buttons_demo.py
+++ b/src/samples/buttons_demo.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, FilledTonalButton, OutlinedButton, ElevatedButton, TextButton
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgets.box import Box
@@ -104,7 +104,7 @@ def main() -> None:
 
     root = Box(child=content, padding=24, background_color="#F2F2F7")
 
-    app = MaterialApp(content=root)
+    app = App(content=root)
     app.run()
 
 

--- a/src/samples/chips_demo.py
+++ b/src/samples/chips_demo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import AssistChip, FilterChip, InputChip, SuggestionChip, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.observable import Observable
 
 
@@ -85,7 +85,7 @@ class ChipsDemoWidget:
 def main() -> None:
     """Run chip demo."""
     demo = ChipsDemoWidget()
-    app = MaterialApp(content=demo.build())
+    app = App(content=demo.build())
     app.run()
 
 

--- a/src/samples/cross_aligned_demo.py
+++ b/src/samples/cross_aligned_demo.py
@@ -4,7 +4,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.cross_aligned import CrossAligned
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.modifiers import background, border, corner_radius
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgets.box import Box
@@ -76,7 +76,7 @@ def main() -> None:
         cross_alignment="start",
     )
 
-    app = MaterialApp(content=content)
+    app = App(content=content)
     app.run()
 
 

--- a/src/samples/deck_demo.py
+++ b/src/samples/deck_demo.py
@@ -2,7 +2,7 @@
 
 from enum import IntEnum
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.material.text_fields import OutlinedTextField
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -140,7 +140,7 @@ class DeckDemo(ComposableWidget):
 
 if __name__ == "__main__":
     demo = DeckDemo()
-    app = MaterialApp(content=demo, width=600, height=400)
+    app = App(content=demo, width=600, height=400)
     try:
         app.run()
     except Exception:

--- a/src/samples/deck_with_rail_demo.py
+++ b/src/samples/deck_with_rail_demo.py
@@ -2,7 +2,7 @@
 
 from enum import IntEnum
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.material.text_fields import OutlinedTextField
 from nuiitivet.material.navigation_rail import NavigationRail, RailItem
@@ -175,7 +175,7 @@ class DesktopAppDemo(ComposableWidget):
 
 if __name__ == "__main__":
     demo = DesktopAppDemo()
-    app = MaterialApp(content=demo, width=800, height=768)
+    app = App(content=demo, width=800, height=768)
     try:
         app.run()
     except Exception:

--- a/src/samples/dialogs/basic_usage.py
+++ b/src/samples/dialogs/basic_usage.py
@@ -1,13 +1,13 @@
 """
 Basic Dialog Usage
 
-Shows how to display a standard AlertDialog using MaterialOverlay.
+Shows how to display a standard AlertDialog using Overlay.
 """
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -19,8 +19,8 @@ class BasicDialogDemo(ComposableWidget):
     result_text: Observable[str] = Observable("Ready")
 
     async def _show_dialog(self):
-        # MaterialOverlay.root() finds the globally unique Overlay
-        overlay = MaterialOverlay.root()
+        # Overlay.root() finds the globally unique Overlay
+        overlay = Overlay.root()
 
         # Create the dialog widget
         dialog = AlertDialog(
@@ -69,11 +69,11 @@ def main(png_path: str = ""):
             message="Do you want to proceed with this action?",
             actions=[TextButton("CANCEL"), TextButton("OK")],
         )
-        app = MaterialApp(content=Container(alignment="center", child=dialog), width=400, height=300)
+        app = App(content=Container(alignment="center", child=dialog), width=400, height=300)
         app.render_to_png(png_path)
         return app
 
-    return MaterialApp(content=BasicDialogDemo(), width=400, height=300)
+    return App(content=BasicDialogDemo(), width=400, height=300)
 
 
 if __name__ == "__main__":

--- a/src/samples/dialogs/custom_dialog.py
+++ b/src/samples/dialogs/custom_dialog.py
@@ -1,12 +1,12 @@
 """
 Custom Dialog Usage
 
-Shows how to display any generic Widget as a modal dialog using MaterialOverlay.
+Shows how to display any generic Widget as a modal dialog using Overlay.
 """
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, OutlinedButton
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.material.card import Card
 from nuiitivet.layout.column import Column
@@ -20,7 +20,7 @@ from nuiitivet.widgeting.widget import ComposableWidget, Widget
 class CustomDialogContent(ComposableWidget):
     """A completely custom widget to be used as a dialog."""
 
-    def __init__(self, overlay: MaterialOverlay):
+    def __init__(self, overlay: Overlay):
         super().__init__()
         self.overlay = overlay
         self.counter = Observable(0)
@@ -58,7 +58,7 @@ class CustomDialogDemo(ComposableWidget):
     last_count: Observable[str] = Observable("No count yet")
 
     async def _show_custom_dialog(self):
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
 
         # Pass the overlay instance to the content so it can close itself
         content = CustomDialogContent(overlay)
@@ -90,13 +90,13 @@ def main(png_path: str = ""):
         from typing import cast
 
         # Mock overlay for screenshot
-        content = CustomDialogContent(overlay=cast(MaterialOverlay, None))
+        content = CustomDialogContent(overlay=cast(Overlay, None))
         content.counter.value = 5
-        app = MaterialApp(content=Container(alignment="center", child=content), width=400, height=300)
+        app = App(content=Container(alignment="center", child=content), width=400, height=300)
         app.render_to_png(png_path)
         return app
 
-    return MaterialApp(content=CustomDialogDemo(), width=400, height=300)
+    return App(content=CustomDialogDemo(), width=400, height=300)
 
 
 if __name__ == "__main__":

--- a/src/samples/dialogs/custom_intent.py
+++ b/src/samples/dialogs/custom_intent.py
@@ -7,9 +7,9 @@ without knowing about the specific UI implementation (Widgets).
 """
 
 from dataclasses import dataclass
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, OutlinedButton
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.material.card import Card
 from nuiitivet.layout.column import Column
@@ -23,7 +23,7 @@ from nuiitivet.widgeting.widget import ComposableWidget, Widget
 class CustomDialogContent(ComposableWidget):
     """A completely custom widget to be used as a dialog."""
 
-    def __init__(self, overlay: MaterialOverlay, initial: int = 0):
+    def __init__(self, overlay: Overlay, initial: int = 0):
         super().__init__()
         self.overlay = overlay
         self.counter = Observable(initial)
@@ -65,7 +65,7 @@ class CounterIntent:
 def create_counter_dialog(intent: CounterIntent) -> Widget:
     """Creates a widget for the CounterIntent."""
     return CustomDialogContent(
-        MaterialOverlay.root(),
+        Overlay.root(),
         initial=intent.initial_value,
     )
 
@@ -74,7 +74,7 @@ class CustomIntentViewModel:
     def __init__(self):
         self.message = Observable("No result yet")
 
-    async def open_counter(self, overlay: MaterialOverlay):
+    async def open_counter(self, overlay: Overlay):
         # The ViewModel just emits an intent and waits for a result
         result = await overlay.dialog(CounterIntent(initial_value=5))
 
@@ -88,7 +88,7 @@ class CustomIntentDemo(ComposableWidget):
         self.vm = CustomIntentViewModel()
 
     async def _on_open_click(self):
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         await self.vm.open_counter(overlay)
 
     def build(self) -> Widget:
@@ -111,13 +111,13 @@ def main(png_path: str = ""):
     if png_path:
         from typing import cast
 
-        content = CustomDialogContent(overlay=cast(MaterialOverlay, None), initial=5)
-        app = MaterialApp(content=Container(alignment="center", child=content), width=400, height=300)
+        content = CustomDialogContent(overlay=cast(Overlay, None), initial=5)
+        app = App(content=Container(alignment="center", child=content), width=400, height=300)
         app.render_to_png(png_path)
         return app
 
-    # 3. Register the Mapping in MaterialApp
-    return MaterialApp(
+    # 3. Register the Mapping in App
+    return App(
         content=CustomIntentDemo(),
         overlay_routes={CounterIntent: create_counter_dialog},
         width=400,

--- a/src/samples/dialogs/view_model_direct.py
+++ b/src/samples/dialogs/view_model_direct.py
@@ -5,10 +5,10 @@ Shows a ViewModel pattern where the ViewModel depends directly on UI components 
 This is simpler but creates strong coupling between Logic and View.
 """
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -22,7 +22,7 @@ class CoupledViewModel:
     def __init__(self):
         self.status = Observable("Ready")
 
-    async def process_action(self, overlay: MaterialOverlay):
+    async def process_action(self, overlay: Overlay):
         self.status.value = "Processing..."
 
         # ViewModel creates and configures the View (AlertDialog)
@@ -45,7 +45,7 @@ class DirectViewModelDemo(ComposableWidget):
         self.vm = CoupledViewModel()
 
     async def _on_run_click(self):
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         await self.vm.process_action(overlay)
 
     def build(self) -> Widget:
@@ -73,11 +73,11 @@ def main(png_path: str = ""):
             icon="check_circle",
             actions=[TextButton("OK")],
         )
-        app = MaterialApp(content=Container(alignment="center", child=dialog), width=400, height=300)
+        app = App(content=Container(alignment="center", child=dialog), width=400, height=300)
         app.render_to_png(png_path)
         return app
 
-    return MaterialApp(content=DirectViewModelDemo(), width=400, height=300)
+    return App(content=DirectViewModelDemo(), width=400, height=300)
 
 
 if __name__ == "__main__":

--- a/src/samples/dialogs/view_model_intent.py
+++ b/src/samples/dialogs/view_model_intent.py
@@ -5,11 +5,11 @@ Shows how to trigger a standard AlertDialog using an Intent from a ViewModel-lik
 This decouples the presentation logic (ViewModel) from the View implementation.
 """
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material.intents import AlertDialogIntent
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -23,7 +23,7 @@ class DecoupledViewModel:
     def __init__(self):
         self.status = Observable("Ready")
 
-    async def process_action(self, overlay: MaterialOverlay):
+    async def process_action(self, overlay: Overlay):
         self.status.value = "Processing..."
 
         # Express the intent to show an operation complete dialog
@@ -41,7 +41,7 @@ class IntentDemo(ComposableWidget):
         self.vm = DecoupledViewModel()
 
     async def _on_run_click(self):
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         await self.vm.process_action(overlay)
 
     def build(self) -> Widget:
@@ -68,11 +68,11 @@ def main(png_path: str = ""):
             icon="check_circle",
             actions=[TextButton("OK")],
         )
-        app = MaterialApp(content=Container(alignment="center", child=dialog), width=400, height=300)
+        app = App(content=Container(alignment="center", child=dialog), width=400, height=300)
         app.render_to_png(png_path)
         return app
 
-    return MaterialApp(content=IntentDemo(), width=400, height=300)
+    return App(content=IntentDemo(), width=400, height=300)
 
 
 if __name__ == "__main__":

--- a/src/samples/disabled_button_demo.py
+++ b/src/samples/disabled_button_demo.py
@@ -1,6 +1,6 @@
 """Visual demo for disabled button states."""
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.observable import Observable
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
@@ -65,5 +65,5 @@ class DisabledButtonDemoWidget:
 
 if __name__ == "__main__":
     demo = DisabledButtonDemoWidget()
-    app = MaterialApp(content=demo.build())
+    app = App(content=demo.build())
     app.run()

--- a/src/samples/divider_demo.py
+++ b/src/samples/divider_demo.py
@@ -8,7 +8,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.layout.spacer import Spacer
 from nuiitivet.material import Divider, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.styles.divider_style import DividerStyle
 from nuiitivet.widgeting.widget import Widget
 
@@ -98,7 +98,7 @@ def main() -> None:
         gap=16,
     )
 
-    app = MaterialApp(content=content)
+    app = App(content=content)
     app.run()
 
 

--- a/src/samples/flow_demo.py
+++ b/src/samples/flow_demo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.observable import Observable
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -105,7 +105,7 @@ class FlowDemo(ComposableWidget):
 
 if __name__ == "__main__":
     demo = FlowDemo()
-    app = MaterialApp(
+    app = App(
         content=demo,
         width=600,
         height=500,

--- a/src/samples/grid_demo.py
+++ b/src/samples/grid_demo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from nuiitivet.layout.grid import Grid, GridItem
 from nuiitivet.material import Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.card import FilledCard
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -51,7 +51,7 @@ class GridDemo(ComposableWidget):
 if __name__ == "__main__":
     demo = GridDemo()
     # ドキュメントに合わせて 400x400
-    app = MaterialApp(content=demo, width=400, height=400)
+    app = App(content=demo, width=400, height=400)
     try:
         app.run()
     except Exception:

--- a/src/samples/grid_demo_areas.py
+++ b/src/samples/grid_demo_areas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from nuiitivet.layout.grid import Grid, GridItem
 from nuiitivet.material import Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.card import FilledCard
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -45,7 +45,7 @@ class GridDemo(ComposableWidget):
 
 if __name__ == "__main__":
     demo = GridDemo()
-    app = MaterialApp(content=demo, width=640, height=480)
+    app = App(content=demo, width=640, height=480)
     try:
         app.run()
     except Exception:

--- a/src/samples/icon_buttons_demo.py
+++ b/src/samples/icon_buttons_demo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FloatingActionButton, IconButton, IconToggleButton
 from nuiitivet.material.styles import IconButtonStyle, IconToggleButtonStyle
 from nuiitivet.observable import Observable
@@ -109,5 +109,5 @@ class IconButtonsDemoWidget:
 
 if __name__ == "__main__":
     demo = IconButtonsDemoWidget()
-    app = MaterialApp(content=demo.build())
+    app = App(content=demo.build())
     app.run()

--- a/src/samples/image_demo.py
+++ b/src/samples/image_demo.py
@@ -7,7 +7,7 @@ from typing import Callable
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
-from nuiitivet.material import FilledButton, MaterialApp, OutlinedButton, Text
+from nuiitivet.material import FilledButton, App, OutlinedButton, Text
 from nuiitivet.observable import Observable
 from nuiitivet.rendering.fit import Fit
 from nuiitivet.widgets import Image
@@ -119,7 +119,7 @@ def main() -> None:
         ],
     )
 
-    app = MaterialApp(root)
+    app = App(root)
     app.run()
 
 

--- a/src/samples/japanese_text_demo.py
+++ b/src/samples/japanese_text_demo.py
@@ -1,5 +1,5 @@
 import nuiitivet
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.text import Text
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.layout.column import Column
@@ -23,8 +23,8 @@ def main():
         cross_alignment="center",
     )
 
-    # Use MaterialApp which sets up the proper theme and window
-    app = MaterialApp(
+    # Use App which sets up the proper theme and window
+    app = App(
         content=column,
         width=600,
         height=400,

--- a/src/samples/layout_alignment/column_alignment.py
+++ b/src/samples/layout_alignment/column_alignment.py
@@ -56,7 +56,7 @@ def main(png: str = ""):
         cross_alignment="start",
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=content,
         title_bar=nv.DefaultTitleBar(title="nv.Column main_alignment"),
         width="auto",

--- a/src/samples/layout_alignment/column_cross_alignment.py
+++ b/src/samples/layout_alignment/column_cross_alignment.py
@@ -54,7 +54,7 @@ def main(png: str = ""):
         cross_alignment="start",
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=content,
         title_bar=nv.DefaultTitleBar(title="nv.Column cross_alignment"),
         width="auto",

--- a/src/samples/layout_alignment/container_alignment.py
+++ b/src/samples/layout_alignment/container_alignment.py
@@ -34,7 +34,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", padding=24, child=grid)
 
-    app = md.MaterialApp(
+    app = md.App(
         content=root,
         title_bar=nv.DefaultTitleBar(title="nv.Container Alignment"),
         width="auto",

--- a/src/samples/layout_alignment/row_alignment.py
+++ b/src/samples/layout_alignment/row_alignment.py
@@ -51,7 +51,7 @@ def main(png: str = ""):
         cross_alignment="start",
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=content,
         title_bar=nv.DefaultTitleBar(title="nv.Row main_alignment"),
         width="auto",

--- a/src/samples/layout_alignment/row_cross_alignment.py
+++ b/src/samples/layout_alignment/row_cross_alignment.py
@@ -48,7 +48,7 @@ def main(png: str = ""):
         cross_alignment="start",
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=content,
         title_bar=nv.DefaultTitleBar(title="nv.Row cross_alignment"),
         width="auto",

--- a/src/samples/layout_basics/basic_column.py
+++ b/src/samples/layout_basics/basic_column.py
@@ -13,7 +13,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Basic nv.Column"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Basic nv.Column"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_basics/basic_row.py
+++ b/src/samples/layout_basics/basic_row.py
@@ -12,7 +12,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=actions, title_bar=nv.DefaultTitleBar(title="Basic nv.Row"), width=400)
+    app = md.App(content=actions, title_bar=nv.DefaultTitleBar(title="Basic nv.Row"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_basics/row_column_combination.py
+++ b/src/samples/layout_basics/row_column_combination.py
@@ -30,7 +30,7 @@ def main(png: str = ""):
         cross_alignment="center",
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=form,
         title_bar=nv.DefaultTitleBar(title="nv.Row/nv.Column Combination"),
         width="auto",

--- a/src/samples/layout_extras/container_demo.py
+++ b/src/samples/layout_extras/container_demo.py
@@ -11,7 +11,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=widget, title_bar=nv.DefaultTitleBar(title="nv.Container Demo"))
+    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="nv.Container Demo"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/deck_demo.py
+++ b/src/samples/layout_extras/deck_demo.py
@@ -58,7 +58,7 @@ class DeckDemo(nv.ComposableWidget):
 
 def main(png: str = ""):
 
-    app = md.MaterialApp(
+    app = md.App(
         content=DeckDemo(),
         title_bar=nv.DefaultTitleBar(title="nv.Deck Demo"),
         width=520,

--- a/src/samples/layout_extras/flow_demo.py
+++ b/src/samples/layout_extras/flow_demo.py
@@ -26,7 +26,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="nv.Flow Demo"))
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.Flow Demo"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/flow_minimal_demo.py
+++ b/src/samples/layout_extras/flow_minimal_demo.py
@@ -26,7 +26,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="nv.Flow Demo"))
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.Flow Demo"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/spacer_flex_demo.py
+++ b/src/samples/layout_extras/spacer_flex_demo.py
@@ -15,7 +15,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.MaterialApp(content=widget, title_bar=nv.DefaultTitleBar(title="nv.Spacer Flex Demo"))
+    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="nv.Spacer Flex Demo"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/stack_demo.py
+++ b/src/samples/layout_extras/stack_demo.py
@@ -36,7 +36,7 @@ def main(png: str = ""):
         style=CardStyle(background=None, border_radius=0),
     )
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="nv.Stack Demo"))
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.Stack Demo"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/uniform_flow_minimal_demo.py
+++ b/src/samples/layout_extras/uniform_flow_minimal_demo.py
@@ -19,7 +19,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="nv.UniformFlow Demo"))
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.UniformFlow Demo"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_grid/app_layout_grid.py
+++ b/src/samples/layout_grid/app_layout_grid.py
@@ -34,7 +34,7 @@ def main(png: str = ""):
 
     # 400x400 as requested
     # title_bar argument included so render_layout_images.py can extract the title string
-    app = md.MaterialApp(
+    app = md.App(
         content=widget,
         title_bar=nv.DefaultTitleBar(title="nv.Grid Layout"),
         width=400,

--- a/src/samples/layout_grid/basic_grid.py
+++ b/src/samples/layout_grid/basic_grid.py
@@ -33,7 +33,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.MaterialApp(content=widget, title_bar=nv.DefaultTitleBar(title="Basic nv.Grid"))
+    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="Basic nv.Grid"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_grid/expanded_cell.py
+++ b/src/samples/layout_grid/expanded_cell.py
@@ -24,7 +24,7 @@ def main(png: str = ""):
 
     root = nv.Container(padding=50, child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="Expanded Cell"))
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Expanded Cell"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_grid/named_areas_grid.py
+++ b/src/samples/layout_grid/named_areas_grid.py
@@ -37,7 +37,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=widget, title_bar=nv.DefaultTitleBar(title="nv.Grid Layout (Named Areas)"), width=400, height=400
     )
     if png:

--- a/src/samples/layout_grid/step1_grid.py
+++ b/src/samples/layout_grid/step1_grid.py
@@ -39,7 +39,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=widget,
         title_bar=nv.DefaultTitleBar(title="Step 1: Simple nv.Grid"),
         width=400,

--- a/src/samples/layout_grid/step2_span.py
+++ b/src/samples/layout_grid/step2_span.py
@@ -34,7 +34,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=widget,
         title_bar=nv.DefaultTitleBar(title="Step 2: Spanning"),
         width=400,

--- a/src/samples/layout_grid/step3_sizing.py
+++ b/src/samples/layout_grid/step3_sizing.py
@@ -34,7 +34,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=widget, title_bar=nv.DefaultTitleBar(title="Step 3: nv.Sizing Strategies"), width=400, height=400
     )
     if png:

--- a/src/samples/layout_grid/step4_expand.py
+++ b/src/samples/layout_grid/step4_expand.py
@@ -45,7 +45,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.MaterialApp(
+    app = md.App(
         content=widget,
         title_bar=nv.DefaultTitleBar(title="Step 4: Expansion"),
         width=400,

--- a/src/samples/layout_overflow/clipped_content.py
+++ b/src/samples/layout_overflow/clipped_content.py
@@ -19,7 +19,7 @@ def main(png: str = ""):
 
     root = nv.Container(padding=100, child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="Clipped Content"), width=400)
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Clipped Content"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_overflow/default_overflow.py
+++ b/src/samples/layout_overflow/default_overflow.py
@@ -19,7 +19,7 @@ def main(png: str = ""):
     # Center it so we can see the overflow clearly
     root = nv.Container(padding=100, child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="Default Overflow"), width=400)
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Default Overflow"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_overflow/scrollable_list.py
+++ b/src/samples/layout_overflow/scrollable_list.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
         ).modifier(mod.scrollable(axis="y", show_scrollbar=True)),
     )
 
-    app = md.MaterialApp(content=widget, title_bar=nv.DefaultTitleBar(title="Scrollable List"), width=400)
+    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="Scrollable List"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_sizing/auto_size.py
+++ b/src/samples/layout_sizing/auto_size.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="Auto Size"), width=400)
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Auto Size"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_sizing/fixed_size.py
+++ b/src/samples/layout_sizing/fixed_size.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
     # Wrap in center container for better visibility
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.MaterialApp(content=root, title_bar=nv.DefaultTitleBar(title="Fixed Size"), width=400)
+    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Fixed Size"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_sizing/flex_width.py
+++ b/src/samples/layout_sizing/flex_width.py
@@ -10,7 +10,7 @@ def main(png: str = ""):
         alignment="center",
     )
 
-    app = md.MaterialApp(content=widget, title_bar=nv.DefaultTitleBar(title="Full Width Box"), width=400)
+    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="Full Width Box"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/container_margin.py
+++ b/src/samples/layout_spacing/container_margin.py
@@ -17,7 +17,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="nv.Container Margin"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="nv.Container Margin"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/gap_demo.py
+++ b/src/samples/layout_spacing/gap_demo.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Gap Demo"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Gap Demo"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/padding_demo.py
+++ b/src/samples/layout_spacing/padding_demo.py
@@ -13,7 +13,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Padding Demo"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Padding Demo"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/spacer_demo.py
+++ b/src/samples/layout_spacing/spacer_demo.py
@@ -16,7 +16,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="nv.Spacer Demo"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="nv.Spacer Demo"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/loading_demo.py
+++ b/src/samples/loading_demo.py
@@ -1,4 +1,4 @@
-"""MaterialOverlay.loading() demo.
+"""Overlay.loading() demo.
 
 Shows how to display a centered loading indicator overlay.
 """
@@ -23,10 +23,10 @@ class LoadingDemo(nv.ComposableWidget):
     def __init__(self) -> None:
         super().__init__()
         self._active_handle: OverlayHandle[Any] | None = None
-        self._active_ctx: md.MaterialOverlay._LoadingContext | None = None
+        self._active_ctx: md.Overlay._LoadingContext | None = None
 
     def show_manual_overlay_loading(self) -> None:
-        overlay = md.MaterialOverlay.root()
+        overlay = md.Overlay.root()
         handle = overlay.show_modal(
             md.LoadingIndicator(size=48),
             dismiss_on_outside_tap=False,
@@ -42,8 +42,8 @@ class LoadingDemo(nv.ComposableWidget):
         runtime.clock.schedule_once(_close, 2.0)
 
     def show_loading_context_non_blocking(self) -> None:
-        """Show MaterialOverlay.loading() without blocking the UI thread."""
-        overlay = md.MaterialOverlay.root()
+        """Show Overlay.loading() without blocking the UI thread."""
+        overlay = md.Overlay.root()
         ctx = overlay.loading()
         ctx.__enter__()
         self._active_ctx = ctx
@@ -76,7 +76,7 @@ class LoadingDemo(nv.ComposableWidget):
 
 
 def main() -> None:
-    md.MaterialApp(content=LoadingDemo()).run()
+    md.App(content=LoadingDemo()).run()
 
 
 if __name__ == "__main__":

--- a/src/samples/menu_demo.py
+++ b/src/samples/menu_demo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from nuiitivet.layout.column import Column
 from nuiitivet.material import FilledButton, Menu, MenuDivider, MenuItem, SubMenuItem, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.modifiers.popup import light_dismiss
 from nuiitivet.observable.value import Observable
 
@@ -63,7 +63,7 @@ def main() -> None:
         padding=24,
     )
 
-    app = MaterialApp(content=content, width=500, height=600)
+    app = App(content=content, width=500, height=600)
     app.run()
 
 

--- a/src/samples/modifier/basic_usage.py
+++ b/src/samples/modifier/basic_usage.py
@@ -13,7 +13,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Modifier Basic Usage"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Modifier Basic Usage"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_decoration/background_border.py
+++ b/src/samples/modifier_decoration/background_border.py
@@ -29,7 +29,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Background & Border"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Background & Border"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_decoration/corner_radius_clip.py
+++ b/src/samples/modifier_decoration/corner_radius_clip.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Corner Radius & Clip"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Corner Radius & Clip"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_decoration/shadow.py
+++ b/src/samples/modifier_decoration/shadow.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=32,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Shadow Modifier"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Shadow Modifier"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_demo.py
+++ b/src/samples/modifier_demo.py
@@ -1,4 +1,4 @@
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.layout.column import Column
 from nuiitivet.widgets.box import Box
@@ -69,7 +69,7 @@ def main():
         cross_alignment="center",
     )
 
-    app = MaterialApp(content=content)
+    app = App(content=content)
     app.run()
 
 

--- a/src/samples/modifier_interaction/clickable.py
+++ b/src/samples/modifier_interaction/clickable.py
@@ -17,7 +17,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Clickable Modifier"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Clickable Modifier"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_interaction/focusable.py
+++ b/src/samples/modifier_interaction/focusable.py
@@ -35,7 +35,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Focusable Modifier"))
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Focusable Modifier"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_interaction/hoverable.py
+++ b/src/samples/modifier_interaction/hoverable.py
@@ -30,7 +30,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Hoverable Modifier"))
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Hoverable Modifier"))
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_others/scrollable.py
+++ b/src/samples/modifier_others/scrollable.py
@@ -20,7 +20,7 @@ def main(png: str = ""):
         child=nv.Column(children=items, gap=8),
     ).modifier(scrollable(axis="y"))
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Scrollable Modifier"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Scrollable Modifier"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -4,7 +4,7 @@ import nuiitivet as nv
 import nuiitivet.material as md
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.text_fields import OutlinedTextField
 from nuiitivet.modifiers import will_pop
 from nuiitivet.navigation import Navigator, PageRoute
@@ -54,14 +54,14 @@ class EditScreen(nv.ComposableWidget):
             return True
 
         def _cancel() -> None:
-            MaterialOverlay.root().close(None)
+            Overlay.root().close(None)
 
         def _discard() -> None:
             self._initial_text = str(self.text.value)
-            MaterialOverlay.root().close(None)
+            Overlay.root().close(None)
             Navigator.root().pop()
 
-        MaterialOverlay.root().dialog(
+        Overlay.root().dialog(
             AlertDialog(
                 title="Discard changes?",
                 message="You have unsaved changes.",
@@ -101,7 +101,7 @@ class EditScreen(nv.ComposableWidget):
 
 
 def main(png: str = ""):
-    app = md.MaterialApp.navigation(
+    app = md.App.navigation(
         routes={
             HomeIntent: lambda _i: PageRoute(builder=HomeScreen),
         },

--- a/src/samples/modifier_transform/opacity.py
+++ b/src/samples/modifier_transform/opacity.py
@@ -29,7 +29,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Opacity Modifier"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Opacity Modifier"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_transform/rotate_scale.py
+++ b/src/samples/modifier_transform/rotate_scale.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=48,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Rotate & Scale"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Rotate & Scale"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_transform/translate.py
+++ b/src/samples/modifier_transform/translate.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.MaterialApp(content=content, title_bar=nv.DefaultTitleBar(title="Translate Modifier"), width=400)
+    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Translate Modifier"), width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/my_widget.py
+++ b/src/samples/my_widget.py
@@ -10,7 +10,7 @@ import sys
 from typing import List, Optional
 
 from nuiitivet.common.logging_once import exception_once
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Checkbox, Icon, Text
 from nuiitivet.material.styles import IconStyle
 from nuiitivet.observable import Observable
@@ -36,7 +36,7 @@ from nuiitivet.material.buttons import (
 from nuiitivet.theme import manager as theme_manager
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.scrollbar import ScrollbarBehavior
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material import ThemeFactory
 
 
 _logger = logging.getLogger(__name__)
@@ -45,9 +45,9 @@ _logger = logging.getLogger(__name__)
 def _update_theme_seed(seed: str) -> None:
     mode = theme_manager.current.mode
     if mode == "dark":
-        theme_manager.set_theme(MaterialTheme.dark(seed))
+        theme_manager.set_theme(ThemeFactory.dark(seed))
     else:
-        theme_manager.set_theme(MaterialTheme.light(seed))
+        theme_manager.set_theme(ThemeFactory.light(seed))
 
 
 def _toggle_theme_mode() -> None:
@@ -55,9 +55,9 @@ def _toggle_theme_mode() -> None:
     # Default seed since we don't track it
     seed = "#6750A4"
     if mode == "light":
-        theme_manager.set_theme(MaterialTheme.dark(seed))
+        theme_manager.set_theme(ThemeFactory.dark(seed))
     else:
-        theme_manager.set_theme(MaterialTheme.light(seed))
+        theme_manager.set_theme(ThemeFactory.light(seed))
 
 
 class MyWidgetModel:
@@ -334,7 +334,7 @@ if __name__ == "__main__":
     widget = MyWidget(model)
     import nuiitivet as nv
 
-    app = MaterialApp(
+    app = App(
         content=widget,
         # width=750,
         # height=850,

--- a/src/samples/navigation/basic.py
+++ b/src/samples/navigation/basic.py
@@ -1,6 +1,6 @@
 import nuiitivet as nv
 
-from nuiitivet.material import FilledButton, MaterialApp, Text
+from nuiitivet.material import FilledButton, App, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.navigation import Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
@@ -43,7 +43,7 @@ class HomeScreen(ComposableWidget):
 
 
 def main(png_path: str | None = None) -> None:
-    app = MaterialApp(
+    app = App(
         content=HomeScreen(),
         title_bar=nv.DefaultTitleBar(title="Navigation Basic"),
         width=400,

--- a/src/samples/navigation/intent.py
+++ b/src/samples/navigation/intent.py
@@ -2,7 +2,7 @@ import nuiitivet as nv
 
 from dataclasses import dataclass
 
-from nuiitivet.material import FilledButton, MaterialApp, Text
+from nuiitivet.material import FilledButton, App, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.navigation import Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
@@ -70,7 +70,7 @@ class HomeScreen(ComposableWidget):
 
 
 def main(png_path: str | None = None) -> None:
-    app = MaterialApp.navigation(
+    app = App.navigation(
         routes={
             HomeIntent: lambda _: HomeScreen(),
             DetailsIntent: lambda intent: DetailsScreen(item_id=intent.item_id),

--- a/src/samples/navigation/route.py
+++ b/src/samples/navigation/route.py
@@ -4,7 +4,7 @@ from nuiitivet.material import (
     FadeIn,
     FadeOut,
     FilledButton,
-    MaterialApp,
+    App,
     MaterialTransitions,
     SlideInVertically,
     SlideOutVertically,
@@ -68,7 +68,7 @@ class HomeScreen(ComposableWidget):
 
 
 def main(png_path: str | None = None) -> None:
-    app = MaterialApp(
+    app = App(
         content=HomeScreen(),
         title_bar=nv.DefaultTitleBar(title="Navigation Route"),
         width=400,

--- a/src/samples/navigation/sub.py
+++ b/src/samples/navigation/sub.py
@@ -1,6 +1,6 @@
 import nuiitivet as nv
 
-from nuiitivet.material import FilledButton, MaterialApp, Text
+from nuiitivet.material import FilledButton, App, Text
 from nuiitivet.material.navigator import MaterialNavigator
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -102,7 +102,7 @@ class MainScreen(ComposableWidget):
 
 
 def main(png_path: str | None = None) -> None:
-    app = MaterialApp(
+    app = App(
         content=MainScreen(),
         title_bar=nv.DefaultTitleBar(title="Nested Navigation"),
         width=400,

--- a/src/samples/navigation_rail_demo.py
+++ b/src/samples/navigation_rail_demo.py
@@ -2,7 +2,7 @@
 
 from enum import IntEnum
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import BadgeValue, FilledButton, OutlinedButton, Text, TextButton
 from nuiitivet.material.navigation_rail import NavigationRail, RailItem
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -120,7 +120,7 @@ class NavigationRailDemo(ComposableWidget):
 
 if __name__ == "__main__":
     demo = NavigationRailDemo()
-    app = MaterialApp(content=demo, width=800, height=600)
+    app = App(content=demo, width=800, height=600)
     try:
         app.run()
     except Exception:

--- a/src/samples/navigator_demo.py
+++ b/src/samples/navigator_demo.py
@@ -17,7 +17,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.modifiers import background
 from nuiitivet.navigation import Navigator, PageRoute
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material import Text
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -71,7 +71,7 @@ class DetailsPage(ComposableWidget):
 
 
 def main() -> None:
-    MaterialApp.navigation(
+    App.navigation(
         routes={
             HomeIntent: lambda _i: PageRoute(builder=HomePage),
         },

--- a/src/samples/observable_async.py
+++ b/src/samples/observable_async.py
@@ -12,7 +12,7 @@ import time
 from typing import Optional
 
 from nuiitivet.observable import Observable
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -171,7 +171,7 @@ class AsyncDataApp(ComposableWidget):
 
 if __name__ == "__main__":
     widget = AsyncDataApp()
-    app = MaterialApp(content=widget)
+    app = App(content=widget)
     try:
         app.run()
     except Exception:

--- a/src/samples/observable_cart.py
+++ b/src/samples/observable_cart.py
@@ -8,7 +8,7 @@ Demonstrates:
 """
 
 from nuiitivet.observable import Observable, combine
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
@@ -165,7 +165,7 @@ class ShoppingCartApp(ComposableWidget):
 
 if __name__ == "__main__":
     widget = ShoppingCartApp()
-    app = MaterialApp(content=widget)
+    app = App(content=widget)
     try:
         app.run()
     except Exception:

--- a/src/samples/observable_debounce_throttle.py
+++ b/src/samples/observable_debounce_throttle.py
@@ -6,7 +6,7 @@ Demonstrates timing control with debounce and throttle:
 - Throttle: Button clicks sampled at regular intervals
 """
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.observable import Observable
@@ -191,5 +191,5 @@ class DebounceThrottleDemo(ComposableWidget):
 
 if __name__ == "__main__":
     widget = DebounceThrottleDemo()
-    app = MaterialApp(content=widget)
+    app = App(content=widget)
     app.run()

--- a/src/samples/observable_todo.py
+++ b/src/samples/observable_todo.py
@@ -11,7 +11,7 @@ from typing import List
 from dataclasses import dataclass
 
 from nuiitivet.observable import Observable
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.material import Checkbox
 from nuiitivet.material.styles.text_style import TextStyle
@@ -213,7 +213,7 @@ class TodoApp(ComposableWidget):
 
 if __name__ == "__main__":
     widget = TodoApp()
-    app = MaterialApp(content=widget)
+    app = App(content=widget)
     try:
         app.run()
     except Exception:

--- a/src/samples/overflow_demo.py
+++ b/src/samples/overflow_demo.py
@@ -8,7 +8,7 @@ Shows the difference between overflow="visible" and overflow="clip":
 Visual comparison demonstrates the clipping behavior.
 """
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.rendering import Sizing
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -93,5 +93,5 @@ def build_ui():
 
 
 if __name__ == "__main__":
-    app = MaterialApp(content=build_ui(), background=(ColorRole.SURFACE, 1.0))
+    app = App(content=build_ui(), background=(ColorRole.SURFACE, 1.0))
     app.run()

--- a/src/samples/overlay_demo.py
+++ b/src/samples/overlay_demo.py
@@ -7,11 +7,11 @@ This demo shows how to use the Overlay system:
 
 import logging
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.observable import Observable
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import Overlay
 from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material import Text
@@ -33,21 +33,21 @@ class OverlayDemo(ComposableWidget):
     def show_snackbar(self):
         """Show a simple snackbar message."""
         self.snackbar_count.value += 1
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         logger.warning("[overlay-demo] show_snackbar before entries=%s", overlay.has_entries())
         overlay.snackbar(f"Snackbar #{self.snackbar_count.value}")
         logger.warning("[overlay-demo] show_snackbar after entries=%s", overlay.has_entries())
 
     def show_long_snackbar(self):
         """Show a snackbar with longer duration."""
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         logger.warning("[overlay-demo] show_long_snackbar before entries=%s", overlay.has_entries())
         overlay.snackbar("This snackbar lasts 5 seconds", duration=5.0)
         logger.warning("[overlay-demo] show_long_snackbar after entries=%s", overlay.has_entries())
 
     def show_info_dialog(self):
         """Show an information dialog."""
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         logger.warning("[overlay-demo] show_info_dialog begin entries=%s", overlay.has_entries())
 
         def on_ok():
@@ -68,7 +68,7 @@ class OverlayDemo(ComposableWidget):
 
     def show_confirm_dialog(self):
         """Show a confirmation dialog."""
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         logger.warning("[overlay-demo] show_confirm_dialog begin entries=%s", overlay.has_entries())
 
         def on_cancel():
@@ -95,7 +95,7 @@ class OverlayDemo(ComposableWidget):
 
     def show_custom_dialog(self):
         """Show a dialog with custom styling."""
-        overlay = MaterialOverlay.root()
+        overlay = Overlay.root()
         logger.warning("[overlay-demo] show_custom_dialog begin entries=%s", overlay.has_entries())
 
         def on_close():
@@ -150,7 +150,7 @@ class OverlayDemo(ComposableWidget):
 
 def main():
     """Run the overlay demo."""
-    app = MaterialApp(content=OverlayDemo(), width=600, height=700)
+    app = App(content=OverlayDemo(), width=600, height=700)
     app.run()
 
 

--- a/src/samples/overlay_navigator_demo.py
+++ b/src/samples/overlay_navigator_demo.py
@@ -17,8 +17,8 @@ from nuiitivet.layout.container import Container
 from nuiitivet.modifiers import background
 from nuiitivet.navigation import Navigator, PageRoute
 from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.material.app import MaterialApp
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import App
+from nuiitivet.material import Overlay
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.material import Text, MaterialTransitions, FadeIn, ScaleIn, SlideOutVertically
@@ -66,11 +66,11 @@ class HomePage(ComposableWidget):
                 enter=FadeIn() | ScaleIn(initial_scale=0.5),
                 exit=SlideOutVertically(target_offset_y=50, duration=0.4),
             )
-            result = await MaterialOverlay.root().dialog(HelloDialogIntent(), transition=transition)
+            result = await Overlay.root().dialog(HelloDialogIntent(), transition=transition)
             if result.value == "OK":
-                MaterialOverlay.root().snackbar("Dialog confirmed (OK)")
+                Overlay.root().snackbar("Dialog confirmed (OK)")
             else:
-                MaterialOverlay.root().snackbar("Dialog dismissed")
+                Overlay.root().snackbar("Dialog dismissed")
 
         def go_next() -> None:
             Navigator.of(self).push(DetailsIntent())
@@ -96,7 +96,7 @@ class DetailsPage(ComposableWidget):
             Navigator.of(self).pop()
 
         def show_snackbar() -> None:
-            MaterialOverlay.root().snackbar("Snackbar from Details")
+            Overlay.root().snackbar("Snackbar from Details")
 
         def go_settings() -> None:
             Navigator.of(self).push(SettingsIntent())
@@ -122,11 +122,11 @@ class SettingsPage(ComposableWidget):
             Navigator.of(self).pop()
 
         async def confirm_reset() -> None:
-            result = await MaterialOverlay.root().dialog(ConfirmResetDialogIntent())
+            result = await Overlay.root().dialog(ConfirmResetDialogIntent())
             if result.value is True:
-                MaterialOverlay.root().snackbar("Reset done")
+                Overlay.root().snackbar("Reset done")
             else:
-                MaterialOverlay.root().snackbar("Cancelled")
+                Overlay.root().snackbar("Cancelled")
 
         return Container(
             padding=24,
@@ -147,7 +147,7 @@ def main() -> None:
         dialog: Widget
 
         def on_ok() -> None:
-            MaterialOverlay.root().close("OK", target=dialog)
+            Overlay.root().close("OK", target=dialog)
 
         dialog = AlertDialog(
             title="Hello",
@@ -160,10 +160,10 @@ def main() -> None:
         dialog: Widget
 
         def on_cancel() -> None:
-            MaterialOverlay.root().close(False, target=dialog)
+            Overlay.root().close(False, target=dialog)
 
         def on_reset() -> None:
-            MaterialOverlay.root().close(True, target=dialog)
+            Overlay.root().close(True, target=dialog)
 
         dialog = AlertDialog(
             title="Confirm",
@@ -175,7 +175,7 @@ def main() -> None:
         )
         return dialog
 
-    MaterialApp.navigation(
+    App.navigation(
         routes={
             HomeIntent: lambda _i: PageRoute(builder=HomePage),
             DetailsIntent: lambda _i: PageRoute(builder=DetailsPage),

--- a/src/samples/padding_demo.py
+++ b/src/samples/padding_demo.py
@@ -1,6 +1,6 @@
 """Demo app to test Column and Row padding functionality."""
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material.card import FilledCard
@@ -12,7 +12,7 @@ from nuiitivet.material.theme.color_role import ColorRole
 
 def main():
     """Show various padding configurations for Column and Row."""
-    app = MaterialApp(
+    app = App(
         content=FilledCard(
             child=Column(
                 [

--- a/src/samples/popup_demo.py
+++ b/src/samples/popup_demo.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Icon, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, OutlinedButton
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.transition_spec import MaterialTransitions
@@ -349,7 +349,7 @@ def _build_content() -> Widget:
 
 
 def main() -> None:
-    app = MaterialApp(content=_build_content())
+    app = App(content=_build_content())
     app.run()
 
 

--- a/src/samples/progress_indicators_demo.py
+++ b/src/samples/progress_indicators_demo.py
@@ -10,7 +10,7 @@ from nuiitivet.material import (
     IndeterminateCircularProgressIndicator,
     IndeterminateLinearProgressIndicator,
     LinearProgressIndicator,
-    MaterialApp,
+    App,
     Slider,
     Switch,
     Text,
@@ -78,7 +78,7 @@ def main() -> None:
         cross_alignment="start",
     )
 
-    app = MaterialApp(content=Container(child=content, padding=24))
+    app = App(content=Container(child=content, padding=24))
     app.run()
 
 

--- a/src/samples/readme/readme_counter_app.py
+++ b/src/samples/readme/readme_counter_app.py
@@ -36,7 +36,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    app = md.MaterialApp(content=CounterApp(), title_bar=nv.DefaultTitleBar(title="Counter Demo"))
+    app = md.App(content=CounterApp(), title_bar=nv.DefaultTitleBar(title="Counter Demo"))
 
     if args.png:
         app.render_to_png(args.png)

--- a/src/samples/readme/readme_layout_demo.py
+++ b/src/samples/readme/readme_layout_demo.py
@@ -36,7 +36,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    app = md.MaterialApp(content=build_layout_demo(), title_bar=nv.DefaultTitleBar(title="Layout Demo"))
+    app = md.App(content=build_layout_demo(), title_bar=nv.DefaultTitleBar(title="Layout Demo"))
 
     if args.png:
         app.render_to_png(args.png)

--- a/src/samples/readme/readme_login_form.py
+++ b/src/samples/readme/readme_login_form.py
@@ -38,7 +38,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    app = md.MaterialApp(content=build_login_form(), title_bar=nv.DefaultTitleBar(title="Login Form"))
+    app = md.App(content=build_login_form(), title_bar=nv.DefaultTitleBar(title="Login Form"))
 
     if args.png:
         app.render_to_png(args.png)

--- a/src/samples/readme/readme_modifier_demo.py
+++ b/src/samples/readme/readme_modifier_demo.py
@@ -34,7 +34,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    app = md.MaterialApp(content=build_modifier_demo(), title_bar=nv.DefaultTitleBar(title="Modifier Demo"))
+    app = md.App(content=build_modifier_demo(), title_bar=nv.DefaultTitleBar(title="Modifier Demo"))
 
     if args.png:
         app.render_to_png(args.png)

--- a/src/samples/readme/readme_multi_counter_app.py
+++ b/src/samples/readme/readme_multi_counter_app.py
@@ -51,7 +51,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    app = md.MaterialApp(content=MultiCounterApp())
+    app = md.App(content=MultiCounterApp())
 
     if args.png:
         app.render_to_png(args.png)

--- a/src/samples/row_builder_list_vs_observable_demo.py
+++ b/src/samples/row_builder_list_vs_observable_demo.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import List
 
 from nuiitivet.observable import Observable
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.material.buttons import FilledButton, OutlinedButton
 from nuiitivet.material.card import FilledCard
@@ -151,5 +151,5 @@ class RowBuilderDemo(ComposableWidget):
 
 if __name__ == "__main__":
     widget = RowBuilderDemo()
-    app = MaterialApp(content=widget)
+    app = App(content=widget)
     app.run()

--- a/src/samples/scope_counter.py
+++ b/src/samples/scope_counter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
@@ -67,5 +67,5 @@ class ScopeCounterDemo(ComposableWidget):
 
 if __name__ == "__main__":
     demo = ScopeCounterDemo()
-    app = MaterialApp(content=demo)
+    app = App(content=demo)
     app.run()

--- a/src/samples/scope_partial_rebuild.py
+++ b/src/samples/scope_partial_rebuild.py
@@ -6,7 +6,7 @@ Run with:
 
 from __future__ import annotations
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.observable import Observable
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
@@ -102,7 +102,7 @@ class ScopedCountersDemo(ComposableWidget):
 
 def main() -> None:
     demo = ScopedCountersDemo()
-    app = MaterialApp(content=demo)
+    app = App(content=demo)
     app.run()
 
 

--- a/src/samples/scroller_demo.py
+++ b/src/samples/scroller_demo.py
@@ -1,6 +1,6 @@
 """Scroller のサンプル: 基本的な使い方"""
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.layout.column import Column
 from nuiitivet.material.card import FilledCard
 from nuiitivet.material.styles.card_style import CardStyle
@@ -56,7 +56,7 @@ def main():
         gap=16,
         cross_alignment="center",
     )
-    app = MaterialApp(root)
+    app = App(root)
     app.run()
 
 
@@ -78,7 +78,7 @@ def main_auto_hide():
         padding=8,
         scrollbar=ScrollbarBehavior(auto_hide=True),
     )
-    app = MaterialApp(scroller)
+    app = App(scroller)
     app.run()
 
 
@@ -97,7 +97,7 @@ def main_with_controller():
         scroll_controller=controller,
         scrollbar=ScrollbarBehavior(auto_hide=True),
     )
-    app = MaterialApp(scroller)
+    app = App(scroller)
     import threading
 
     def auto_scroll():
@@ -133,7 +133,7 @@ def main_horizontal():
         padding=(16, 16, 16, 32),
         scrollbar=ScrollbarBehavior(auto_hide=True),
     )
-    app = MaterialApp(scroller)
+    app = App(scroller)
     app.run()
 
 

--- a/src/samples/selection_controls_demo.py
+++ b/src/samples/selection_controls_demo.py
@@ -11,7 +11,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
 from nuiitivet.material import RadioButton, RadioGroup, Switch, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.observable import Observable
 
 
@@ -71,7 +71,7 @@ def main() -> None:
 
     root = Container(child=content, padding=20)
 
-    app = MaterialApp(content=root)
+    app = App(content=root)
     app.run()
 
 

--- a/src/samples/sheet_demo.py
+++ b/src/samples/sheet_demo.py
@@ -17,8 +17,8 @@ from nuiitivet.layout.row import Row
 from nuiitivet.material import (
     Divider,
     FilledButton,
-    MaterialApp,
-    MaterialOverlay,
+    App,
+    Overlay,
     OutlinedButton,
     Text,
 )
@@ -60,13 +60,13 @@ def _sheet_content(label: str) -> Box:
 def main() -> None:
     def open_right_sheet() -> None:
         """Right-side sheet — default SideSheetStyle (width=400)."""
-        MaterialOverlay.root().side_sheet(
+        Overlay.root().side_sheet(
             SideSheet(_sheet_content("Right Side Sheet"), headline="Settings"),
         )
 
     def open_left_sheet() -> None:
         """Left-side sheet — custom width."""
-        MaterialOverlay.root().side_sheet(
+        Overlay.root().side_sheet(
             SideSheet(
                 _sheet_content("Left Side Sheet"),
                 headline="Navigation",
@@ -77,7 +77,7 @@ def main() -> None:
 
     def open_bottom_sheet_fixed() -> None:
         """Bottom sheet — fixed height."""
-        MaterialOverlay.root().bottom_sheet(
+        Overlay.root().bottom_sheet(
             BottomSheet(
                 _sheet_content("Bottom Sheet (height=280)"),
                 headline="Filter",
@@ -87,7 +87,7 @@ def main() -> None:
 
     def open_bottom_sheet_auto() -> None:
         """Bottom sheet — content-driven height (default)."""
-        MaterialOverlay.root().bottom_sheet(
+        Overlay.root().bottom_sheet(
             BottomSheet(
                 _sheet_content("Bottom Sheet (content-driven)"),
                 headline="Filter",
@@ -96,7 +96,7 @@ def main() -> None:
 
     def open_non_dismissible_sheet() -> None:
         """Right-side sheet — dismiss_on_outside_tap=False, close via on_close callback."""
-        handle = MaterialOverlay.root().side_sheet(
+        handle = Overlay.root().side_sheet(
             SideSheet(
                 _sheet_content("Non-Dismissible Sheet"),
                 headline="Edit",
@@ -128,7 +128,7 @@ def main() -> None:
             padding=24,
         )
 
-        MaterialOverlay.root().side_sheet(
+        Overlay.root().side_sheet(
             SideSheet(
                 content,
                 headline="Settings",
@@ -165,7 +165,7 @@ def main() -> None:
         padding=32,
     )
 
-    app = MaterialApp(content=content, width=600, height=420)
+    app = App(content=content, width=600, height=420)
     app.run()
 
 

--- a/src/samples/slider_demo.py
+++ b/src/samples/slider_demo.py
@@ -6,7 +6,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
 from nuiitivet.material import CenteredSlider, Orientation, RangeSlider, Slider, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.observable import Observable
 
 
@@ -110,7 +110,7 @@ def main() -> None:
         padding=24,
     )
 
-    app = MaterialApp(content=Container(child=content, padding=8))
+    app = App(content=Container(child=content, padding=8))
     app.run()
 
 

--- a/src/samples/stack_demo.py
+++ b/src/samples/stack_demo.py
@@ -1,4 +1,4 @@
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.layout.stack import Stack
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -70,7 +70,7 @@ def main():
         ],
     )
 
-    app = MaterialApp(root)
+    app = App(root)
     app.run()
 
 

--- a/src/samples/style_theme_demo.py
+++ b/src/samples/style_theme_demo.py
@@ -8,7 +8,7 @@ Demonstrates:
 """
 
 from dataclasses import replace
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Text
@@ -17,14 +17,14 @@ from nuiitivet.material.icon import Icon
 from nuiitivet.material.buttons import FilledButton
 from nuiitivet.material.styles import ButtonStyle, CheckboxStyle, IconStyle, TextStyle
 from nuiitivet.theme import manager
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material import ThemeFactory
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
 
 def main():
-    light, _ = MaterialTheme.from_seed_pair("#6750A4", name="Base Theme")
+    light, _ = ThemeFactory.from_seed_pair("#6750A4", name="Base Theme")
     custom_checkbox = CheckboxStyle(
         default_touch_target=56,
         icon_size_ratio=0.5,
@@ -112,7 +112,7 @@ def main():
         Text("• copy_with() → customizes existing style", style=TextStyle(color=ColorRole.ON_SURFACE_VARIANT)),
     ]
     root = Column(gap=16, padding=20, children=children)
-    app = MaterialApp(content=root)
+    app = App(content=root)
     app.run()
 
 

--- a/src/samples/text_field_demo.py
+++ b/src/samples/text_field_demo.py
@@ -1,4 +1,4 @@
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Checkbox, Text
 from nuiitivet.material.text_fields import FilledTextField, OutlinedTextField
 from nuiitivet.layout.container import Container
@@ -54,7 +54,7 @@ def main():
         height=400,
         padding=20,
     )
-    app = MaterialApp(root)
+    app = App(root)
     app.run()
 
 

--- a/src/samples/toggle_buttons_demo.py
+++ b/src/samples/toggle_buttons_demo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import (
     FilledToggleButton,
     OutlinedToggleButton,
@@ -128,5 +128,5 @@ class ToggleButtonsDemoWidget:
 
 if __name__ == "__main__":
     demo = ToggleButtonsDemoWidget()
-    app = MaterialApp(content=demo.build())
+    app = App(content=demo.build())
     app.run()

--- a/src/samples/toolbar_demo.py
+++ b/src/samples/toolbar_demo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import DockedToolbar, FloatingToolbar, Text
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import IconButton
 from nuiitivet.material.styles import IconButtonStyle, ToolbarStyle
 from nuiitivet.widgets.box import Box
@@ -91,7 +91,7 @@ class ToolbarDemoWidget:
 def main() -> None:
     """Run toolbar demo."""
     demo = ToolbarDemoWidget()
-    app = MaterialApp(content=demo.build())
+    app = App(content=demo.build())
     app.run()
 
 

--- a/src/samples/tooltip_demo.py
+++ b/src/samples/tooltip_demo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import RichTooltip, Text, Tooltip
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton, IconButton, OutlinedButton
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.modifiers import tooltip
@@ -96,5 +96,5 @@ class TooltipStyleCustom:
 
 
 if __name__ == "__main__":
-    app = MaterialApp(content=TooltipDemo(), width=760, height=520)
+    app = App(content=TooltipDemo(), width=760, height=520)
     app.run()

--- a/src/samples/uniform_flow_demo.py
+++ b/src/samples/uniform_flow_demo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.observable import Observable
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -106,7 +106,7 @@ class FlowUniformDemo(ComposableWidget):
 
 if __name__ == "__main__":
     demo = FlowUniformDemo()
-    app = MaterialApp(content=demo, width=720, height=520)
+    app = App(content=demo, width=720, height=520)
     try:
         app.run()
     except Exception:

--- a/src/samples/will_pop_demo.py
+++ b/src/samples/will_pop_demo.py
@@ -18,8 +18,8 @@ from nuiitivet.modifiers import will_pop
 from nuiitivet.navigation import Navigator, PageRoute
 from nuiitivet.observable import Observable
 from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.material.app import MaterialApp
-from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material import App
+from nuiitivet.material import Overlay
 from nuiitivet.material.buttons import FilledButton, TextButton
 from nuiitivet.material import Text
 from nuiitivet.material.text_fields import OutlinedTextField
@@ -96,7 +96,7 @@ class EditScreen(ComposableWidget):
     def _save(self) -> None:
         self._initial_text = str(self.vm.text.value)
         self.vm.dirty.value = False
-        MaterialOverlay.root().snackbar("Saved")
+        Overlay.root().snackbar("Saved")
 
     def _try_pop(self) -> None:
         Navigator.root().pop()
@@ -112,15 +112,15 @@ class EditScreen(ComposableWidget):
 
         def _cancel() -> None:
             self._confirm_open = False
-            MaterialOverlay.root().close(None)
+            Overlay.root().close(None)
 
         def _discard() -> None:
             self._confirm_open = False
             self.vm.dirty.value = False
-            MaterialOverlay.root().close(None)
+            Overlay.root().close(None)
             Navigator.root().pop()
 
-        handle = MaterialOverlay.root().dialog(
+        handle = Overlay.root().dialog(
             AlertDialog(
                 title="Discard changes?",
                 message="You have unsaved changes.",
@@ -175,7 +175,7 @@ class EditScreen(ComposableWidget):
 
 
 def main() -> None:
-    MaterialApp.navigation(
+    App.navigation(
         routes={
             HomeIntent: lambda _i: PageRoute(builder=HomeScreen),
         },

--- a/src/samples/window_intent_demo.py
+++ b/src/samples/window_intent_demo.py
@@ -1,11 +1,10 @@
 """Demo of intent-based window control."""
 
-from nuiitivet.material.app import MaterialApp
+from nuiitivet.material import App
 from nuiitivet.material.buttons import FilledButton
 from nuiitivet.material.text import Text
 from nuiitivet.layout.column import Column
 from nuiitivet.widgeting.widget import ComposableWidget
-from nuiitivet.runtime.app import App
 from nuiitivet.observable import runtime
 from nuiitivet.runtime.intents import (
     ExitAppIntent,
@@ -82,7 +81,7 @@ class WindowDemo(ComposableWidget):
 
 
 def main():
-    app = MaterialApp(content=WindowDemo())
+    app = App(content=WindowDemo())
     app.run()
 
 

--- a/tests/test_material_namespace_aliases.py
+++ b/tests/test_material_namespace_aliases.py
@@ -1,0 +1,39 @@
+"""Tests for theme-namespaced aliases in ``nuiitivet.material``.
+
+See issue #85.
+"""
+
+from __future__ import annotations
+
+import nuiitivet
+from nuiitivet import material
+from nuiitivet.material import App, MaterialApp, MaterialOverlay, MaterialTheme, Overlay, ThemeFactory
+
+
+def test_app_alias_is_material_app() -> None:
+    assert App is MaterialApp
+
+
+def test_overlay_alias_is_material_overlay() -> None:
+    assert Overlay is MaterialOverlay
+
+
+def test_theme_factory_alias_is_material_theme() -> None:
+    assert ThemeFactory is MaterialTheme
+
+
+def test_aliases_in_all() -> None:
+    assert "App" in material.__all__
+    assert "Overlay" in material.__all__
+    assert "ThemeFactory" in material.__all__
+
+
+def test_original_names_still_exported() -> None:
+    assert "MaterialApp" in material.__all__
+    assert "MaterialOverlay" in material.__all__
+    assert "MaterialTheme" in material.__all__
+
+
+def test_top_level_does_not_expose_app() -> None:
+    assert "App" not in nuiitivet.__all__
+    assert not hasattr(nuiitivet, "App")


### PR DESCRIPTION
## Summary
Closes #85.

Introduce theme-agnostic aliases under `nuiitivet.material` so that switching
themes (e.g. to a future `nuiitivet.cupertino`) requires only a one-line import
change.

```python
from nuiitivet.material import App, Overlay, ThemeFactory
```

| Alias          | Points to         |
| -------------- | ----------------- |
| `App`          | `MaterialApp`     |
| `Overlay`      | `MaterialOverlay` |
| `ThemeFactory` | `MaterialTheme`   |

## Design Notes
- **`ThemeFactory` instead of `Theme`**: `nuiitivet.theme.Theme` already exists
  as the theme-instance class. Using `Theme` as an alias for the factory would
  collide with that concept in documentation and IDE completion. See the
  discussion on issue #85.
- `MaterialTheme` itself is now exported from `nuiitivet.material`
  (previously only reachable via `nuiitivet.material.theme.material_theme`).
- Existing `MaterialApp` / `MaterialOverlay` / `MaterialTheme` names remain
  exported for backward compatibility.
- Top-level `nuiitivet` intentionally does **not** expose `App` (there is no
  theme-agnostic `App`).
- Scope limited to `nuiitivet.material`. Applying the same pattern to future
  theme packages (e.g. `nuiitivet.cupertino`) is out of scope for this PR.

## Changes
- `src/nuiitivet/material/__init__.py`: register aliases in `__all__` and
  `_EXPORTS`; add `MaterialTheme` export.
- `tests/test_material_namespace_aliases.py`: new tests covering alias identity,
  `__all__` membership, backward compatibility, and top-level non-exposure.
- Samples (`src/samples/**`): migrated to the new aliases. `window_intent_demo`
  dropped its direct dependency on `nuiitivet.runtime.app.App` and now uses
  `App.of()` on the material alias.
- User guides (`docs/guide/**`): references updated to `App` / `Overlay` /
  `ThemeFactory`. Internal design docs (`docs/design/**`) keep the `Material*`
  names deliberately.

## Verification
- `uv run pytest` → **1157 passed** (incl. 6 new tests)
- `uv run mypy` → **Success: no issues found in 495 source files**
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` → clean
- All sample files `py_compile` cleanly.
