### PR TITLE
feat(overlay): add OverlayAware mixin for auto-injecting OverlayHandle

### DIFF
--- a/docs/guide/dialogs.md
+++ b/docs/guide/dialogs.md
@@ -115,6 +115,68 @@ class CustomDialogContent(ComposableWidget):
 
 ![Custom Dialog](../assets/dialogs_custom_dialog.png)
 
+### Self-Closing Dialogs with `OverlayAware`
+
+The example above requires the caller to pass an `Overlay` reference into
+`CustomDialogContent` so the dialog can close itself. For fully self-contained
+dialogs, inherit from `OverlayAware[T]`. The framework automatically injects
+the created `OverlayHandle` into the widget before it is mounted, so the
+dialog can close itself via `self.overlay_handle.close(value)` without any
+external wiring.
+
+The type parameter `T` describes the result type returned from
+`handle.close(value)` / `await handle`.
+
+```python
+# src/samples/dialogs/custom_dialog_overlay_aware.py (Excerpt)
+
+from nuiitivet.overlay import OverlayAware
+
+
+class CounterDialog(ComposableWidget, OverlayAware[int]):
+    """A self-contained dialog that closes itself via OverlayAware."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.counter = Observable(0)
+
+    def _close(self) -> None:
+        # No Overlay reference needed — the framework injected the handle.
+        self.overlay_handle.close(self.counter.value)
+
+    def build(self) -> Widget:
+        return Card(
+            child=Container(
+                padding=24,
+                child=Column(
+                    gap=16,
+                    children=[
+                        Text("Self-Closing Dialog"),
+                        FilledButton("Increment", on_click=self._increment),
+                        OutlinedButton("Close & Return Count", on_click=self._close),
+                    ],
+                ),
+            ),
+            width=300,
+        )
+
+
+# Caller code no longer needs to pass the overlay:
+# result = await overlay.dialog(CounterDialog())
+```
+
+#### Notes
+
+- `overlay_handle` is available from the moment the dialog is mounted. Accessing
+  it before the widget has been shown raises `RuntimeError`.
+- `OverlayAware` works with **all** overlay show APIs, including
+  `dialog`, `show_modal`, `show_modeless`, `show_light_dismiss`, `side_sheet`,
+  `bottom_sheet`, and `loading`. It also works when the widget is wrapped in a
+  `Route` (e.g. `DialogRoute(builder=lambda: CounterDialog())`).
+- Attempting to display the same `OverlayAware` widget instance while its
+  previous handle is still active raises `RuntimeError`. Re-displaying after
+  the previous handle has completed is allowed.
+
 ## Architecting Dialogs in MVVM
 
 When building larger applications with patterns like MVVM (Model-View-ViewModel), handling dialogs requires care regarding boundaries and testing. To illustrate the differences, we will use the same "Operation Complete" dialog in both coupled and decoupled patterns.

--- a/src/nuiitivet/overlay/__init__.py
+++ b/src/nuiitivet/overlay/__init__.py
@@ -2,6 +2,7 @@
 
 from .dialog_route import DialogRoute
 from .intent_resolver import IntentResolver
+from .overlay_aware import OverlayAware
 from .overlay_handle import OverlayHandle
 from .overlay import Overlay
 from .overlay_entry import OverlayEntry
@@ -22,6 +23,7 @@ __all__ = [
     "OverlayLayerComposer",
     "OverlayLayerCompositionContext",
     "OverlayDismissReason",
+    "OverlayAware",
     "OverlayEntry",
     "OverlayHandle",
     "OverlayResult",

--- a/src/nuiitivet/overlay/overlay.py
+++ b/src/nuiitivet/overlay/overlay.py
@@ -19,13 +19,13 @@ from nuiitivet.navigation.stack_runtime import RouteStackRuntime
 from nuiitivet.navigation.transition_engine import TransitionEngine
 from nuiitivet.navigation.transition_spec import EmptyTransitionSpec, TransitionPhase, TransitionSpec, Transitions
 from nuiitivet.common.logging_once import exception_once
+from .overlay_aware import OverlayAware
 from .overlay_entry import OverlayEntry
 from .overlay_handle import OverlayHandle
 from .overlay_position import AnchoredOverlayPosition, OverlayPosition
 from .result import OverlayDismissReason, OverlayResult
 from .layer_composer import OverlayLayerComposer, OverlayLayerCompositionContext
 from .transition_state import OverlayTransitionState
-
 
 logger = logging.getLogger(__name__)
 
@@ -569,6 +569,13 @@ class Overlay(ComposableWidget):
             barrier_dismissible=barrier_dismissible,
         )
         route_holder["route"] = modal_route
+
+        # Construct the handle first so OverlayAware widgets receive it
+        # before the entry is inserted (i.e. before first build / mount).
+        handle: OverlayHandle[Any] = OverlayHandle(overlay=self, entry=entry)
+        if isinstance(content_widget, OverlayAware):
+            content_widget._set_overlay_handle(handle)
+
         self._insert_entry_with_route(entry, modal_route)
 
         self.rebuild()
@@ -581,7 +588,7 @@ class Overlay(ComposableWidget):
             self._entry_to_timeout_cb[entry] = on_timeout
             runtime.clock.schedule_once(on_timeout, float(timeout))
 
-        return OverlayHandle(overlay=self, entry=entry)
+        return handle
 
     def hit_test(self, x: int, y: int):
         """Hit test that passes through if no entry is hit."""

--- a/src/nuiitivet/overlay/overlay_aware.py
+++ b/src/nuiitivet/overlay/overlay_aware.py
@@ -1,0 +1,69 @@
+"""OverlayAware mixin for widgets that receive their OverlayHandle automatically."""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from .overlay_handle import OverlayHandle
+
+T = TypeVar("T")
+
+
+class OverlayAware(Generic[T]):
+    """Mixin that lets a widget receive its own :class:`OverlayHandle`.
+
+    When a widget inheriting ``OverlayAware`` is displayed through any
+    :class:`Overlay` show API (``show_modal``, ``show_modeless``,
+    ``show_light_dismiss``, ``dialog``, ``side_sheet``, ``bottom_sheet``,
+    ``snackbar``, ``loading``), the framework injects the created handle
+    into the widget instance before mounting. The widget (or its ViewModel)
+    can then close itself via ``self.overlay_handle.close(value)`` without
+    requiring the caller to wire the handle manually.
+
+    Type parameter ``T`` represents the result type returned from
+    ``handle.close(value)`` / ``await handle``. Note that the return type
+    of the ``Overlay`` show APIs stays ``OverlayHandle[Any]``; only the
+    widget-side view is typed.
+
+    Example:
+        >>> class MyDialog(ComposableWidget, OverlayAware[str]):
+        ...     def on_save(self) -> None:
+        ...         self.overlay_handle.close("saved")
+        ...
+        >>> result = await overlay.dialog(MyDialog())
+    """
+
+    _overlay_handle: OverlayHandle[T] | None = None
+
+    @property
+    def overlay_handle(self) -> OverlayHandle[T]:
+        """Return the handle injected by the overlay framework.
+
+        Raises:
+            RuntimeError: If accessed before the widget is displayed via
+                an ``Overlay`` show API.
+        """
+        handle = self._overlay_handle
+        if handle is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.overlay_handle is not available yet. "
+                "The widget must be displayed via an Overlay show API "
+                "(e.g. overlay.dialog(...)) before accessing overlay_handle."
+            )
+        return handle
+
+    def _set_overlay_handle(self, handle: OverlayHandle[T]) -> None:
+        """Framework-internal setter. Do not call from user code.
+
+        Raises:
+            RuntimeError: If the widget is already attached to an active
+                (not-yet-completed) handle. Re-display after the previous
+                handle has completed is allowed.
+        """
+        existing = self._overlay_handle
+        if existing is not None and not existing.done():
+            raise RuntimeError(
+                f"{type(self).__name__} is already attached to an active OverlayHandle. "
+                "Cannot display the same OverlayAware widget instance concurrently."
+            )
+        self._overlay_handle = handle

--- a/src/samples/dialogs/custom_dialog_overlay_aware.py
+++ b/src/samples/dialogs/custom_dialog_overlay_aware.py
@@ -1,0 +1,95 @@
+"""
+Custom Dialog Usage (OverlayAware variant)
+
+Shows how to use the OverlayAware mixin to let a custom dialog widget
+close itself without requiring the caller to pass an Overlay reference.
+"""
+
+from nuiitivet.material import App
+from nuiitivet.material.buttons import FilledButton, OutlinedButton
+from nuiitivet.material import Overlay
+from nuiitivet.material.text import Text
+from nuiitivet.material.card import Card
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.row import Row
+from nuiitivet.layout.container import Container
+from nuiitivet.layout.spacer import Spacer
+from nuiitivet.observable import Observable
+from nuiitivet.overlay import OverlayAware
+from nuiitivet.widgeting.widget import ComposableWidget, Widget
+
+
+class CounterDialog(ComposableWidget, OverlayAware[int]):
+    """A self-contained dialog that closes itself via OverlayAware."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.counter = Observable(0)
+
+    def _increment(self) -> None:
+        self.counter.value += 1
+
+    def _close(self) -> None:
+        # No Overlay reference needed — the framework injected the handle.
+        self.overlay_handle.close(self.counter.value)
+
+    def build(self) -> Widget:
+        return Card(
+            child=Container(
+                padding=24,
+                child=Column(
+                    gap=16,
+                    children=[
+                        Text("Self-Closing Dialog"),
+                        Text("Uses OverlayAware to close itself."),
+                        Row(
+                            gap=10,
+                            children=[
+                                Text("Count:"),
+                                Text(self.counter.map(str)),
+                            ],
+                        ),
+                        FilledButton("Increment", on_click=self._increment),
+                        Spacer(height=8),
+                        OutlinedButton("Close & Return Count", on_click=self._close),
+                    ],
+                ),
+            ),
+            width=300,
+        )
+
+
+class OverlayAwareDialogDemo(ComposableWidget):
+    last_count: Observable[str] = Observable("No count yet")
+
+    async def _show_custom_dialog(self):
+        overlay = Overlay.root()
+
+        # Caller no longer needs to pass the overlay into the dialog.
+        result = await overlay.dialog(CounterDialog())
+
+        if result.value is not None:
+            self.last_count.value = f"Final Count: {result.value}"
+
+    def build(self) -> Widget:
+        return Container(
+            alignment="center",
+            child=Column(
+                gap=20,
+                children=[
+                    Text(self.last_count),
+                    FilledButton(
+                        "Open Self-Closing Dialog",
+                        on_click=self._show_custom_dialog,
+                    ),
+                ],
+            ),
+        )
+
+
+def main(png_path: str = ""):
+    return App(content=OverlayAwareDialogDemo(), width=400, height=300)
+
+
+if __name__ == "__main__":
+    main().run()

--- a/tests/test_overlay_aware.py
+++ b/tests/test_overlay_aware.py
@@ -1,0 +1,103 @@
+"""Tests for OverlayAware mixin auto-injection."""
+
+from __future__ import annotations
+
+import pytest
+
+from nuiitivet.layout.container import Container
+from nuiitivet.overlay import DialogRoute, Overlay, OverlayAware, OverlayHandle
+from nuiitivet.widgeting.widget import ComposableWidget, Widget
+
+
+class _AwareDialog(ComposableWidget, OverlayAware[str]):
+    def build(self) -> Widget:
+        return Container(width=10, height=10)
+
+
+def test_overlay_aware_injected_on_show_modal() -> None:
+    overlay = Overlay()
+    dialog = _AwareDialog()
+
+    handle = overlay.show_modal(dialog, dismiss_on_outside_tap=False)
+
+    assert dialog.overlay_handle is handle
+
+
+def test_overlay_aware_injected_on_show_modeless() -> None:
+    overlay = Overlay()
+    dialog = _AwareDialog()
+
+    handle = overlay.show_modeless(dialog)
+
+    assert dialog.overlay_handle is handle
+
+
+def test_overlay_aware_injected_on_show_light_dismiss() -> None:
+    overlay = Overlay()
+    dialog = _AwareDialog()
+
+    handle = overlay.show_light_dismiss(dialog)
+
+    assert dialog.overlay_handle is handle
+
+
+def test_overlay_aware_injected_when_passed_via_route() -> None:
+    overlay = Overlay()
+    dialog = _AwareDialog()
+    route = DialogRoute(builder=lambda: dialog)
+
+    handle = overlay.show_modal(route, dismiss_on_outside_tap=False)
+
+    assert dialog.overlay_handle is handle
+
+
+def test_overlay_aware_close_via_handle() -> None:
+    overlay = Overlay()
+    dialog = _AwareDialog()
+
+    overlay.show_modal(dialog, dismiss_on_outside_tap=False)
+    dialog.overlay_handle.close("done")
+
+    assert dialog.overlay_handle.done() is True
+    result = dialog.overlay_handle.result()
+    assert result is not None
+    assert result.value == "done"
+
+
+def test_overlay_handle_raises_before_display() -> None:
+    dialog = _AwareDialog()
+
+    with pytest.raises(RuntimeError, match="not available yet"):
+        _ = dialog.overlay_handle
+
+
+def test_overlay_aware_concurrent_display_raises() -> None:
+    overlay = Overlay()
+    dialog = _AwareDialog()
+
+    overlay.show_modal(dialog, dismiss_on_outside_tap=False)
+
+    with pytest.raises(RuntimeError, match="already attached"):
+        overlay.show_modal(dialog, dismiss_on_outside_tap=False)
+
+
+def test_overlay_aware_redisplay_after_close_allowed() -> None:
+    overlay = Overlay()
+    dialog = _AwareDialog()
+
+    first = overlay.show_modal(dialog, dismiss_on_outside_tap=False)
+    first.close(None)
+
+    second = overlay.show_modal(dialog, dismiss_on_outside_tap=False)
+
+    assert dialog.overlay_handle is second
+
+
+def test_non_overlay_aware_widget_unaffected() -> None:
+    overlay = Overlay()
+    widget = Container(width=10, height=10)
+
+    # Should not raise and should return a usable handle.
+    handle = overlay.show_modal(widget, dismiss_on_outside_tap=False)
+
+    assert isinstance(handle, OverlayHandle)


### PR DESCRIPTION
### Summary

Introduces the `OverlayAware[T]` mixin that lets widgets receive their own `OverlayHandle` automatically when displayed via any `Overlay` show API. This removes the boilerplate of passing an `Overlay` reference into the dialog or capturing the handle manually before injecting it into a widget/ViewModel.

### Motivation

Before:
```python
vm = MyViewModel()
dialog = MyDialog(vm)
handle = overlay.dialog(dialog)
vm.set_handle(handle)           # manual injection
await handle
```

After:
```python
class MyDialog(ComposableWidget, OverlayAware[str]):
    def on_save(self) -> None:
        self.overlay_handle.close("saved")

result = await overlay.dialog(MyDialog())
```

### Design Decisions

Agreed in [#38 comment](https://github.com/yuksblog/nuiitivet/issues/38#issuecomment-4288302897):

- **Naming**: `OverlayAware` (no `I` prefix, PEP 8-friendly).
- **Scope**: Applied once in `Overlay._show_internal`, covering `show_modal` / `show_modeless` / `show_light_dismiss` / `dialog` / `snackbar` / `side_sheet` / `bottom_sheet` / `loading`.
- **Widget & Route**: Both are supported. Injection targets the resolved widget from `content_route.build_widget()`.
- **Injection timing**: Handle is constructed first and injected **before mount**, so `overlay_handle` is available during the first `build()` / `on_mount()`.
- **Generic `T`**: Only the widget-side view is typed. `Overlay` show APIs retain `OverlayHandle[Any]` return type (propagating `T` to the overlay API is out of scope).
- **Duplicate display**: Displaying the same `OverlayAware` instance while its previous handle is still active raises `RuntimeError`. Re-display after the previous handle has completed is allowed.
- **Migration**: No existing `set_handle` pattern in the codebase; nothing to migrate.

### Changes

- **New** `src/nuiitivet/overlay/overlay_aware.py` — `OverlayAware[T]` mixin
- **New** `tests/test_overlay_aware.py` — 9 tests (injection across all show APIs, Route path, pre-display access, duplicate display, re-display, non-aware widget)
- **New** `src/samples/dialogs/custom_dialog_overlay_aware.py` — runnable demo
- **Modified** `src/nuiitivet/overlay/overlay.py` — construct handle first, inject before `_insert_entry_with_route` in `_show_internal`
- **Modified** `src/nuiitivet/overlay/__init__.py` — export `OverlayAware`
- **Modified** `docs/guide/dialogs.md` — "Self-Closing Dialogs with `OverlayAware`" section under "Custom Dialogs"

### Test / Quality Checks

- `uv run pytest` → **1166 passed** (9 new)
- `uv run mypy` → **Success: no issues found in 498 source files**
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` → clean

### Related

- Closes #38
- Spin-off: #96 (mypy revealed an unrelated typing discrepancy on `on_click` — async support not reflected in type annotations)
