### PR TITLE
refactor(nav): redesign Navigator/App initialization API (#55)

### DIFF
--- a/docs/design/NAVIGATION.md
+++ b/docs/design/NAVIGATION.md
@@ -187,21 +187,37 @@ Navigator.root().push(UnknownIntent())
 # → RuntimeError: Intent 'UnknownIntent' not found in routes
 ```
 
-### 2.5 `App.navigation(...)` Initialization Pattern
+### 2.5 `Navigator.intents(...)` Initialization Pattern
 
-To enable ViewModels to request screen transitions based on Intents without depending on View (Widget) details, `App.navigation(...)` is provided as an alternative initialization pattern.
+To enable ViewModels to request screen transitions based on Intents without depending on View (Widget) details, `Navigator.intents(...)` is provided as an Intent-based factory. It is passed directly to `App(...)` so the resulting Navigator becomes the root Navigator.
 
 ```python
-# App with navigation
-App.navigation(
-    routes={
-        HomeIntent: lambda intent: PageRoute(builder=...),
-        DetailIntent: lambda intent: PageRoute(builder=...),
-        SettingsIntent: lambda intent: PageRoute(builder=...),
-    },
-    initial_route=HomeIntent(),
+# App with intent-based navigation
+App(
+    Navigator.intents(
+        initial_route=HomeIntent(),
+        routes={
+            HomeIntent: lambda intent: PageRoute(builder=...),
+            DetailIntent: lambda intent: PageRoute(builder=...),
+            SettingsIntent: lambda intent: PageRoute(builder=...),
+        },
+    ),
     title="My App",
 )
+```
+
+For the most common case of starting from a single screen, simply pass the screen to `App(...)`:
+
+```python
+# App wraps the Widget in an implicit root Navigator
+App(HomeScreen())
+# Navigator.root().push(...) works anywhere.
+```
+
+Use `Navigator.routes([...])` when the navigator must start with a pre-populated stack (e.g. deep linking, state restoration):
+
+```python
+App(Navigator.routes([HomeScreen(), DetailsScreen()]))
 ```
 
 ## 3. Back Button Handling

--- a/docs/design/OVERLAY.md
+++ b/docs/design/OVERLAY.md
@@ -215,7 +215,7 @@ Scenario-specific APIs are moved to subclasses.
 
 To allow Material apps to use `MaterialOverlay` as the root overlay, `App` allows for overlay injection.
 
-- `App` / `App.navigation()` accepts `overlay_factory: Callable[[], Overlay]`.
+- `App` accepts `overlay_factory: Callable[[], Overlay]`.
 - If omitted, `App` defaults to creating a standard `Overlay`.
 
 Example:

--- a/docs/guide/modifier_others.md
+++ b/docs/guide/modifier_others.md
@@ -131,9 +131,11 @@ class EditScreen(nv.ComposableWidget):
         )
 
 def main() -> None:
-    md.App.navigation(
-        routes={HomeIntent: lambda _i: PageRoute(builder=HomeScreen)},
-        initial_route=HomeIntent(),
+    md.App(
+        Navigator.intents(
+            initial_route=HomeIntent(),
+            routes={HomeIntent: lambda _i: PageRoute(builder=HomeScreen)},
+        ),
     ).run()
 ```
 

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -6,7 +6,7 @@ Nuiitivet provides a robust navigation system for managing screen transitions an
 
 The `Navigator` is a widget that manages a set of child widgets with a stack discipline. It allows you to transition between different screens (or "pages") in your application.
 
-When you use `App.navigation()`, a root `Navigator` is automatically created and configured for you. You can access this root navigator from anywhere in your application using `Navigator.root()`.
+When you create an `App`, a root `Navigator` is automatically set up for you. If you pass a plain `Widget` as content (e.g. `App(HomeScreen())`), it is wrapped in an implicit root `Navigator`. If you pass a `Navigator` explicitly (e.g. `App(Navigator.intents(...))`), that instance is used as the root. In all cases you can access the root navigator from anywhere using `Navigator.root()`.
 
 ## Basic Navigation: Push and Pop
 

--- a/docs/guide/navigation_intent.md
+++ b/docs/guide/navigation_intent.md
@@ -14,9 +14,9 @@ class DetailsIntent:
     item_id: int
 ```
 
-## Configuring App.navigation()
+## Configuring Navigator.intents()
 
-To use Intents, you configure your `App` using the `navigation()` method instead of the standard constructor. You provide a mapping of Intent types to route builder functions.
+To use Intents, you create a Navigator with the `Navigator.intents(...)` factory and pass it to `App(...)`. You provide a mapping of Intent types to route builder functions.
 
 ![Navigation Intent](../assets/navigation_intent.png)
 
@@ -72,12 +72,14 @@ class DetailsScreen(ComposableWidget):
             ),
         )
 
-app = App.navigation(
-    routes={
-        HomeIntent: lambda _: HomeScreen(),
-        DetailsIntent: lambda intent: DetailsScreen(intent),
-    }
-    initial_route=HomeIntent(),
+app = App(
+    Navigator.intents(
+        initial_route=HomeIntent(),
+        routes={
+            HomeIntent: lambda _: HomeScreen(),
+            DetailsIntent: lambda intent: DetailsScreen(intent),
+        },
+    ),
     title_bar=nv.DefaultTitleBar(title="Navigation Intent"),
     width=400,
     height=300,

--- a/src/nuiitivet/material/app.py
+++ b/src/nuiitivet/material/app.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping, Optional, cast
+from typing import Any, Callable, Mapping, Optional
 
 from nuiitivet.material.navigation_visual_state import MaterialNavigationLayerComposer
 from nuiitivet.material.navigator import MaterialNavigator
@@ -10,14 +10,12 @@ from nuiitivet.material.overlay import MaterialOverlay
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.navigation.navigator import Navigator
-from nuiitivet.navigation.route import PageRoute, Route
+from nuiitivet.navigation.route import Route
 from nuiitivet.runtime.app import App
 from nuiitivet.runtime.title_bar import TitleBar
 from nuiitivet.runtime.window import WindowPosition, WindowSizingLike
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.widgeting.widget import Widget
-
-from .transition_spec import MaterialTransitions
 
 
 class MaterialApp(App):
@@ -27,95 +25,17 @@ class MaterialApp(App):
     - Material Theme (light/dark)
     - Material Dialogs (Alert, Loading)
     - Material Background color
+    - Material Navigator (with Material page transitions)
+
+    Pass a ``Widget`` to use it directly as the root screen (with an implicit
+    root ``MaterialNavigator``), or pass a ``Navigator`` / ``Navigator.routes(...)``
+    / ``Navigator.intents(...)`` to customize the initial navigation stack.
     """
 
-    @classmethod
-    def navigation(  # type: ignore[override]
-        cls,
-        routes: Mapping[type[Any], Callable[[Any], Route | Widget]],
-        initial_route: Any,
-        *,
-        overlay_routes: Mapping[type[Any], Callable[[Any], Route | Widget]] | None = None,
-        width: WindowSizingLike = "auto",
-        height: WindowSizingLike = "auto",
-        background: ColorSpec = ColorRole.SURFACE,
-        theme: Optional[Any] = None,
-        title_bar: Optional[TitleBar] = None,
-        window_position: WindowPosition | None = None,
-        resizable: bool = True,
-    ) -> "MaterialApp":
-        """Create a MaterialApp with a root Navigator and Overlay.
-
-        Args:
-            routes: A mapping of Intent types to route builder functions.
-            initial_route: The initial Intent to launch.
-            overlay_routes: Optional mapping of Intent types to overlay builder functions.
-            width: Window width specification ("auto", fixed integer, etc.).
-            height: Window height specification.
-            background: Background color of the window. Defaults to Material Surface color.
-            theme: The MaterialTheme to use. Defaults to Light theme.
-            title_bar: Custom window title bar.
-            window_position: Initial window position.
-            resizable: Whether the window can be resized. Defaults to True.
-
-        Returns:
-            Configured MaterialApp instance.
-        """
-        if theme is None:
-            theme = MaterialTheme.light("#6750A4")
-
-        wrapped_routes: dict[type[Any], Callable[[Any], Route | Widget]] = {}
-
-        def _normalize_resolved(value: Route | Widget) -> Route:
-            if isinstance(value, Route):
-                return value
-            if isinstance(value, Widget):
-                widget = value
-                return PageRoute(
-                    builder=lambda: widget,
-                    transition_spec=MaterialTransitions.page(),
-                )
-            raise TypeError("Route factory must return a Route or Widget.")
-
-        def _wrap_route_factory(
-            factory: Callable[[Any], Route | Widget],
-        ) -> Callable[[Any], Route]:
-            def _wrapped(intent: Any) -> Route:
-                return _normalize_resolved(factory(intent))
-
-            return _wrapped
-
-        for intent_type, factory in routes.items():
-            wrapped_routes[intent_type] = _wrap_route_factory(factory)
-
-        def _overlay_factory() -> MaterialOverlay:
-            return MaterialOverlay(intents=overlay_routes)
-
-        def _navigator_factory(
-            initial: Route,
-            intent_routes: Mapping[type[Any], Callable[[Any], Route | Widget]] | None,
-        ) -> Navigator:
-            return MaterialNavigator(
-                routes=[initial],
-                intent_routes=intent_routes,
-                layer_composer=MaterialNavigationLayerComposer(),
-            )
-
-        return cast(
-            MaterialApp,
-            super().navigation(
-                routes=wrapped_routes,
-                initial_route=initial_route,
-                overlay_factory=_overlay_factory,
-                navigator_factory=_navigator_factory,
-                width=width,
-                height=height,
-                title_bar=title_bar,
-                background=background,
-                theme=theme,
-                window_position=window_position,
-                resizable=resizable,
-            ),
+    def _build_default_navigator(self, content: Widget) -> Navigator:
+        return MaterialNavigator(
+            content,
+            layer_composer=MaterialNavigationLayerComposer(),
         )
 
     def __init__(
@@ -131,10 +51,13 @@ class MaterialApp(App):
         window_position: WindowPosition | None = None,
         resizable: bool = True,
     ) -> None:
-        """Initialize a MaterialApp with a single root widget.
+        """Initialize a MaterialApp.
 
         Args:
-            content: The root widget of the application.
+            content: The root content. Can be a ``Widget`` (used as the initial
+                screen under an implicit ``MaterialNavigator``) or a
+                ``Navigator`` (e.g. ``Navigator.routes(...)`` or
+                ``Navigator.intents(...)``) to customize the navigation stack.
             overlay_routes: Optional mapping of Intent types to overlay builder functions.
             width: Window width specification ("auto", fixed integer, etc.).
             height: Window height specification.
@@ -150,16 +73,6 @@ class MaterialApp(App):
         def _overlay_factory() -> MaterialOverlay:
             return MaterialOverlay(intents=overlay_routes)
 
-        def _navigator_factory(
-            initial: Route,
-            intent_routes: Mapping[type[Any], Callable[[Any], Route | Widget]] | None,
-        ) -> Navigator:
-            return MaterialNavigator(
-                routes=[initial],
-                intent_routes=intent_routes,
-                layer_composer=MaterialNavigationLayerComposer(),
-            )
-
         super().__init__(
             content=content,
             width=width,
@@ -168,7 +81,6 @@ class MaterialApp(App):
             background=background,
             theme=theme,
             overlay_factory=_overlay_factory,
-            navigator_factory=_navigator_factory,
             window_position=window_position,
             resizable=resizable,
         )

--- a/src/nuiitivet/navigation/navigator.py
+++ b/src/nuiitivet/navigation/navigator.py
@@ -14,7 +14,6 @@ from .stack_runtime import RouteStackRuntime
 from .transition_engine import TransitionEngine, TransitionHandle
 from .transition_spec import EmptyTransitionSpec, TransitionPhase
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -51,7 +50,12 @@ class _DefaultNavigationLayerComposer:
 class Navigator(ComposableWidget):
     """A minimal navigation stack.
 
-    Phase 3 scope:
+    Initialization forms:
+        - ``Navigator(screen)``: start with a single screen (``Route`` or ``Widget``).
+        - ``Navigator.routes([...])``: pre-populated stack (e.g. deep linking).
+        - ``Navigator.intents(initial_route=..., routes={...})``: Intent-based routing.
+
+    Features:
         - push/pop
         - root()/set_root()
         - of(context)
@@ -62,20 +66,85 @@ class Navigator(ComposableWidget):
 
     def __init__(
         self,
-        routes: Sequence[Route] | None = None,
+        screen: Route | Widget | None = None,
         *,
-        intent_routes: Mapping[type[Any], Callable[[Any], Route | Widget]] | None = None,
         layer_composer: NavigationLayerComposer | None = None,
     ) -> None:
+        """Initialize a Navigator with a single initial screen.
+
+        Args:
+            screen: The initial screen as a ``Route`` or ``Widget``. If ``None``,
+                the navigator starts with an empty stack (use :meth:`routes` or
+                :meth:`intents` factories for alternative initialization).
+            layer_composer: Optional custom layer composer.
+        """
         super().__init__()
-        self._stack = RouteStackRuntime(initial_routes=list(routes or []))
-        self._intent_routes: Mapping[type[Any], Callable[[Any], Route | Widget]] = dict(intent_routes or {})
+        self._intent_routes: Mapping[type[Any], Callable[[Any], Route | Widget]] = {}
         self._transition: _NavTransition | None = None
         self._transition_handle: TransitionHandle | None = None
         self._transition_engine = TransitionEngine()
         self._pending_pop_requests: int = 0
         self._exiting_route: Route | None = None
         self._layer_composer: NavigationLayerComposer = layer_composer or _DefaultNavigationLayerComposer()
+
+        initial_routes: list[Route] = []
+        if screen is not None:
+            initial_routes.append(self._to_initial_route(screen))
+        self._stack = RouteStackRuntime(initial_routes=initial_routes)
+
+    def _to_initial_route(self, value: Route | Widget) -> Route:
+        """Convert a ``Route`` or ``Widget`` into a ``Route`` for initial stack construction."""
+        if isinstance(value, Route):
+            return value
+        if isinstance(value, Widget):
+            return self._route_from_widget(value)
+        raise TypeError(f"Navigator initial screen must be a Route or Widget, got {type(value).__name__}")
+
+    @classmethod
+    def routes(
+        cls,
+        screens: Sequence[Route | Widget],
+        *,
+        layer_composer: NavigationLayerComposer | None = None,
+    ) -> Navigator:
+        """Create a Navigator with a pre-populated stack.
+
+        Use this when the navigator should start with multiple screens already
+        on the stack (e.g. deep linking, state restoration).
+
+        Args:
+            screens: Sequence of ``Route`` or ``Widget`` instances. The last item
+                becomes the top of the stack.
+            layer_composer: Optional custom layer composer.
+        """
+        if not screens:
+            raise ValueError("Navigator.routes(...) requires at least one screen")
+        instance = cls(layer_composer=layer_composer)
+        initial_routes = [instance._to_initial_route(s) for s in screens]
+        instance._stack = RouteStackRuntime(initial_routes=initial_routes)
+        return instance
+
+    @classmethod
+    def intents(
+        cls,
+        *,
+        initial_route: Any,
+        routes: Mapping[type[Any], Callable[[Any], Route | Widget]],
+        layer_composer: NavigationLayerComposer | None = None,
+    ) -> Navigator:
+        """Create a Navigator configured for Intent-based routing.
+
+        Args:
+            initial_route: The initial Intent instance used to resolve the first route.
+            routes: Mapping of Intent types to route builder functions. Each
+                builder returns a ``Route`` or ``Widget``.
+            layer_composer: Optional custom layer composer.
+        """
+        instance = cls(layer_composer=layer_composer)
+        instance._intent_routes = dict(routes)
+        initial = instance._resolve_intent_to_route(initial_route)
+        instance._stack = RouteStackRuntime(initial_routes=[initial])
+        return instance
 
     @classmethod
     def set_root(cls, navigator: Navigator) -> None:

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -7,7 +7,6 @@ import time
 import traceback
 import warnings
 import weakref
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from ..widgeting.widget import ComposableWidget, Widget
@@ -36,16 +35,10 @@ from nuiitivet.layout.container import Container
 
 if TYPE_CHECKING:
     from nuiitivet.navigation.navigator import Navigator
-    from nuiitivet.navigation.route import Route
     from nuiitivet.overlay.overlay import Overlay
 
 
 logger = logging.getLogger(__name__)
-
-NavigatorFactory = Callable[
-    ["Route", Mapping[type[Any], Callable[[Any], "Route | Widget"]] | None],
-    "Navigator",
-]
 
 
 # NOTE: compatibility wrapper removed. Use `resolve_color_to_rgba` from
@@ -125,13 +118,11 @@ class App:
     @staticmethod
     def _build_root_navigation_stack(
         *,
-        initial: "Route",
-        intent_routes: Mapping[type[Any], Callable[[Any], "Route | Widget"]] | None,
+        navigator: "Navigator",
         overlay_factory: Callable[[], "Overlay"] | None,
-        navigator_factory: NavigatorFactory | None = None,
     ) -> tuple[Widget, Widget | None]:
         from nuiitivet.layout.stack import Stack
-        from nuiitivet.navigation import Navigator, Route
+        from nuiitivet.navigation import Navigator as _Navigator
         from nuiitivet.overlay import Overlay
         from nuiitivet.rendering.sizing import Sizing
 
@@ -141,21 +132,15 @@ class App:
             raise TypeError("overlay_factory must return an Overlay instance")
         Overlay.set_root(overlay)
 
-        def _default_navigator_factory(
-            initial_route: Route,
-            routes: Mapping[type[Any], Callable[[Any], "Route | Widget"]] | None,
-        ) -> Navigator:
-            return Navigator(routes=[initial_route], intent_routes=routes)
-
-        resolved_navigator_factory = navigator_factory or _default_navigator_factory
-        navigator = resolved_navigator_factory(initial, intent_routes)
-        if not isinstance(navigator, Navigator):
-            raise TypeError("navigator_factory must return a Navigator instance")
-        Navigator.set_root(navigator)
+        if not isinstance(navigator, _Navigator):
+            raise TypeError("navigator must be a Navigator instance")
+        _Navigator.set_root(navigator)
 
         initial_route_widget: Widget | None = None
         try:
-            initial_route_widget = navigator._route_widget(initial)  # type: ignore[attr-defined]
+            top_route = navigator._stack.top()  # type: ignore[attr-defined]
+            if top_route is not None:
+                initial_route_widget = navigator._route_widget(top_route)  # type: ignore[attr-defined]
         except Exception:
             exception_once(logger, "navigator_route_widget_prime_exc", "Failed to prime initial route widget")
 
@@ -414,64 +399,15 @@ class App:
                 exception_once(logger, "app_navigator_back_exc", "Navigator back handling failed")
         return False
 
-    @classmethod
-    def navigation(
-        cls,
-        *,
-        routes: Mapping[type[Any], Callable[[Any], "Route | Widget"]],
-        initial_route: Any,
-        overlay_factory: Callable[[], "Overlay"] | None = None,
-        navigator_factory: NavigatorFactory | None = None,
-        width: WindowSizingLike = "auto",
-        height: WindowSizingLike = "auto",
-        title_bar: Optional[TitleBar] = None,
-        background: ColorSpec = PlainColorRole.SURFACE,
-        theme: Optional[Any] = None,
-        window_position: WindowPosition | None = None,
-        resizable: bool = True,
-    ) -> "App":
-        """Create an App with a root Navigator and Overlay.
+    def _build_default_navigator(self, content: Widget) -> "Navigator":
+        """Wrap ``content`` in a default root Navigator.
 
-        This provides the Phase 6 initialization pattern:
-        - Navigator.root() / Overlay.root() are set
-        - The UI is stacked as [Navigator, Overlay]
+        Subclasses (e.g. ``MaterialApp``) can override this to provide a
+        framework-specific Navigator (e.g. ``MaterialNavigator``).
         """
+        from nuiitivet.navigation import Navigator
 
-        from nuiitivet.navigation import PageRoute, Route
-
-        try:
-            factory = routes[type(initial_route)]
-        except Exception as exc:
-            raise RuntimeError(f"No route is registered for intent: {type(initial_route).__name__}") from exc
-
-        resolved = factory(initial_route)
-        if isinstance(resolved, Route):
-            initial = resolved
-        elif isinstance(resolved, Widget):
-            widget = resolved
-            initial = PageRoute(builder=lambda: widget)
-        else:
-            raise TypeError("Route factory must return a Route or Widget.")
-
-        root_widget, initial_route_widget = cls._build_root_navigation_stack(
-            initial=initial,
-            intent_routes=routes,
-            overlay_factory=overlay_factory,
-            navigator_factory=navigator_factory,
-        )
-        self = cls.__new__(cls)
-        self._init_common(
-            root=root_widget,
-            width=width,
-            height=height,
-            title_bar=title_bar,
-            background=background,
-            theme=theme,
-            window_position=window_position,
-            window_auto_size_target=initial_route_widget,
-            resizable=resizable,
-        )
-        return self
+        return Navigator(content)
 
     def __init__(
         self,
@@ -482,25 +418,42 @@ class App:
         title_bar: Optional[TitleBar] = None,
         background: ColorSpec = PlainColorRole.SURFACE,
         overlay_factory: Callable[[], "Overlay"] | None = None,
-        navigator_factory: NavigatorFactory | None = None,
         theme: Optional[Any] = None,
         window_position: WindowPosition | None = None,
         resizable: bool = True,
     ):
-        """Initialize App with a root Navigator and Overlay."""
+        """Initialize the App.
+
+        Args:
+            content: The root content. Can be either:
+                - A ``Navigator`` (including factory-built variants like
+                  ``Navigator.routes(...)`` / ``Navigator.intents(...)``), which
+                  is used directly as the root Navigator.
+                - Any other ``Widget``, in which case a default root ``Navigator``
+                  is created implicitly so ``Navigator.root().push(...)`` works
+                  out of the box.
+            width: Window width specification.
+            height: Window height specification.
+            title_bar: Custom window title bar.
+            background: Window background color.
+            overlay_factory: Optional overlay factory.
+            theme: Theme to install.
+            window_position: Initial window position.
+            resizable: Whether the window can be resized.
+        """
         if not isinstance(content, Widget):
             raise TypeError("'content' must be a Widget instance.")
 
-        from nuiitivet.navigation import PageRoute
+        from nuiitivet.navigation import Navigator
 
-        from nuiitivet.navigation.transition_spec import Transitions
+        if isinstance(content, Navigator):
+            navigator = content
+        else:
+            navigator = self._build_default_navigator(content)
 
-        initial = PageRoute(builder=lambda: content, transition_spec=Transitions.empty())
         root_widget, initial_route_widget = self._build_root_navigation_stack(
-            initial=initial,
-            intent_routes=None,
+            navigator=navigator,
             overlay_factory=overlay_factory,
-            navigator_factory=navigator_factory,
         )
         self._init_common(
             root=root_widget,

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -101,11 +101,13 @@ class EditScreen(nv.ComposableWidget):
 
 
 def main(png: str = ""):
-    app = md.App.navigation(
-        routes={
-            HomeIntent: lambda _i: PageRoute(builder=HomeScreen),
-        },
-        initial_route=HomeIntent(),
+    app = md.App(
+        Navigator.intents(
+            initial_route=HomeIntent(),
+            routes={
+                HomeIntent: lambda _i: PageRoute(builder=HomeScreen),
+            },
+        ),
         width=400,
         height=200,
         title_bar=nv.DefaultTitleBar(title="Will Pop Modifier"),

--- a/src/samples/navigation/README.md
+++ b/src/samples/navigation/README.md
@@ -4,5 +4,4 @@ These samples are aligned with `docs/guide/navigation*.md` as far as the current
 
 ## Current limitations
 
-- `MaterialNavigator(NestedHome())` is not supported yet. `sub.py` uses `MaterialNavigator(routes=[PageRoute(...)])`.
 - `NavigationProxy` type is not available yet. `intent.py` uses `Navigator` directly in the ViewModel example.

--- a/src/samples/navigation/intent.py
+++ b/src/samples/navigation/intent.py
@@ -70,12 +70,14 @@ class HomeScreen(ComposableWidget):
 
 
 def main(png_path: str | None = None) -> None:
-    app = App.navigation(
-        routes={
-            HomeIntent: lambda _: HomeScreen(),
-            DetailsIntent: lambda intent: DetailsScreen(item_id=intent.item_id),
-        },
-        initial_route=HomeIntent(),
+    app = App(
+        Navigator.intents(
+            initial_route=HomeIntent(),
+            routes={
+                HomeIntent: lambda _: HomeScreen(),
+                DetailsIntent: lambda intent: DetailsScreen(item_id=intent.item_id),
+            },
+        ),
         title_bar=nv.DefaultTitleBar(title="Navigation Intent"),
         width=400,
         height=300,

--- a/src/samples/navigation/sub.py
+++ b/src/samples/navigation/sub.py
@@ -5,7 +5,7 @@ from nuiitivet.material.navigator import MaterialNavigator
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 
@@ -91,11 +91,7 @@ class MainScreen(ComposableWidget):
                 Container(
                     width=nv.Sizing.flex(1),
                     height=nv.Sizing.flex(1),
-                    child=MaterialNavigator(
-                        routes=[
-                            PageRoute(builder=lambda: NestedHome()),
-                        ]
-                    ),
+                    child=MaterialNavigator(NestedHome()),
                 ),
             ],
         )

--- a/src/samples/navigator_demo.py
+++ b/src/samples/navigator_demo.py
@@ -71,11 +71,13 @@ class DetailsPage(ComposableWidget):
 
 
 def main() -> None:
-    App.navigation(
-        routes={
-            HomeIntent: lambda _i: PageRoute(builder=HomePage),
-        },
-        initial_route=HomeIntent(),
+    App(
+        Navigator.intents(
+            initial_route=HomeIntent(),
+            routes={
+                HomeIntent: lambda _i: PageRoute(builder=HomePage),
+            },
+        ),
         width=480,
         height=360,
     ).run()

--- a/src/samples/overlay_navigator_demo.py
+++ b/src/samples/overlay_navigator_demo.py
@@ -175,13 +175,15 @@ def main() -> None:
         )
         return dialog
 
-    App.navigation(
-        routes={
-            HomeIntent: lambda _i: PageRoute(builder=HomePage),
-            DetailsIntent: lambda _i: PageRoute(builder=DetailsPage),
-            SettingsIntent: lambda _i: PageRoute(builder=SettingsPage),
-        },
-        initial_route=HomeIntent(),
+    App(
+        Navigator.intents(
+            initial_route=HomeIntent(),
+            routes={
+                HomeIntent: lambda _i: PageRoute(builder=HomePage),
+                DetailsIntent: lambda _i: PageRoute(builder=DetailsPage),
+                SettingsIntent: lambda _i: PageRoute(builder=SettingsPage),
+            },
+        ),
         overlay_routes={
             HelloDialogIntent: _build_hello_dialog,
             ConfirmResetDialogIntent: _build_confirm_reset_dialog,

--- a/src/samples/will_pop_demo.py
+++ b/src/samples/will_pop_demo.py
@@ -25,7 +25,6 @@ from nuiitivet.material import Text
 from nuiitivet.material.text_fields import OutlinedTextField
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -175,11 +174,13 @@ class EditScreen(ComposableWidget):
 
 
 def main() -> None:
-    App.navigation(
-        routes={
-            HomeIntent: lambda _i: PageRoute(builder=HomeScreen),
-        },
-        initial_route=HomeIntent(),
+    App(
+        Navigator.intents(
+            initial_route=HomeIntent(),
+            routes={
+                HomeIntent: lambda _i: PageRoute(builder=HomeScreen),
+            },
+        ),
         width=720,
         height=420,
     ).run()

--- a/tests/test_app_initialization_patterns.py
+++ b/tests/test_app_initialization_patterns.py
@@ -53,18 +53,20 @@ class _HomeIntent:
     label: str
 
 
-def test_app_navigation_sets_root_navigator_and_overlay() -> None:
+def test_app_with_intents_navigator_sets_root_navigator_and_overlay() -> None:
     prev_nav = Navigator._root  # type: ignore[attr-defined]
     prev_overlay = Overlay._root_overlay  # type: ignore[attr-defined]
     try:
         Navigator._root = None  # type: ignore[attr-defined]
         Overlay._root_overlay = None  # type: ignore[attr-defined]
 
-        app = App.navigation(
-            routes={
-                _HomeIntent: lambda i: _FlagWidget(label=i.label),
-            },
-            initial_route=_HomeIntent(label="home"),
+        app = App(
+            Navigator.intents(
+                initial_route=_HomeIntent(label="home"),
+                routes={
+                    _HomeIntent: lambda i: _FlagWidget(label=i.label),
+                },
+            ),
         )
 
         assert isinstance(app.root, AppScope)
@@ -102,16 +104,18 @@ def test_app_resizable_explicit_false() -> None:
     assert app.resizable is False
 
 
-def test_app_navigation_resizable_default_true() -> None:
+def test_app_with_intents_navigator_resizable_default_true() -> None:
     prev_nav = Navigator._root  # type: ignore[attr-defined]
     prev_overlay = Overlay._root_overlay  # type: ignore[attr-defined]
     try:
         Navigator._root = None  # type: ignore[attr-defined]
         Overlay._root_overlay = None  # type: ignore[attr-defined]
 
-        app = App.navigation(
-            routes={_HomeIntent: lambda i: _FlagWidget(label=i.label)},
-            initial_route=_HomeIntent(label="home"),
+        app = App(
+            Navigator.intents(
+                initial_route=_HomeIntent(label="home"),
+                routes={_HomeIntent: lambda i: _FlagWidget(label=i.label)},
+            ),
         )
 
         assert app.resizable is True
@@ -120,16 +124,18 @@ def test_app_navigation_resizable_default_true() -> None:
         Overlay._root_overlay = prev_overlay  # type: ignore[attr-defined]
 
 
-def test_app_navigation_resizable_explicit_false() -> None:
+def test_app_with_intents_navigator_resizable_explicit_false() -> None:
     prev_nav = Navigator._root  # type: ignore[attr-defined]
     prev_overlay = Overlay._root_overlay  # type: ignore[attr-defined]
     try:
         Navigator._root = None  # type: ignore[attr-defined]
         Overlay._root_overlay = None  # type: ignore[attr-defined]
 
-        app = App.navigation(
-            routes={_HomeIntent: lambda i: _FlagWidget(label=i.label)},
-            initial_route=_HomeIntent(label="home"),
+        app = App(
+            Navigator.intents(
+                initial_route=_HomeIntent(label="home"),
+                routes={_HomeIntent: lambda i: _FlagWidget(label=i.label)},
+            ),
             resizable=False,
         )
 

--- a/tests/test_intent_system.py
+++ b/tests/test_intent_system.py
@@ -40,9 +40,9 @@ class _DialogIntent:
 
 
 def test_navigator_push_intent_resolves_to_route() -> None:
-    nav = Navigator(
-        routes=[PageRoute(builder=_FlagWidget)],
-        intent_routes={
+    nav = Navigator.intents(
+        initial_route=_PushIntent(label="home"),
+        routes={
             _PushIntent: lambda i: PageRoute(builder=lambda: _FlagWidget(label=i.label)),
         },
     )
@@ -55,7 +55,7 @@ def test_navigator_push_intent_resolves_to_route() -> None:
 
 
 def test_navigator_push_intent_raises_when_unregistered() -> None:
-    nav = Navigator(routes=[PageRoute(builder=_FlagWidget)])
+    nav = Navigator(PageRoute(builder=_FlagWidget))
 
     with pytest.raises(RuntimeError, match=r"No route is registered for intent"):
         nav.push(_PushIntent(label="x"))

--- a/tests/test_navigation_layer_composer.py
+++ b/tests/test_navigation_layer_composer.py
@@ -22,7 +22,7 @@ class _FlagWidget(Widget):
 
 def test_navigator_delegates_static_paint_to_layer_composer() -> None:
     spy = RecordingNavigationComposer()
-    nav = Navigator(routes=[PageRoute(builder=_FlagWidget)], layer_composer=spy)
+    nav = Navigator(PageRoute(builder=_FlagWidget), layer_composer=spy)
 
     nav.paint(canvas=None, x=0, y=0, width=100, height=100)
 
@@ -33,7 +33,7 @@ def test_navigator_delegates_static_paint_to_layer_composer() -> None:
 def test_navigator_delegates_transition_paint_to_layer_composer() -> None:
     spy = RecordingNavigationComposer()
     nav = Navigator(
-        routes=[PageRoute(builder=_FlagWidget, transition_spec=_AnimatedTransitionSpec())],
+        PageRoute(builder=_FlagWidget, transition_spec=_AnimatedTransitionSpec()),
         layer_composer=spy,
     )
     nav._app = object()  # type: ignore[attr-defined]

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -34,7 +34,7 @@ def test_navigator_push_sets_built_child() -> None:
 
 
 def test_navigator_pop_disposes_route_widget() -> None:
-    nav = Navigator([PageRoute(builder=_FlagWidget)])
+    nav = Navigator(PageRoute(builder=_FlagWidget))
 
     page2 = _FlagWidget()
     nav.push(page2)
@@ -45,7 +45,7 @@ def test_navigator_pop_disposes_route_widget() -> None:
 
 
 def test_navigator_pop_noop_when_single_route() -> None:
-    nav = Navigator([PageRoute(builder=_FlagWidget)])
+    nav = Navigator(PageRoute(builder=_FlagWidget))
     nav.rebuild()
     nav.pop()
     assert nav.can_pop() is False

--- a/tests/test_navigator_intent_and_back.py
+++ b/tests/test_navigator_intent_and_back.py
@@ -51,9 +51,9 @@ def test_navigator_of_not_found_raises() -> None:
 
 
 def test_navigator_push_intent_resolves_widget() -> None:
-    nav = Navigator(
-        routes=[PageRoute(builder=_FlagWidget)],
-        intent_routes={_GoIntent: lambda i: _FlagWidget()},
+    nav = Navigator.intents(
+        initial_route=_GoIntent("home"),
+        routes={_GoIntent: lambda i: _FlagWidget()},
     )
 
     nav.push(_GoIntent("x"))
@@ -61,9 +61,9 @@ def test_navigator_push_intent_resolves_widget() -> None:
 
 
 def test_navigator_push_intent_resolves_route() -> None:
-    nav = Navigator(
-        routes=[PageRoute(builder=_FlagWidget)],
-        intent_routes={_GoIntent: lambda i: Route(builder=_FlagWidget)},
+    nav = Navigator.intents(
+        initial_route=_GoIntent("home"),
+        routes={_GoIntent: lambda i: Route(builder=_FlagWidget)},
     )
 
     nav.push(_GoIntent("x"))
@@ -71,14 +71,14 @@ def test_navigator_push_intent_resolves_route() -> None:
 
 
 def test_navigator_push_unknown_intent_raises() -> None:
-    nav = Navigator(routes=[PageRoute(builder=_FlagWidget)])
+    nav = Navigator(PageRoute(builder=_FlagWidget))
 
     with pytest.raises(RuntimeError, match=r"No route is registered for intent: _GoIntent"):
         nav.push(_GoIntent("x"))
 
 
 def test_navigator_normalize_to_route_passes_route_through() -> None:
-    nav = Navigator(routes=[PageRoute(builder=_FlagWidget)])
+    nav = Navigator(PageRoute(builder=_FlagWidget))
     route = Route(builder=_FlagWidget)
 
     normalized = nav._normalize_to_route(route)
@@ -87,7 +87,7 @@ def test_navigator_normalize_to_route_passes_route_through() -> None:
 
 
 def test_navigator_normalize_to_route_wraps_widget() -> None:
-    nav = Navigator(routes=[PageRoute(builder=_FlagWidget)])
+    nav = Navigator(PageRoute(builder=_FlagWidget))
     widget = _FlagWidget()
 
     normalized = nav._normalize_to_route(widget)
@@ -98,9 +98,9 @@ def test_navigator_normalize_to_route_wraps_widget() -> None:
 
 
 def test_navigator_normalize_to_route_resolves_intent() -> None:
-    nav = Navigator(
-        routes=[PageRoute(builder=_FlagWidget)],
-        intent_routes={_GoIntent: lambda _i: _FlagWidget()},
+    nav = Navigator.intents(
+        initial_route=_GoIntent("home"),
+        routes={_GoIntent: lambda _i: _FlagWidget()},
     )
 
     normalized = nav._normalize_to_route(_GoIntent("x"))
@@ -112,7 +112,7 @@ def test_navigator_request_back_is_canceled_by_top_widget_handler() -> None:
     bottom = PageRoute(builder=_FlagWidget)
     top_widget = _BackCancelWidget()
 
-    nav = Navigator(routes=[bottom])
+    nav = Navigator(bottom)
     nav.push(top_widget)
 
     assert nav.can_pop() is True
@@ -124,7 +124,7 @@ def test_navigator_request_back_is_canceled_by_top_widget_handler() -> None:
 
 
 def test_navigator_push_widget_and_route_have_same_pop_behavior() -> None:
-    nav_widget = Navigator(routes=[PageRoute(builder=_FlagWidget)])
+    nav_widget = Navigator(PageRoute(builder=_FlagWidget))
     top_widget = _FlagWidget()
     nav_widget.push(top_widget)
 
@@ -133,7 +133,7 @@ def test_navigator_push_widget_and_route_have_same_pop_behavior() -> None:
     assert nav_widget.can_pop() is False
     assert top_widget.unmounted is True
 
-    nav_route = Navigator(routes=[PageRoute(builder=_FlagWidget)])
+    nav_route = Navigator(PageRoute(builder=_FlagWidget))
     top_route_widget = _FlagWidget()
     nav_route.push(Route(builder=lambda: top_route_widget))
 

--- a/tests/test_navigator_pop_transition_repeat.py
+++ b/tests/test_navigator_pop_transition_repeat.py
@@ -37,7 +37,7 @@ class _Handle:
 
 
 def test_pop_finishes_when_pop_transition_running() -> None:
-    nav = Navigator(routes=[PageRoute(builder=_FlagWidget), PageRoute(builder=_FlagWidget)])
+    nav = Navigator.routes([PageRoute(builder=_FlagWidget), PageRoute(builder=_FlagWidget)])
 
     # Simulate an in-flight pop transition without requiring App.animate.
     handle = _Handle()

--- a/tests/test_will_pop.py
+++ b/tests/test_will_pop.py
@@ -45,8 +45,8 @@ def test_navigator_pop_respects_will_pop_cancel() -> None:
         calls.append("called")
         return False
 
-    nav = Navigator(
-        routes=[
+    nav = Navigator.routes(
+        [
             PageRoute(builder=lambda: _FlagWidget(label="root")),
             PageRoute(builder=lambda: outgoing.modifier(will_pop(on_will_pop))),
         ]
@@ -68,8 +68,8 @@ def test_navigator_pop_respects_will_pop_allow() -> None:
     def on_will_pop() -> bool:
         return True
 
-    nav = Navigator(
-        routes=[
+    nav = Navigator.routes(
+        [
             PageRoute(builder=lambda: _FlagWidget(label="root")),
             PageRoute(builder=lambda: outgoing.modifier(will_pop(on_will_pop))),
         ]
@@ -105,8 +105,8 @@ def test_navigator_pop_calls_will_pop_inside_build() -> None:
             return Widget().modifier(will_pop(on_will_pop))
 
     outgoing = Outgoing()
-    nav = Navigator(
-        routes=[
+    nav = Navigator.routes(
+        [
             PageRoute(builder=lambda: _FlagWidget(label="root")),
             PageRoute(builder=lambda: outgoing),
         ]


### PR DESCRIPTION
## Summary

Resolves #55.

Refactors the `Navigator` and `App` initialization API for better intuitiveness and ergonomics. Removes the leaky `routes=[PageRoute(builder=...)]` boilerplate and consolidates navigation variants under `Navigator` factories, so `App` keeps a minimal surface.

## Changes

### Navigator
- **Default constructor**: `Navigator(screen)` — start from a single screen (`Route` or `Widget`). Most common case.
- **`Navigator.routes([...])`**: factory for a pre-populated stack (deep linking, state restoration).
- **`Navigator.intents(initial_route=..., routes={...})`**: factory for Intent-based routing.
- Removed the former `Navigator(routes=[...], intent_routes={...})` keyword form.

### App / MaterialApp
- Removed `App.navigation(...)` / `MaterialApp.navigation(...)` classmethods.
- `App(content)` now accepts either:
  - a `Widget` — wrapped in an implicit root `Navigator` so `Navigator.root().push(...)` works out of the box, or
  - a `Navigator` (e.g. `Navigator.routes(...)` / `Navigator.intents(...)`) — used directly as the root.
- Introduced `App._build_default_navigator()` hook; `MaterialApp` overrides it to return a `MaterialNavigator` so the implicit default uses Material page transitions.
- Dropped the `navigator_factory` parameter; pass a `Navigator` via content instead.

### Docs / samples / tests
- Updated `docs/design/NAVIGATION.md`, `docs/design/OVERLAY.md`, and relevant `docs/guide/*.md`.
- Migrated all samples under `src/samples/` to the new API.
- Updated all affected tests.

## Usage examples

```python
# 1. Single-screen start (most common)
App(HomeScreen())

# 2. Pre-populated stack
App(Navigator.routes([HomeScreen(), DetailsScreen()]))

# 3. Intent-based routing
App(
    Navigator.intents(
        initial_route=HomeIntent(),
        routes={
            HomeIntent: lambda _: HomeScreen(),
            DetailsIntent: lambda intent: DetailsScreen(intent),
        },
    )
)
```

## Breaking changes

Yes. The following are removed:
- `Navigator(routes=[...], intent_routes={...})` keyword form
- `App.navigation(...)` / `MaterialApp.navigation(...)`
- `navigator_factory` parameter on `App`

Migration:

| Before | After |
| --- | --- |
| `Navigator(routes=[PageRoute(builder=lambda: Screen())])` | `Navigator(Screen())` |
| `Navigator(routes=[...])` | `Navigator.routes([...])` |
| `App.navigation(routes={...}, initial_route=...)` | `App(Navigator.intents(initial_route=..., routes={...}))` |

## Verification
- `uv run pytest` — 1166 passed
- `uv run mypy` — Success (498 source files)
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` — clean