### PR TITLE
refactor(card,textfield)!: unify Card/TextField on style-driven preset API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ For example, a login form can be written like this:
 login_form = Column(
     [
         # Username and Password fields
-        OutlinedTextField(
+        TextField(
             value="",
             label="Username",
             width=300,
+            style=TextFieldStyle.outlined(),
         ),
-        OutlinedTextField(
+        TextField(
             value="",
             label="Password",
             width=300,
+            style=TextFieldStyle.outlined(),
         ),
         # Login Button
         FilledButton(

--- a/docs/design/TEXT_EDITING.md
+++ b/docs/design/TEXT_EDITING.md
@@ -33,8 +33,8 @@ The `TextField` widget follows the Material Design 3 specification and is struct
   - Defines abstract/hook methods for variant-specific rendering (e.g., `_draw_container`).
 
 - **Concrete Classes**:
-  - **`FilledTextField`**: Implements the M3 "Filled" style with a background container and bottom indicator.
-  - **`OutlinedTextField`**: Implements the M3 "Outlined" style with a border and transparent background.
+  - **`TextField`**: Implements the M3 "Filled" style with a background container and bottom indicator.
+  - **`TextField`**: Implements the M3 "Outlined" style with a border and transparent background.
 
 - **Styling (`TextFieldStyle`)**:
   - An immutable dataclass (`frozen=True`) defining all visual properties (colors, dimensions, fonts).

--- a/docs/guide/layout_alignment.md
+++ b/docs/guide/layout_alignment.md
@@ -33,8 +33,8 @@ alignments = [
 ]
 
 
-def _tile(alignment: str) -> md.FilledCard:
-    return md.FilledCard(
+def _tile(alignment: str) -> md.Card:
+    return md.Card(
         md.Text(alignment, padding=8),
         width=160,
         height=96,
@@ -95,8 +95,8 @@ def _demo_row(alignment: str) -> nv.Row:
     )
 
 
-def _tile(label: str) -> md.FilledCard:
-    return md.FilledCard(
+def _tile(label: str) -> md.Card:
+    return md.Card(
         md.Text(label),
         width=56,
         height=40,
@@ -108,7 +108,7 @@ nv.Column(
     gap=12,
     cross_alignment="start",
     children=[
-        md.OutlinedCard(
+        md.Card(
             nv.Column(
                 children=[
                     md.Text(a),
@@ -118,7 +118,8 @@ nv.Column(
                 cross_alignment="start",
                 width="100%",
             ),
-            padding=12,
+            padding=12,,
+            style=md.CardStyle.outlined(),
         )
         for a in main_alignments
     ],
@@ -152,8 +153,8 @@ def _demo_row(alignment: str) -> nv.Row:
     )
 
 
-def _bar(label: str, h: int) -> md.FilledCard:
-    return md.FilledCard(
+def _bar(label: str, h: int) -> md.Card:
+    return md.Card(
         md.Text(label),
         width=72,
         height=h,
@@ -161,15 +162,16 @@ def _bar(label: str, h: int) -> md.FilledCard:
     )
 
 
-def _panel(alignment: str) -> md.OutlinedCard:
-    return md.OutlinedCard(
+def _panel(alignment: str) -> md.Card:
+    return md.Card(
         nv.Column(
             children=[md.Text(alignment), _demo_row(alignment)],
             gap=8,
             cross_alignment="start",
             width="100%",
         ),
-        padding=12,
+        padding=12,,
+        style=md.CardStyle.outlined(),
     )
 
 
@@ -221,8 +223,8 @@ def _demo_column(alignment: str) -> nv.Column:
     )
 
 
-def _tile(label: str, *, width: int = 72, height: int = 32) -> md.FilledCard:
-    return md.FilledCard(
+def _tile(label: str, *, width: int = 72, height: int = 32) -> md.Card:
+    return md.Card(
         md.Text(label),
         width=width,
         height=height,
@@ -230,8 +232,8 @@ def _tile(label: str, *, width: int = 72, height: int = 32) -> md.FilledCard:
     )
 
 
-def _panel(alignment: str) -> md.OutlinedCard:
-    return md.OutlinedCard(
+def _panel(alignment: str) -> md.Card:
+    return md.Card(
         nv.Column(
             children=[md.Text(alignment), _demo_column(alignment)],
             gap=8,
@@ -239,7 +241,8 @@ def _panel(alignment: str) -> md.OutlinedCard:
             width="100%",
         ),
         width=150,
-        padding=12,
+        padding=12,,
+        style=md.CardStyle.outlined(),
     )
 
 
@@ -284,8 +287,8 @@ def _demo_column(alignment: str) -> nv.Column:
     )
 
 
-def _tile(label: str, *, width: int = 72, height: int = 32) -> md.FilledCard:
-    return md.FilledCard(
+def _tile(label: str, *, width: int = 72, height: int = 32) -> md.Card:
+    return md.Card(
         md.Text(label),
         width=width,
         height=height,
@@ -293,8 +296,8 @@ def _tile(label: str, *, width: int = 72, height: int = 32) -> md.FilledCard:
     )
 
 
-def _panel(alignment: str) -> md.OutlinedCard:
-    return md.OutlinedCard(
+def _panel(alignment: str) -> md.Card:
+    return md.Card(
         nv.Column(
             children=[md.Text(alignment), _demo_column(alignment)],
             gap=8,
@@ -302,7 +305,8 @@ def _panel(alignment: str) -> md.OutlinedCard:
             width="100%",
         ),
         width=200,
-        padding=12,
+        padding=12,,
+        style=md.CardStyle.outlined(),
     )
 
 

--- a/docs/guide/layout_basics.md
+++ b/docs/guide/layout_basics.md
@@ -18,8 +18,8 @@ import nuiitivet.material as md
 
 content = nv.Column(
     children=[
-        md.FilledTextField(label="Email"),
-        md.FilledTextField(label="Password"),
+        md.TextField(label="Email"),
+        md.TextField(label="Password"),
         md.Button("Login", style=md.ButtonStyle.filled()),
     ],
     gap=16,
@@ -67,14 +67,14 @@ form = nv.Column(
         # Row 1: Name (Horizontal)
         nv.Row(
             children=[
-                md.FilledTextField(label="First Name"),
-                md.FilledTextField(label="Last Name"),
+                md.TextField(label="First Name"),
+                md.TextField(label="Last Name"),
             ],
             gap=8,
         ),
 
         # Row 2: Address
-        md.FilledTextField(label="Address", width=nv.Sizing.flex(1)),
+        md.TextField(label="Address", width=nv.Sizing.flex(1)),
 
         # Row 3: Buttons (Horizontal)
         nv.Row(

--- a/docs/guide/layout_extras.md
+++ b/docs/guide/layout_extras.md
@@ -24,17 +24,17 @@ nv.Stack(
     height=200,
     alignment="center",  # Default alignment position
     children=[
-        md.FilledCard(
+        md.Card(
             md.Text(""),
             width="100%",
             height="100%",
         ).modifier(mod.background("#BBDEFB")),
-        md.FilledCard(
+        md.Card(
             md.Text(""),
             width="80%",
             height="80%",
         ).modifier(mod.background("#90CAF9")),
-        md.FilledCard(
+        md.Card(
             md.Text("Overlay Text"),
             width="60%",
             height="60%",
@@ -123,7 +123,7 @@ nv.Flow(
     cross_gap=8,
     padding=8,
     children=[
-        md.OutlinedCard(md.Text(tag)) for tag in tags
+        md.Card(md.Text(tag), style=md.CardStyle.outlined()) for tag in tags
     ],
 )
 ```
@@ -148,7 +148,7 @@ nv.UniformFlow(
     padding=8,
     aspect_ratio=1.0,
     children=[
-        md.FilledCard(md.Text(t), alignment="center", padding=12)
+        md.Card(md.Text(t), alignment="center", padding=12)
         for t in tiles
     ],
 )

--- a/docs/guide/layout_grid.md
+++ b/docs/guide/layout_grid.md
@@ -51,8 +51,8 @@ nv.Grid(
 )
 
 # Helper for creating cards
-def _card(label: str, width="100%", height="100%") -> md.FilledCard:
-    return md.FilledCard(
+def _card(label: str, width="100%", height="100%") -> md.Card:
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/docs/guide/layout_overflow.md
+++ b/docs/guide/layout_overflow.md
@@ -16,16 +16,17 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 # Parent frame (150x150)
-md.OutlinedCard(
+md.Card(
     width=150,
     height=150,
     padding=10,
     # Child is larger (200x200) -> Displayed as overflowing
-    child=md.FilledCard(
+    child=md.Card(
         width=200,
         height=200,
         child=md.Text("Overflow Content"),
-    ),
+    ),,
+    style=md.CardStyle.outlined(),
 )
 ```
 
@@ -42,15 +43,16 @@ import nuiitivet as nv
 import nuiitivet.material as md
 import nuiitivet.modifiers as mod
 
-md.OutlinedCard(
+md.Card(
     width=150,
     height=150,
     padding=10,
-    child=md.FilledCard(
+    child=md.Card(
         width=200,
         height=200,
         child=md.Text("Clipped Content"),
-    ),
+    ),,
+    style=md.CardStyle.outlined(),
 ).modifier(mod.clip())  # Parts sticking out of the frame are not drawn
 ```
 

--- a/docs/guide/layout_sizing.md
+++ b/docs/guide/layout_sizing.md
@@ -20,7 +20,7 @@ Specify a number like `100`.
 import nuiitivet as nv
 import nuiitivet.material as md
 
-md.FilledCard(
+md.Card(
     width=200,   # Fix width to 200px
     height=100,  # Fix height to 100px
     child=md.Text("Fixed Size Box"),
@@ -38,7 +38,7 @@ Specify `"auto"`.
 
 ```python
 # The box grows to fit the text size inside
-md.FilledCard(
+md.Card(
     width="auto",
     height="auto",
     child=md.Text("This box fits the content"),
@@ -58,7 +58,7 @@ Since it is a ratio, it is not a problem if the total exceeds 100%.
 
 ```python
 # Expands to full width (100%)
-md.FilledCard(
+md.Card(
     width="100%", 
     child=md.Text("Full Width Box"),
     padding=16,

--- a/docs/guide/modifier_others.md
+++ b/docs/guide/modifier_others.md
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from nuiitivet.material.buttons import Button
 from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material import Overlay
-from nuiitivet.material.text_fields import OutlinedTextField
+from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
 from nuiitivet.navigation import Navigator, PageRoute
 from nuiitivet.observable import Observable
@@ -110,7 +110,7 @@ class EditScreen(nv.ComposableWidget):
             child=nv.Column(
                 children=[
                     md.Text("Edit text. Back/Esc asks confirmation when unsaved."),
-                    OutlinedTextField.two_way(
+                    TextField.two_way(
                         self.text,
                         width=420,
                         height=52,

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
     from .styles.button_style import ButtonStyle, IconButtonStyle, IconToggleButtonStyle
     from .styles.button_size import ButtonSize
     from .styles.toggle_button_style import ToggleButtonStyle
-    from .card import Card, ElevatedCard, FilledCard, OutlinedCard
+    from .card import Card
+    from .styles.card_style import CardStyle
     from .chip import AssistChip, FilterChip, InputChip, SuggestionChip
     from .dialogs import AlertDialog
     from .loading_indicator import LoadingIndicator
@@ -35,7 +36,8 @@ if TYPE_CHECKING:
     from .selection_controls import Checkbox, RadioButton, RadioGroup, Switch
     from .slider import CenteredSlider, Orientation, RangeSlider, Slider
     from .symbols import Symbol, Symbols
-    from .text_fields import FilledTextField, OutlinedTextField, TextField
+    from .text_fields import TextField
+    from .styles.text_field_style import TextFieldStyle
     from .text import Text
     from .overlay import MaterialOverlay
     from .overlay import MaterialOverlay as Overlay
@@ -82,9 +84,7 @@ __all__ = [
     "RangeSlider",
     "Orientation",
     "Card",
-    "ElevatedCard",
-    "FilledCard",
-    "OutlinedCard",
+    "CardStyle",
     "AssistChip",
     "FilterChip",
     "InputChip",
@@ -100,8 +100,7 @@ __all__ = [
     "IconToggleButtonStyle",
     "ButtonSize",
     "TextField",
-    "FilledTextField",
-    "OutlinedTextField",
+    "TextFieldStyle",
     "NavigationRail",
     "RailItem",
     "MaterialOverlay",
@@ -166,9 +165,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "RangeSlider": ("slider", "RangeSlider"),
     "Orientation": ("slider", "Orientation"),
     "Card": ("card", "Card"),
-    "ElevatedCard": ("card", "ElevatedCard"),
-    "FilledCard": ("card", "FilledCard"),
-    "OutlinedCard": ("card", "OutlinedCard"),
+    "CardStyle": ("styles.card_style", "CardStyle"),
     "AssistChip": ("chip", "AssistChip"),
     "FilterChip": ("chip", "FilterChip"),
     "InputChip": ("chip", "InputChip"),
@@ -184,8 +181,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "ToggleButtonStyle": ("styles.toggle_button_style", "ToggleButtonStyle"),
     "ButtonSize": ("styles.button_size", "ButtonSize"),
     "TextField": ("text_fields", "TextField"),
-    "FilledTextField": ("text_fields", "FilledTextField"),
-    "OutlinedTextField": ("text_fields", "OutlinedTextField"),
+    "TextFieldStyle": ("styles.text_field_style", "TextFieldStyle"),
     "NavigationRail": ("navigation_rail", "NavigationRail"),
     "RailItem": ("navigation_rail", "RailItem"),
     "MaterialOverlay": ("overlay", "MaterialOverlay"),

--- a/src/nuiitivet/material/card.py
+++ b/src/nuiitivet/material/card.py
@@ -1,4 +1,11 @@
-"""Material Design Card widgets."""
+"""Material Design Card widget.
+
+The :class:`Card` widget is unified across all visual variants. The visual
+variant (filled, outlined, elevated) is expressed entirely through the
+``style`` argument. Use :class:`CardStyle` factory methods to obtain
+variant presets: ``CardStyle.filled()``, ``CardStyle.outlined()``,
+``CardStyle.elevated()``.
+"""
 
 from __future__ import annotations
 
@@ -21,18 +28,26 @@ _logger = logging.getLogger(__name__)
 
 
 class Card(ComposableWidget, Box):
-    """Base class for Material Design cards."""
+    """Unified Material Design 3 card.
+
+    The visual variant (filled, outlined, elevated) is expressed entirely
+    through the ``style`` argument, which accepts any :class:`CardStyle`
+    instance. Use the :class:`CardStyle` factory methods to obtain
+    variant presets: ``CardStyle.filled()``, ``CardStyle.outlined()``,
+    ``CardStyle.elevated()``.
+
+    When ``style`` is not provided, the theme's filled card style is used
+    as the default.
+    """
 
     @property
     def style(self) -> CardStyle:
-        if hasattr(self, "_user_style") and self._user_style is not None:
+        if self._user_style is not None:
             return self._user_style
 
         from nuiitivet.theme.manager import manager
-        from nuiitivet.material.styles.card_style import CardStyle
 
-        variant = getattr(self, "_variant", "filled")
-        return CardStyle.from_theme(manager.current, variant)
+        return CardStyle.from_theme(manager.current)
 
     def __init__(
         self,
@@ -52,13 +67,12 @@ class Card(ComposableWidget, Box):
             height: Height specification.
             padding: Padding around the content.
             alignment: Alignment of the content.
-            style: Optional CardStyle override.
+            style: Visual style preset. Defaults to the theme's filled card
+                style. Use :meth:`CardStyle.filled`, :meth:`CardStyle.outlined`,
+                or :meth:`CardStyle.elevated` for the standard M3 variants.
         """
         self._child_spec: ChildSpec = child
-        self._user_style = style
-
-        if not hasattr(self, "_variant"):
-            self._variant = "filled"
+        self._user_style: Optional[CardStyle] = style
 
         # Resolve style
         final_style = self.style
@@ -168,105 +182,3 @@ class Card(ComposableWidget, Box):
     def _invalidate_content_scope(self) -> None:
         if self._content_scope_id:
             self.invalidate_scope_id(self._content_scope_id)
-
-
-class ElevatedCard(Card):
-    """Elevated Card implementation."""
-
-    def __init__(
-        self,
-        child: ChildSpec,
-        *,
-        width: SizingLike = None,
-        height: SizingLike = None,
-        padding: PaddingLike = 0,
-        alignment: AlignmentLike = "start",
-        style: Optional[CardStyle] = None,
-    ) -> None:
-        """Initialize ElevatedCard.
-
-        Args:
-            child: The child widget or factory.
-            width: Width specification.
-            height: Height specification.
-            padding: Padding around the content.
-            alignment: Alignment of the content.
-            style: Optional CardStyle override.
-        """
-        self._variant = "elevated"
-        super().__init__(
-            child=child,
-            width=width,
-            height=height,
-            padding=padding,
-            alignment=alignment,
-            style=style,
-        )
-
-
-class FilledCard(Card):
-    """Filled Card implementation."""
-
-    def __init__(
-        self,
-        child: ChildSpec,
-        *,
-        width: SizingLike = None,
-        height: SizingLike = None,
-        padding: PaddingLike = 0,
-        alignment: AlignmentLike = "start",
-        style: Optional[CardStyle] = None,
-    ) -> None:
-        """Initialize FilledCard.
-
-        Args:
-            child: The child widget or factory.
-            width: Width specification.
-            height: Height specification.
-            padding: Padding around the content.
-            alignment: Alignment of the content.
-            style: Optional CardStyle override.
-        """
-        self._variant = "filled"
-        super().__init__(
-            child=child,
-            width=width,
-            height=height,
-            padding=padding,
-            alignment=alignment,
-            style=style,
-        )
-
-
-class OutlinedCard(Card):
-    """Outlined Card implementation."""
-
-    def __init__(
-        self,
-        child: ChildSpec,
-        *,
-        width: SizingLike = None,
-        height: SizingLike = None,
-        padding: PaddingLike = 0,
-        alignment: AlignmentLike = "start",
-        style: Optional[CardStyle] = None,
-    ) -> None:
-        """Initialize OutlinedCard.
-
-        Args:
-            child: The child widget or factory.
-            width: Width specification.
-            height: Height specification.
-            padding: Padding around the content.
-            alignment: Alignment of the content.
-            style: Optional CardStyle override.
-        """
-        self._variant = "outlined"
-        super().__init__(
-            child=child,
-            width=width,
-            height=height,
-            padding=padding,
-            alignment=alignment,
-            style=style,
-        )

--- a/src/nuiitivet/material/styles/card_style.py
+++ b/src/nuiitivet/material/styles/card_style.py
@@ -44,7 +44,7 @@ class CardStyle:
 
     @classmethod
     def elevated(cls) -> "CardStyle":
-        """Create a default style for ElevatedCard."""
+        """Create a default style for an elevated card."""
         return cls(
             background=ColorRole.SURFACE,
             elevation=1.0,
@@ -54,7 +54,7 @@ class CardStyle:
 
     @classmethod
     def filled(cls) -> "CardStyle":
-        """Create a default style for FilledCard."""
+        """Create a default style for a filled card."""
         return cls(
             background=ColorRole.SURFACE_CONTAINER_HIGHEST,
             elevation=0.0,
@@ -63,7 +63,7 @@ class CardStyle:
 
     @classmethod
     def outlined(cls) -> "CardStyle":
-        """Create a default style for OutlinedCard."""
+        """Create a default style for an outlined card."""
         return cls(
             background=ColorRole.SURFACE,
             elevation=0.0,
@@ -73,26 +73,15 @@ class CardStyle:
         )
 
     @classmethod
-    def from_theme(cls, theme: "Theme", variant: str = "filled") -> "CardStyle":
+    def from_theme(cls, theme: "Theme") -> "CardStyle":
+        """Resolve the default :class:`CardStyle` for the given theme.
+
+        Returns the theme's filled card style if a Material theme extension
+        is present, otherwise a fresh :meth:`filled` preset.
+        """
         from nuiitivet.material.theme.theme_data import MaterialThemeData
 
         theme_data = theme.extension(MaterialThemeData)
-        v = (variant or "").lower()
-
         if theme_data:
-            if v == "filled":
-                return theme_data.filled_card_style
-            if v == "outlined":
-                return theme_data.outlined_card_style
-            if v == "elevated":
-                return theme_data.elevated_card_style
-
-        # Fallback
-        if v == "filled":
-            return cls.filled()
-        if v == "outlined":
-            return cls.outlined()
-        if v == "elevated":
-            return cls.elevated()
-
+            return theme_data.filled_card_style
         return cls.filled()

--- a/src/nuiitivet/material/styles/text_field_style.py
+++ b/src/nuiitivet/material/styles/text_field_style.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Tuple, TYPE_CHECKING
+from typing import Literal, Tuple, TYPE_CHECKING
 
 from ..theme.color_role import ColorRole
 from nuiitivet.theme.types import ColorSpec
@@ -10,9 +10,21 @@ if TYPE_CHECKING:
     from ...theme import Theme
 
 
+TextFieldMode = Literal["filled", "outlined"]
+
+
 @dataclass(frozen=True)
 class TextFieldStyle:
-    """Style configuration for TextField (M3-compliant)."""
+    """Style configuration for :class:`TextField` (M3-compliant).
+
+    The visual variant is captured by the :attr:`mode` field: ``"filled"``
+    draws an underline indicator with top-rounded container corners while
+    ``"outlined"`` draws a full rectangular border. Use the :meth:`filled`
+    and :meth:`outlined` factory methods to obtain the standard presets.
+    """
+
+    # Visual mode (drives container shape and indicator drawing)
+    mode: TextFieldMode = "filled"
 
     # Container
     container_color: ColorSpec = ColorRole.SURFACE_CONTAINER_HIGHEST
@@ -51,6 +63,7 @@ class TextFieldStyle:
     def filled(cls) -> "TextFieldStyle":
         """Default M3 Filled TextField style."""
         return cls(
+            mode="filled",
             container_color=ColorRole.SURFACE_CONTAINER_HIGHEST,
             indicator_color=ColorRole.ON_SURFACE_VARIANT,
             border_radius=4.0,
@@ -61,6 +74,7 @@ class TextFieldStyle:
     def outlined(cls) -> "TextFieldStyle":
         """Default M3 Outlined TextField style."""
         return cls(
+            mode="outlined",
             container_color=(0, 0, 0, 0),  # Transparent
             indicator_color=ColorRole.OUTLINE,
             border_radius=4.0,
@@ -68,22 +82,15 @@ class TextFieldStyle:
         )
 
     @classmethod
-    def from_theme(cls, theme: "Theme", variant: str = "filled") -> "TextFieldStyle":
+    def from_theme(cls, theme: "Theme") -> "TextFieldStyle":
+        """Resolve the default :class:`TextFieldStyle` for the given theme.
+
+        Returns the theme's filled text field style if a Material theme
+        extension is present, otherwise a fresh :meth:`filled` preset.
+        """
         from nuiitivet.material.theme.theme_data import MaterialThemeData
 
         theme_data = theme.extension(MaterialThemeData)
-        v = (variant or "").lower()
-
         if theme_data:
-            if v == "filled":
-                return theme_data.filled_text_field_style
-            if v == "outlined":
-                return theme_data.outlined_text_field_style
-
-        # Fallback
-        if v == "filled":
-            return cls.filled()
-        if v == "outlined":
-            return cls.outlined()
-
+            return theme_data.filled_text_field_style
         return cls.filled()

--- a/src/nuiitivet/material/text_fields.py
+++ b/src/nuiitivet/material/text_fields.py
@@ -1,9 +1,9 @@
-"""Material Design 3 Text Fields.
+"""Material Design 3 Text Field.
 
-This module contains the implementation of Material Design 3 text fields:
-- TextField (base class)
-- FilledTextField
-- OutlinedTextField
+This module provides the unified :class:`TextField` widget. The visual
+variant (filled, outlined) is expressed entirely through the ``style``
+argument; use :meth:`TextFieldStyle.filled` or :meth:`TextFieldStyle.outlined`
+to obtain the standard M3 presets.
 """
 
 from __future__ import annotations
@@ -248,9 +248,6 @@ class TextField(InteractiveWidget):
             raise ValueError("on_tap_trailing_icon requires trailing_icon to be provided")
 
         self._user_style = style
-        # Default variant for base class is filled
-        if not hasattr(self, "_variant"):
-            self._variant = "filled"
 
         self._on_change = on_change
 
@@ -325,7 +322,7 @@ class TextField(InteractiveWidget):
     def corner_radii_pixels(self, width: float, height: float) -> Tuple[float, float, float, float]:
         style = self.style
         r = style.border_radius
-        if self._variant == "filled":
+        if style.mode == "filled":
             return (r, r, 0, 0)
         return (r, r, r, r)
 
@@ -434,14 +431,13 @@ class TextField(InteractiveWidget):
 
     @property
     def style(self) -> TextFieldStyle:
-        if hasattr(self, "_user_style") and self._user_style is not None:
+        if self._user_style is not None:
             return self._user_style
 
         from nuiitivet.theme.manager import manager
         from nuiitivet.material.styles.text_field_style import TextFieldStyle
 
-        variant = getattr(self, "_variant", "filled")
-        return TextFieldStyle.from_theme(manager.current, variant)
+        return TextFieldStyle.from_theme(manager.current)
 
     @property
     def value(self) -> str:
@@ -723,7 +719,28 @@ class TextField(InteractiveWidget):
         self._editable.paint(canvas, cx, cy, w, h)
 
     def _draw_container(self, canvas, cx, cy, cw, ch):
-        pass
+        style = self.style
+
+        container_color = resolve_color_to_rgba(style.container_color, theme=theme_manager.current)
+        paint_container = make_paint(color=container_color)
+        rect = make_rect(cx, cy, cw, ch)
+
+        indicator_color = self._anim_indicator_color.value
+        indicator_width = self._anim_indicator_width.value
+
+        if style.mode == "filled":
+            if rect is not None and paint_container is not None:
+                draw_round_rect(canvas, rect, [style.border_radius, style.border_radius, 0, 0], paint_container)
+            paint_indicator = make_paint(color=indicator_color, style="stroke", stroke_width=indicator_width)
+            canvas.drawLine(cx, cy + ch, cx + cw, cy + ch, paint_indicator)
+            return
+
+        # outlined
+        if rect is not None and paint_container is not None:
+            draw_round_rect(canvas, rect, style.border_radius, paint_container)
+        paint_border = make_paint(color=indicator_color, style="stroke", stroke_width=indicator_width)
+        if rect is not None and paint_border is not None:
+            draw_round_rect(canvas, rect, style.border_radius, paint_border)
 
     def _draw_label(self, canvas, text_x, text_y, text_h, cy):
         if not self.label:
@@ -790,180 +807,3 @@ class TextField(InteractiveWidget):
 
     def _get_from_clipboard(self) -> str:
         return get_system_clipboard().get_text() or ""
-
-
-class FilledTextField(TextField):
-    """M3 Filled TextField.
-
-    Note:
-        The constructor `FilledTextField(value=observable)` establishes a **one-way binding**.
-        Changes in the observable will update the text field, but user input will NOT
-        update the observable automatically.
-
-        For **two-way binding**, use the `FilledTextField.two_way(observable)` factory method.
-    """
-
-    def __init__(
-        self,
-        value: Union[str, ObservableProtocol[str]] = "",
-        on_change: Optional[Callable[[str], None]] = None,
-        *,
-        label: str | ReadOnlyObservableProtocol[str] | None = None,
-        leading_icon: Symbol | str | ReadOnlyObservableProtocol[Symbol] | ReadOnlyObservableProtocol[str] | None = None,
-        on_tap_leading_icon: Optional[Callable[[], None]] = None,
-        trailing_icon: (
-            Symbol | str | ReadOnlyObservableProtocol[Symbol] | ReadOnlyObservableProtocol[str] | None
-        ) = None,
-        on_tap_trailing_icon: Optional[Callable[[], None]] = None,
-        obscure_text: bool = False,
-        supporting_text: str | ReadOnlyObservableProtocol[str | None] | None = None,
-        is_error: bool | ObservableProtocol[bool] | None = None,
-        error_text: str | ReadOnlyObservableProtocol[str | None] | None = None,
-        disabled: bool | ObservableProtocol[bool] = False,
-        width: SizingLike = 200,
-        height: SizingLike = None,
-        padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
-        style: Optional[TextFieldStyle] = None,
-    ):
-        """Initialize FilledTextField.
-
-        Args:
-            value: Initial text value or observable.
-            on_change: Callback when value changes.
-            label: Floating label text.
-            leading_icon: Icon displayed before the text.
-            on_tap_leading_icon: Callback invoked when the leading icon is tapped.
-            trailing_icon: Icon displayed after the text.
-            on_tap_trailing_icon: Callback invoked when the trailing icon is tapped.
-            obscure_text: Whether to mask text display (password-style).
-            supporting_text: Supporting text displayed below the field.
-            is_error: Whether to use error colors for the field.
-            error_text: Deprecated alias for supporting_text.
-            disabled: Whether the text field is disabled.
-            width: Width specification.
-            height: Height specification.
-            padding: Padding around the text field.
-            style: Custom style configuration.
-        """
-        self._variant = "filled"
-        super().__init__(
-            value=value,
-            on_change=on_change,
-            label=label,
-            leading_icon=leading_icon,
-            on_tap_leading_icon=on_tap_leading_icon,
-            trailing_icon=trailing_icon,
-            on_tap_trailing_icon=on_tap_trailing_icon,
-            obscure_text=obscure_text,
-            supporting_text=supporting_text,
-            is_error=is_error,
-            error_text=error_text,
-            disabled=disabled,
-            width=width,
-            height=height,
-            padding=padding,
-            style=style,
-        )
-
-    def _draw_container(self, canvas, cx, cy, cw, ch):
-        style = self.style
-
-        container_color = resolve_color_to_rgba(style.container_color, theme=theme_manager.current)
-        paint_container = make_paint(color=container_color)
-        rect = make_rect(cx, cy, cw, ch)
-        if rect is not None and paint_container is not None:
-            draw_round_rect(canvas, rect, [style.border_radius, style.border_radius, 0, 0], paint_container)
-
-        indicator_color = self._anim_indicator_color.value
-        indicator_width = self._anim_indicator_width.value
-        paint_indicator = make_paint(color=indicator_color, style="stroke", stroke_width=indicator_width)
-        canvas.drawLine(cx, cy + ch, cx + cw, cy + ch, paint_indicator)
-
-
-class OutlinedTextField(TextField):
-    """M3 Outlined TextField.
-
-    Note:
-        The constructor `OutlinedTextField(value=observable)` establishes a **one-way binding**.
-        Changes in the observable will update the text field, but user input will NOT
-        update the observable automatically.
-
-        For **two-way binding**, use the `OutlinedTextField.two_way(observable)` factory method.
-    """
-
-    def __init__(
-        self,
-        value: Union[str, ObservableProtocol[str]] = "",
-        on_change: Optional[Callable[[str], None]] = None,
-        *,
-        label: str | ReadOnlyObservableProtocol[str] | None = None,
-        leading_icon: Symbol | str | ReadOnlyObservableProtocol[Symbol] | ReadOnlyObservableProtocol[str] | None = None,
-        on_tap_leading_icon: Optional[Callable[[], None]] = None,
-        trailing_icon: (
-            Symbol | str | ReadOnlyObservableProtocol[Symbol] | ReadOnlyObservableProtocol[str] | None
-        ) = None,
-        on_tap_trailing_icon: Optional[Callable[[], None]] = None,
-        obscure_text: bool = False,
-        supporting_text: str | ReadOnlyObservableProtocol[str | None] | None = None,
-        is_error: bool | ObservableProtocol[bool] | None = None,
-        error_text: str | ReadOnlyObservableProtocol[str | None] | None = None,
-        disabled: bool | ObservableProtocol[bool] = False,
-        width: SizingLike = 200,
-        height: SizingLike = None,
-        padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
-        style: Optional[TextFieldStyle] = None,
-    ):
-        """Initialize OutlinedTextField.
-
-        Args:
-            value: Initial text value or observable.
-            on_change: Callback when value changes.
-            label: Floating label text.
-            leading_icon: Icon displayed before the text.
-            on_tap_leading_icon: Callback invoked when the leading icon is tapped.
-            trailing_icon: Icon displayed after the text.
-            on_tap_trailing_icon: Callback invoked when the trailing icon is tapped.
-            obscure_text: Whether to mask text display (password-style).
-            supporting_text: Supporting text displayed below the field.
-            is_error: Whether to use error colors for the field.
-            error_text: Deprecated alias for supporting_text.
-            disabled: Whether the text field is disabled.
-            width: Width specification.
-            height: Height specification.
-            padding: Padding around the text field.
-            style: Custom style configuration.
-        """
-        self._variant = "outlined"
-        super().__init__(
-            value=value,
-            on_change=on_change,
-            label=label,
-            leading_icon=leading_icon,
-            on_tap_leading_icon=on_tap_leading_icon,
-            trailing_icon=trailing_icon,
-            on_tap_trailing_icon=on_tap_trailing_icon,
-            obscure_text=obscure_text,
-            supporting_text=supporting_text,
-            is_error=is_error,
-            error_text=error_text,
-            disabled=disabled,
-            width=width,
-            height=height,
-            padding=padding,
-            style=style,
-        )
-
-    def _draw_container(self, canvas, cx, cy, cw, ch):
-        style = self.style
-
-        container_color = resolve_color_to_rgba(style.container_color, theme=theme_manager.current)
-        paint_container = make_paint(color=container_color)
-        rect = make_rect(cx, cy, cw, ch)
-        if rect is not None and paint_container is not None:
-            draw_round_rect(canvas, rect, style.border_radius, paint_container)
-
-        indicator_color = self._anim_indicator_color.value
-        indicator_width = self._anim_indicator_width.value
-        paint_border = make_paint(color=indicator_color, style="stroke", stroke_width=indicator_width)
-        if rect is not None and paint_border is not None:
-            draw_round_rect(canvas, rect, style.border_radius, paint_border)

--- a/src/samples/async_demo.py
+++ b/src/samples/async_demo.py
@@ -92,7 +92,7 @@ class AsyncDemoApp(nv.ComposableWidget):
         )
 
     def build(self) -> nv.Widget:
-        status_card = md.FilledCard(
+        status_card = md.Card(
             padding=16,
             child=nv.Column(
                 gap=8,

--- a/src/samples/deck_demo.py
+++ b/src/samples/deck_demo.py
@@ -4,17 +4,18 @@ from enum import IntEnum
 
 from nuiitivet.material import App
 from nuiitivet.material import Text
-from nuiitivet.material.text_fields import OutlinedTextField
+from nuiitivet.material.text_fields import TextField
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.deck import Deck
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.material.buttons import Button
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.observable.value import _ObservableValue
 from nuiitivet.material import ButtonStyle
+from nuiitivet.material.styles.text_field_style import TextFieldStyle
 
 
 class ViewMode(IntEnum):
@@ -73,11 +74,11 @@ class DeckDemo(ComposableWidget):
 
         return Column(
             [
-                FilledCard(
+                Card(
                     tab_buttons,
                     style=CardStyle.filled().copy_with(border_radius=0),
                 ),
-                FilledCard(
+                Card(
                     tab_content,
                     style=CardStyle.filled().copy_with(border_radius=0),
                     width=Sizing.flex(1),
@@ -94,10 +95,11 @@ class DeckDemo(ComposableWidget):
             [
                 Text("Home Tab"),
                 Text("Enter text below and switch tabs to see state preservation:"),
-                OutlinedTextField(
+                TextField(
                     value=self.home_text,
                     label="Type something...",
                     width=Sizing.fixed(400),
+                    style=TextFieldStyle.outlined(),
                 ),
             ],
             gap=12,
@@ -110,10 +112,11 @@ class DeckDemo(ComposableWidget):
             [
                 Text("Profile Tab"),
                 Text("This tab has its own text field with preserved state:"),
-                OutlinedTextField(
+                TextField(
                     value=self.profile_text,
                     label="Type something...",
                     width=Sizing.fixed(400),
+                    style=TextFieldStyle.outlined(),
                 ),
             ],
             gap=12,
@@ -126,10 +129,11 @@ class DeckDemo(ComposableWidget):
             [
                 Text("Settings Tab"),
                 Text("All tabs maintain their state independently:"),
-                OutlinedTextField(
+                TextField(
                     value=self.settings_text,
                     label="Type something...",
                     width=Sizing.fixed(400),
+                    style=TextFieldStyle.outlined(),
                 ),
                 Text("Note: Deck keeps all children mounted,"),
                 Text("so their state (text, scroll position, etc.) is preserved."),

--- a/src/samples/deck_with_rail_demo.py
+++ b/src/samples/deck_with_rail_demo.py
@@ -4,16 +4,17 @@ from enum import IntEnum
 
 from nuiitivet.material import App
 from nuiitivet.material import Text
-from nuiitivet.material.text_fields import OutlinedTextField
+from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.navigation_rail import NavigationRail, RailItem
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.deck import Deck
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.observable.value import _ObservableValue
+from nuiitivet.material.styles.text_field_style import TextFieldStyle
 
 
 class Section(IntEnum):
@@ -75,17 +76,18 @@ class DesktopAppDemo(ComposableWidget):
 
     def _build_dashboard_section(self) -> Widget:
         """Dashboard section with preserved state."""
-        return FilledCard(
+        return Card(
             Column(
                 [
                     Text("Dashboard"),
                     Text(""),
                     Text("Welcome to your dashboard!"),
                     Text("Enter notes below (state preserved when navigating):"),
-                    OutlinedTextField(
+                    TextField(
                         value=self.dashboard_note,
                         label="Type dashboard notes...",
                         width=Sizing.fixed(400),
+                        style=TextFieldStyle.outlined(),
                     ),
                 ],
                 gap=12,
@@ -99,17 +101,18 @@ class DesktopAppDemo(ComposableWidget):
 
     def _build_analytics_section(self) -> Widget:
         """Analytics section with preserved state."""
-        return FilledCard(
+        return Card(
             Column(
                 [
                     Text("Analytics"),
                     Text(""),
                     Text("View and analyze your data"),
                     Text("Filter (state preserved):"),
-                    OutlinedTextField(
+                    TextField(
                         value=self.analytics_filter,
                         label="Enter time range...",
                         width=Sizing.fixed(300),
+                        style=TextFieldStyle.outlined(),
                     ),
                 ],
                 gap=12,
@@ -123,17 +126,18 @@ class DesktopAppDemo(ComposableWidget):
 
     def _build_users_section(self) -> Widget:
         """Users section with preserved state."""
-        return FilledCard(
+        return Card(
             Column(
                 [
                     Text("Users"),
                     Text(""),
                     Text("Manage your users"),
                     Text("Search users (state preserved):"),
-                    OutlinedTextField(
+                    TextField(
                         value=self.users_search,
                         label="Search by name...",
                         width=Sizing.fixed(300),
+                        style=TextFieldStyle.outlined(),
                     ),
                 ],
                 gap=12,
@@ -147,17 +151,18 @@ class DesktopAppDemo(ComposableWidget):
 
     def _build_settings_section(self) -> Widget:
         """Settings section with preserved state."""
-        return FilledCard(
+        return Card(
             Column(
                 [
                     Text("Settings"),
                     Text(""),
                     Text("Configure your application"),
                     Text("App name (state preserved):"),
-                    OutlinedTextField(
+                    TextField(
                         value=self.settings_name,
                         label="Enter app name...",
                         width=Sizing.fixed(300),
+                        style=TextFieldStyle.outlined(),
                     ),
                     Text(""),
                     Text("Note: All section states are independently preserved."),

--- a/src/samples/flow_demo.py
+++ b/src/samples/flow_demo.py
@@ -10,12 +10,13 @@ from nuiitivet.observable import Observable
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.flow import Flow
-from nuiitivet.material.card import OutlinedCard
+from nuiitivet.material.card import Card
 from nuiitivet.layout.row import Row
 from nuiitivet.material.buttons import Button
 from nuiitivet.material.styles import TextStyle
 from nuiitivet.runtime.title_bar import DefaultTitleBar
 from nuiitivet.material import ButtonStyle
+from nuiitivet.material.styles.card_style import CardStyle
 
 
 class FlowDemoModel:
@@ -62,10 +63,11 @@ class FlowDemo(ComposableWidget):
 
     def _build_tag(self, label: str, idx: int) -> Widget:
         # Variable width implied by text content
-        return OutlinedCard(
+        return Card(
             Text(label),
             padding=(16, 8, 16, 8),
             alignment="center",
+            style=CardStyle.outlined(),
         )
 
     def build(self) -> Widget:
@@ -94,7 +96,7 @@ class FlowDemo(ComposableWidget):
                 Text("Flow Layout (Wrapping)", style=TextStyle(font_size=24)),
                 Text("Resize window to see wrapping behavior."),
                 controls,
-                OutlinedCard(flow, padding=0, width="100%", height="auto"),
+                Card(flow, padding=0, width="100%", height="auto", style=CardStyle.outlined()),
             ],
             gap=16,
             padding=24,

--- a/src/samples/grid_demo.py
+++ b/src/samples/grid_demo.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from nuiitivet.layout.grid import Grid, GridItem
 from nuiitivet.material import Text
 from nuiitivet.material import App
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 
 
-def _card(label: str, width=Sizing.flex(1), height=Sizing.flex(1)) -> FilledCard:
-    return FilledCard(
+def _card(label: str, width=Sizing.flex(1), height=Sizing.flex(1)) -> Card:
+    return Card(
         Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/grid_demo_areas.py
+++ b/src/samples/grid_demo_areas.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from nuiitivet.layout.grid import Grid, GridItem
 from nuiitivet.material import Text
 from nuiitivet.material import App
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 
 
-def _card(label: str) -> FilledCard:
-    return FilledCard(
+def _card(label: str) -> Card:
+    return Card(
         Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_alignment/column_alignment.py
+++ b/src/samples/layout_alignment/column_alignment.py
@@ -21,16 +21,16 @@ def main(png: str = ""):
             children=[_tile("A"), _tile("B"), _tile("C")],
         )
 
-    def _tile(label: str, *, width: int = 72, height: int = 32) -> md.FilledCard:
-        return md.FilledCard(
+    def _tile(label: str, *, width: int = 72, height: int = 32) -> md.Card:
+        return md.Card(
             md.Text(label),
             width=width,
             height=height,
             alignment="center",
         )
 
-    def _panel(alignment: str) -> md.OutlinedCard:
-        return md.OutlinedCard(
+    def _panel(alignment: str) -> md.Card:
+        return md.Card(
             nv.Column(
                 children=[md.Text(alignment), _demo_column(alignment)],
                 gap=8,
@@ -39,6 +39,7 @@ def main(png: str = ""):
             ),
             width=150,
             padding=12,
+            style=md.CardStyle.outlined(),
         )
 
     content = nv.Column(

--- a/src/samples/layout_alignment/column_cross_alignment.py
+++ b/src/samples/layout_alignment/column_cross_alignment.py
@@ -19,16 +19,16 @@ def main(png: str = ""):
             children=[_tile("W=72"), _tile("W=72"), _tile("W=72")],
         )
 
-    def _tile(label: str, *, width: int = 72, height: int = 32) -> md.FilledCard:
-        return md.FilledCard(
+    def _tile(label: str, *, width: int = 72, height: int = 32) -> md.Card:
+        return md.Card(
             md.Text(label),
             width=width,
             height=height,
             alignment="center",
         )
 
-    def _panel(alignment: str) -> md.OutlinedCard:
-        return md.OutlinedCard(
+    def _panel(alignment: str) -> md.Card:
+        return md.Card(
             nv.Column(
                 children=[md.Text(alignment), _demo_column(alignment)],
                 gap=8,
@@ -37,6 +37,7 @@ def main(png: str = ""):
             ),
             width=200,
             padding=12,
+            style=md.CardStyle.outlined(),
         )
 
     content = nv.Column(

--- a/src/samples/layout_alignment/container_alignment.py
+++ b/src/samples/layout_alignment/container_alignment.py
@@ -15,8 +15,8 @@ def main(png: str = ""):
         "bottom-right",
     ]
 
-    def _tile(alignment: str) -> md.FilledCard:
-        return md.FilledCard(
+    def _tile(alignment: str) -> md.Card:
+        return md.Card(
             md.Text(alignment, padding=8),
             width=160,
             height=96,

--- a/src/samples/layout_alignment/row_alignment.py
+++ b/src/samples/layout_alignment/row_alignment.py
@@ -2,8 +2,8 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _tile(label: str) -> md.FilledCard:
-    return md.FilledCard(
+def _tile(label: str) -> md.Card:
+    return md.Card(
         md.Text(label),
         width=56,
         height=40,
@@ -34,7 +34,7 @@ def main(png: str = ""):
     content = nv.Column(
         # Render all variants so differences are easy to compare.
         children=[
-            md.OutlinedCard(
+            md.Card(
                 nv.Column(
                     children=[md.Text(a), _demo_row(a)],
                     gap=8,
@@ -43,6 +43,7 @@ def main(png: str = ""):
                 ),
                 width=560,
                 padding=12,
+                style=md.CardStyle.outlined(),
             )
             for a in main_alignments
         ],

--- a/src/samples/layout_alignment/row_cross_alignment.py
+++ b/src/samples/layout_alignment/row_cross_alignment.py
@@ -20,16 +20,16 @@ def main(png: str = ""):
             children=[_bar("H=32", 32), _bar("H=64", 64), _bar("H=96", 96)],
         )
 
-    def _bar(label: str, height: int) -> md.FilledCard:
-        return md.FilledCard(
+    def _bar(label: str, height: int) -> md.Card:
+        return md.Card(
             md.Text(label),
             width=88,
             height=height,
             alignment="center",
         )
 
-    def _panel(alignment: str) -> md.OutlinedCard:
-        return md.OutlinedCard(
+    def _panel(alignment: str) -> md.Card:
+        return md.Card(
             nv.Column(
                 children=[md.Text(alignment), _demo_row(alignment)],
                 gap=8,
@@ -38,6 +38,7 @@ def main(png: str = ""):
             ),
             width=560,
             padding=12,
+            style=md.CardStyle.outlined(),
         )
 
     content = nv.Column(

--- a/src/samples/layout_basics/basic_column.py
+++ b/src/samples/layout_basics/basic_column.py
@@ -5,8 +5,8 @@ import nuiitivet.material as md
 def main(png: str = ""):
     content = nv.Column(
         children=[
-            md.FilledTextField(label="Email"),
-            md.FilledTextField(label="Password"),
+            md.TextField(label="Email"),
+            md.TextField(label="Password"),
             md.FilledButton("Login"),
         ],
         gap=16,

--- a/src/samples/layout_basics/row_column_combination.py
+++ b/src/samples/layout_basics/row_column_combination.py
@@ -9,13 +9,13 @@ def main(png: str = ""):
             # 1行目: 名前（横並び）
             nv.Row(
                 children=[
-                    md.FilledTextField(label="First Name"),
-                    md.FilledTextField(label="Last Name"),
+                    md.TextField(label="First Name"),
+                    md.TextField(label="Last Name"),
                 ],
                 gap=8,
             ),
             # 2行目: 住所
-            md.FilledTextField(label="Address", width=nv.Sizing.flex(1)),
+            md.TextField(label="Address", width=nv.Sizing.flex(1)),
             # 3行目: ボタン（横並び）
             nv.Row(
                 children=[

--- a/src/samples/layout_extras/flow_demo.py
+++ b/src/samples/layout_extras/flow_demo.py
@@ -20,7 +20,7 @@ def main(png: str = ""):
         main_gap=8,
         cross_gap=8,
         padding=8,
-        children=[md.OutlinedCard(child=md.Text(tag, padding=8)) for tag in tags],
+        children=[md.Card(child=md.Text(tag, padding=8), style=md.CardStyle.outlined()) for tag in tags],
         width=300,  # Limit width to force wrapping
     )
 

--- a/src/samples/layout_extras/flow_minimal_demo.py
+++ b/src/samples/layout_extras/flow_minimal_demo.py
@@ -19,7 +19,7 @@ def main(png: str = ""):
         cross_gap=8,
         padding=12,
         children=[
-            md.OutlinedCard(md.Text(tag, padding=8)) for tag in tags
+            md.Card(md.Text(tag, padding=8), style=md.CardStyle.outlined()) for tag in tags
         ],
         width=320,  # Limit width to show wrapping
     )

--- a/src/samples/layout_extras/stack_demo.py
+++ b/src/samples/layout_extras/stack_demo.py
@@ -11,17 +11,17 @@ def main(png: str = ""):
         alignment="center",  # デフォルトの配置位置
         children=[
             # 1. 背景（奥）
-            md.FilledCard(
+            md.Card(
                 md.Text(""),
                 width="100%",
                 height="100%",
             ).modifier(mod.background("#BBDEFB")),
-            md.FilledCard(
+            md.Card(
                 md.Text(""),
                 width="80%",
                 height="80%",
             ).modifier(mod.background("#90CAF9")),
-            md.FilledCard(
+            md.Card(
                 md.Text("Overlay md.Text"),
                 width="60%",
                 height="60%",
@@ -30,7 +30,7 @@ def main(png: str = ""):
         ],
     )
 
-    root = md.FilledCard(
+    root = md.Card(
         widget,
         alignment="center",
         style=CardStyle(background=None, border_radius=0),

--- a/src/samples/layout_extras/uniform_flow_minimal_demo.py
+++ b/src/samples/layout_extras/uniform_flow_minimal_demo.py
@@ -12,7 +12,7 @@ def main(png: str = ""):
         padding=12,
         aspect_ratio=1.0,
         children=[
-            md.FilledCard(md.Text(t), alignment="center", padding=12) for t in tiles
+            md.Card(md.Text(t), alignment="center", padding=12) for t in tiles
         ],
         width=320,
     )

--- a/src/samples/layout_grid/app_layout_grid.py
+++ b/src/samples/layout_grid/app_layout_grid.py
@@ -5,8 +5,8 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _card(label: str, width="100%", height="100%") -> md.FilledCard:
-    return md.FilledCard(
+def _card(label: str, width="100%", height="100%") -> md.Card:
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_grid/basic_grid.py
+++ b/src/samples/layout_grid/basic_grid.py
@@ -2,8 +2,8 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _cell(label: str) -> md.FilledCard:
-    return md.FilledCard(
+def _cell(label: str) -> md.Card:
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_grid/expanded_cell.py
+++ b/src/samples/layout_grid/expanded_cell.py
@@ -9,7 +9,7 @@ def main(png: str = ""):
         columns=[200],
         children=[
             nv.GridItem(
-                child=md.FilledCard(
+                child=md.Card(
                     # カードをセルのサイズいっぱいに広げる
                     width="100%",
                     height="100%",

--- a/src/samples/layout_grid/named_areas_grid.py
+++ b/src/samples/layout_grid/named_areas_grid.py
@@ -5,8 +5,8 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _card(label: str, width="100%", height="100%") -> md.FilledCard:
-    return md.FilledCard(
+def _card(label: str, width="100%", height="100%") -> md.Card:
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_grid/step1_grid.py
+++ b/src/samples/layout_grid/step1_grid.py
@@ -5,9 +5,9 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _card(label: str) -> md.FilledCard:
+def _card(label: str) -> md.Card:
     # Step 1: 単純なカード（サイズ指定なし）
-    return md.FilledCard(
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_grid/step2_span.py
+++ b/src/samples/layout_grid/step2_span.py
@@ -5,9 +5,9 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _card(label: str) -> md.FilledCard:
+def _card(label: str) -> md.Card:
     # Step 2: 単純なカード（サイズ指定なし）
-    return md.FilledCard(
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_grid/step3_sizing.py
+++ b/src/samples/layout_grid/step3_sizing.py
@@ -5,9 +5,9 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _card(label: str) -> md.FilledCard:
+def _card(label: str) -> md.Card:
     # サイズ指定なし
-    return md.FilledCard(
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_grid/step4_expand.py
+++ b/src/samples/layout_grid/step4_expand.py
@@ -5,13 +5,13 @@ import nuiitivet as nv
 import nuiitivet.material as md
 
 
-def _card(label: str, expand: bool = True) -> md.FilledCard:
+def _card(label: str, expand: bool = True) -> md.Card:
     # expand=True -> width/height="100%" (Fills grid cell)
     # expand=False -> width/height=default (Fits content)
     w = "100%" if expand else None
     h = "100%" if expand else None
 
-    return md.FilledCard(
+    return md.Card(
         md.Text(label),
         padding=12,
         alignment="center",

--- a/src/samples/layout_overflow/clipped_content.py
+++ b/src/samples/layout_overflow/clipped_content.py
@@ -4,15 +4,16 @@ import nuiitivet.modifiers as mod
 
 
 def main(png: str = ""):
-    widget = md.OutlinedCard(
+    widget = md.Card(
         width=150,
         height=150,
         padding=10,
-        child=md.FilledCard(
+        child=md.Card(
             width=200,
             height=200,
             child=md.Text("Clipped Content"),
         ),
+        style=md.CardStyle.outlined(),
     ).modifier(
         mod.clip()
     )  # 枠からはみ出た部分は描画されない

--- a/src/samples/layout_overflow/default_overflow.py
+++ b/src/samples/layout_overflow/default_overflow.py
@@ -4,16 +4,17 @@ import nuiitivet.material as md
 
 def main(png: str = ""):
     # 親の枠（150x150）
-    widget = md.OutlinedCard(
+    widget = md.Card(
         width=150,
         height=150,
         padding=10,
         # 子が大きい（200x200）-> そのままはみ出して表示される
-        child=md.FilledCard(
+        child=md.Card(
             width=200,
             height=200,
             child=md.Text("Overflow Content"),
         ),
+        style=md.CardStyle.outlined(),
     )
 
     # Center it so we can see the overflow clearly

--- a/src/samples/layout_sizing/auto_size.py
+++ b/src/samples/layout_sizing/auto_size.py
@@ -3,7 +3,7 @@ import nuiitivet.material as md
 
 
 def main(png: str = ""):
-    widget = md.FilledCard(
+    widget = md.Card(
         # width/height 指定なし -> auto
         width="auto",
         height="auto",

--- a/src/samples/layout_sizing/fixed_size.py
+++ b/src/samples/layout_sizing/fixed_size.py
@@ -3,7 +3,7 @@ import nuiitivet.material as md
 
 
 def main(png: str = ""):
-    widget = md.FilledCard(
+    widget = md.Card(
         width=200,  # 幅を 200px に固定
         height=100,  # 高さを 100px に固定
         child=md.Text("Fixed Size Box"),

--- a/src/samples/layout_sizing/flex_width.py
+++ b/src/samples/layout_sizing/flex_width.py
@@ -3,7 +3,7 @@ import nuiitivet as nv
 
 
 def main(png: str = ""):
-    widget = md.FilledCard(
+    widget = md.Card(
         width="100%",
         child=md.Text("Full Width Box"),
         padding=16,

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -5,7 +5,7 @@ import nuiitivet.material as md
 from nuiitivet.material.buttons import Button
 from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material import Overlay
-from nuiitivet.material.text_fields import OutlinedTextField
+from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
 from nuiitivet.navigation import Navigator, PageRoute
 from nuiitivet.observable import Observable
@@ -81,7 +81,7 @@ class EditScreen(nv.ComposableWidget):
             child=nv.Column(
                 children=[
                     md.Text("Edit text. Back/Esc asks confirmation when unsaved."),
-                    OutlinedTextField.two_way(
+                    TextField.two_way(
                         self.text,
                         width=420,
                         height=52,

--- a/src/samples/my_widget.py
+++ b/src/samples/my_widget.py
@@ -19,7 +19,7 @@ from nuiitivet.layout.column import Column
 
 # flow removed
 from nuiitivet.layout.uniform_flow import UniformFlow
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.layout.row import Row
 from nuiitivet.layout.scroller import Scroller
@@ -154,7 +154,7 @@ class MyWidget(ComposableWidget):
                 gap=8,
                 cross_alignment="center",
             ),
-            FilledCard(
+            Card(
                 Row(
                     [
                         Icon(Symbols.home, size=24),
@@ -169,7 +169,7 @@ class MyWidget(ComposableWidget):
                 style=CardStyle.filled().copy_with(border_radius=8),
                 alignment="center",
             ),
-            FilledCard(
+            Card(
                 Row([Text("Last click:"), Text(self.model.click_log)], gap=8, cross_alignment="center"),
                 padding=6,
                 alignment="center",
@@ -183,7 +183,7 @@ class MyWidget(ComposableWidget):
                 gap=8,
                 cross_alignment="center",
             ),
-            FilledCard(
+            Card(
                 Column(
                     [
                         Text("Column demo:"),
@@ -221,7 +221,7 @@ class MyWidget(ComposableWidget):
                 style=CardStyle.filled().copy_with(border_radius=6),
                 alignment="start",
             ),
-            FilledCard(
+            Card(
                 Column(
                     [
                         Text("Row demo:"),
@@ -252,7 +252,7 @@ class MyWidget(ComposableWidget):
                 style=CardStyle.filled().copy_with(border_radius=6),
                 alignment="start",
             ),
-            FilledCard(
+            Card(
                 Column(
                     [
                         Text("Grid demo:"),
@@ -283,7 +283,7 @@ class MyWidget(ComposableWidget):
                 style=CardStyle.filled().copy_with(border_radius=6),
                 alignment="start",
             ),
-            FilledCard(
+            Card(
                 Column(
                     [
                         Text("Checkbox demo:"),

--- a/src/samples/navigation_rail_demo.py
+++ b/src/samples/navigation_rail_demo.py
@@ -8,7 +8,7 @@ from nuiitivet.material.navigation_rail import NavigationRail, RailItem
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.observable.value import _ObservableValue
@@ -78,7 +78,7 @@ class NavigationRailDemo(ComposableWidget):
         )
 
         # Content area - shows which section is selected
-        content = FilledCard(
+        content = Card(
             Column(
                 [
                     Text(section_label),

--- a/src/samples/overflow_demo.py
+++ b/src/samples/overflow_demo.py
@@ -12,7 +12,7 @@ from nuiitivet.material import App
 from nuiitivet.rendering import Sizing
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.material import Text
 from nuiitivet.material.theme.color_role import ColorRole
@@ -38,7 +38,7 @@ def build_demo_container(overflow_mode: Literal["visible", "clip", "scroll"]):
         height=Sizing.auto(),
     )
 
-    demo_container = FilledCard(
+    demo_container = Card(
         child=large_content,
         width=Sizing.fixed(300),
         height=Sizing.fixed(150),

--- a/src/samples/padding_demo.py
+++ b/src/samples/padding_demo.py
@@ -3,7 +3,7 @@
 from nuiitivet.material import App
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.material import Text
 from nuiitivet.material.buttons import Button
@@ -14,11 +14,11 @@ from nuiitivet.material import ButtonStyle
 def main():
     """Show various padding configurations for Column and Row."""
     app = App(
-        content=FilledCard(
+        content=Card(
             child=Column(
                 [
                     Text("Column and Row Padding Demo"),
-                    FilledCard(
+                    Card(
                         child=Column(
                             [Text("Column with padding=20"), Text("Second item"), Text("Third item")],
                             gap=5,
@@ -26,7 +26,7 @@ def main():
                         ),
                         style=CardStyle.filled().copy_with(background=ColorRole.SURFACE_VARIANT),
                     ),
-                    FilledCard(
+                    Card(
                         child=Row(
                             [Text("Row"), Text("with"), Text("padding=15")],
                             gap=10,
@@ -34,7 +34,7 @@ def main():
                         ),
                         style=CardStyle.filled().copy_with(background=ColorRole.SECONDARY_CONTAINER),
                     ),
-                    FilledCard(
+                    Card(
                         child=Column(
                             [
                                 Text("Asymmetric padding:"),
@@ -44,7 +44,7 @@ def main():
                         ),
                         style=CardStyle.filled().copy_with(background=ColorRole.TERTIARY_CONTAINER),
                     ),
-                    FilledCard(
+                    Card(
                         child=Column(
                             [
                                 Text("Nested: Row in Column, both with padding"),
@@ -65,7 +65,7 @@ def main():
                             border_width=2,
                         ),
                     ),
-                    FilledCard(
+                    Card(
                         child=Row(
                             [Text("No padding"), Button("Button", style=ButtonStyle.outlined())],
                             gap=10,

--- a/src/samples/readme/readme_login_form.py
+++ b/src/samples/readme/readme_login_form.py
@@ -8,15 +8,17 @@ import argparse
 def build_login_form():
     return nv.Column(
         [
-            md.OutlinedTextField(
+            md.TextField(
                 value="",
                 label="Username",
                 width=300,
+                style=md.TextFieldStyle.outlined(),
             ),
-            md.OutlinedTextField(
+            md.TextField(
                 value="",
                 label="Password",
                 width=300,
+                style=md.TextFieldStyle.outlined(),
             ),
             md.FilledButton(
                 "Login",

--- a/src/samples/row_builder_list_vs_observable_demo.py
+++ b/src/samples/row_builder_list_vs_observable_demo.py
@@ -12,7 +12,7 @@ from nuiitivet.observable import Observable
 from nuiitivet.material import App
 from nuiitivet.material import Text
 from nuiitivet.material.buttons import Button
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
@@ -63,7 +63,7 @@ class RowBuilderDemo(ComposableWidget):
     def build(self) -> Widget:
         return Column(
             [
-                FilledCard(
+                Card(
                     Column(
                         [
                             Text("Row.builder with plain list (cannot update)"),
@@ -99,7 +99,7 @@ class RowBuilderDemo(ComposableWidget):
                     style=CardStyle.filled().copy_with(border_radius=8),
                     alignment="start",
                 ),
-                FilledCard(
+                Card(
                     Column(
                         [
                             Text("Row.builder with Observable list (can update)"),

--- a/src/samples/scope_partial_rebuild.py
+++ b/src/samples/scope_partial_rebuild.py
@@ -10,7 +10,7 @@ from nuiitivet.material import App
 from nuiitivet.observable import Observable
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.layout.row import Row
 from nuiitivet.material.buttons import Button
@@ -64,7 +64,7 @@ class ScopedCountersDemo(ComposableWidget):
         return self._build_panel("Right", self.right_count.value, self._right_builds)
 
     def _build_panel(self, label: str, value: int, builds: int) -> Widget:
-        return FilledCard(
+        return Card(
             child=Column(
                 [
                     Text(f"{label} scope value: {value}", padding=(0, 0, 0, 4)),

--- a/src/samples/scroller_demo.py
+++ b/src/samples/scroller_demo.py
@@ -2,7 +2,7 @@
 
 from nuiitivet.material import App
 from nuiitivet.layout.column import Column
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.layout.row import Row
 from nuiitivet.layout.scroller import Scroller
@@ -18,7 +18,7 @@ def main():
     items = []
     for i in range(100):
         items.append(
-            FilledCard(
+            Card(
                 child=Text(f"Item {i + 1}"),
                 padding=12,
                 style=CardStyle.filled().copy_with(
@@ -35,7 +35,7 @@ def main():
     cards = []
     for i in range(1, 21):
         cards.append(
-            FilledCard(
+            Card(
                 child=Text(f"Card {i:02} — swipe horizontally"),
                 padding=(16, 24),
                 style=CardStyle.filled().copy_with(
@@ -65,7 +65,7 @@ def main_auto_hide():
     items = []
     for i in range(100):
         items.append(
-            FilledCard(
+            Card(
                 child=Text(f"Item {i + 1}"),
                 padding=12,
                 style=CardStyle.filled().copy_with(
@@ -119,7 +119,7 @@ def main_horizontal():
     cards = []
     for i in range(1, 21):
         cards.append(
-            FilledCard(
+            Card(
                 child=Text(f"Card {i:02} — swipe horizontally"),
                 padding=(16, 24),
                 style=CardStyle.filled().copy_with(

--- a/src/samples/text_field_demo.py
+++ b/src/samples/text_field_demo.py
@@ -1,14 +1,15 @@
 from nuiitivet.material import App
 from nuiitivet.material import Checkbox, Text
-from nuiitivet.material.text_fields import FilledTextField, OutlinedTextField
+from nuiitivet.material.text_fields import TextField
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
+from nuiitivet.material.styles.text_field_style import TextFieldStyle
 
 
 def main():
     # Filled TextField with Label and Leading Icon
-    tf_filled = FilledTextField(
+    tf_filled = TextField(
         value="",
         label="Username",
         leading_icon="person",
@@ -18,13 +19,14 @@ def main():
     )
 
     # Outlined TextField with Label
-    tf_outlined = OutlinedTextField(
+    tf_outlined = TextField(
         value="",
         label="Password",
         leading_icon="lock",
         obscure_text=True,
         width=300,
         padding=10,
+        style=TextFieldStyle.outlined(),
     )
 
     def _toggle_obscure(checked: bool | None) -> None:
@@ -39,13 +41,14 @@ def main():
     )
 
     # Error State
-    tf_error = OutlinedTextField(
+    tf_error = TextField(
         value="Invalid Input",
         label="Email",
         supporting_text="Invalid email address",
         is_error=True,
         width=300,
         padding=10,
+        style=TextFieldStyle.outlined(),
     )
 
     root = Container(

--- a/src/samples/uniform_flow_demo.py
+++ b/src/samples/uniform_flow_demo.py
@@ -10,7 +10,7 @@ from nuiitivet.observable import Observable
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.uniform_flow import UniformFlow
-from nuiitivet.material.card import FilledCard, OutlinedCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.layout.row import Row
 from nuiitivet.material.buttons import Button
@@ -59,7 +59,7 @@ class FlowUniformDemo(ComposableWidget):
 
     def _build_tile(self, label: str, idx: int) -> Widget:
         del idx
-        return FilledCard(
+        return Card(
             Column([Text(label), Text("Tap to edit")], gap=4, cross_alignment="start"),
             padding=12,
             style=CardStyle.filled().copy_with(border_radius=12),
@@ -95,7 +95,7 @@ class FlowUniformDemo(ComposableWidget):
                     "Flow layout demo (uniform tiles)",
                 ),
                 controls,
-                OutlinedCard(flow, padding=12, alignment="start"),
+                Card(flow, padding=12, alignment="start", style=CardStyle.outlined()),
             ],
             gap=12,
             padding=12,

--- a/src/samples/will_pop_demo.py
+++ b/src/samples/will_pop_demo.py
@@ -22,7 +22,7 @@ from nuiitivet.material import App
 from nuiitivet.material import Overlay
 from nuiitivet.material.buttons import Button
 from nuiitivet.material import Text
-from nuiitivet.material.text_fields import OutlinedTextField
+from nuiitivet.material.text_fields import TextField
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.material import ButtonStyle
 
@@ -152,7 +152,7 @@ class EditScreen(ComposableWidget):
                 children=[
                     Text("Editor"),
                     Text(self.vm.dirty.map(lambda v: "Dirty" if v else "Clean")),
-                    OutlinedTextField.two_way(
+                    TextField.two_way(
                         self.vm.text,
                         width=420,
                         height=52,

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -1,4 +1,4 @@
-from nuiitivet.material.card import Card, FilledCard, ElevatedCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.rendering.sizing import Sizing
@@ -26,8 +26,8 @@ def test_border_radius_tuple_normalization():
 
 
 def test_default_border_radius():
-    # FilledCard defaults to 12.0
-    mc = FilledCard(None)
+    # Card defaults to 12.0
+    mc = Card(None)
     assert mc.corner_radii == (12.0, 12.0, 12.0, 12.0)
     assert mc.corner_radius == 12.0
 
@@ -92,9 +92,9 @@ def test_callable_child_spec_is_evaluated_per_build():
 
 
 def test_elevated_card_reports_shadow_outsets():
-    container = ElevatedCard(None)
+    container = Card(None, style=CardStyle.elevated())
     left, top, right, bottom = container.paint_outsets()
-    # Default shadow for ElevatedCard (elevation 1.0) should reserve bounds
+    # Default shadow for Card(elevation 1.0, style=CardStyle.elevated()) should reserve bounds
     assert left > 0
     assert top > 0
     assert right > 0
@@ -102,6 +102,6 @@ def test_elevated_card_reports_shadow_outsets():
 
 
 def test_filled_card_no_shadow():
-    container = FilledCard(None)
+    container = Card(None)
     left, top, right, bottom = container.paint_outsets()
     assert (left, top, right, bottom) == (0, 0, 0, 0)

--- a/tests/test_clip_modifier_behavior.py
+++ b/tests/test_clip_modifier_behavior.py
@@ -10,7 +10,7 @@ Verifies that:
 from unittest.mock import MagicMock
 import unittest
 from nuiitivet.layout.column import Column
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.layout.row import Row
 from nuiitivet.widgets import TextBase as Text
@@ -92,9 +92,9 @@ def test_row_with_clip_modifier():
 
 
 def test_container_default_no_clip():
-    """FilledCard does not clip by default (if radius is 0)."""
+    """Card does not clip by default (if radius is 0)."""
     t = Text("Large", width=Sizing.fixed(120), height=Sizing.fixed(60))
-    c = FilledCard(
+    c = Card(
         child=t,
         width=Sizing.fixed(100),
         height=Sizing.fixed(50),
@@ -111,17 +111,17 @@ def test_container_default_no_clip():
 
 
 def test_container_with_clip_modifier():
-    """FilledCard with .clip() modifier applies clipping."""
+    """Card with .clip() modifier applies clipping."""
     _skip_if_no_skia(unittest.TestCase())
     t = Text("Large", width=Sizing.fixed(120), height=Sizing.fixed(60))
-    c_inner = FilledCard(
+    c_inner = Card(
         child=t,
         width=Sizing.fixed(100),
         height=Sizing.fixed(50),
         style=CardStyle.filled().copy_with(border_radius=0),
     )
     c = c_inner.modifier(clip())
-    # FilledCard returns a Box, and ClipModifier modifies Box in-place
+    # Card returns a Box, and ClipModifier modifies Box in-place
     # so c is the Box itself, not a wrapper.
 
     canvas = MagicMock()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,5 @@
 from nuiitivet.layout.container import Container
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.widgets import TextBase as Text
 from nuiitivet.widgeting.widget import Widget
@@ -13,7 +13,7 @@ def test_preferred_size_single_child_no_skia():
 
 
 def test_paint_no_skia_does_not_raise():
-    c = FilledCard(
+    c = Card(
         Text("hello"),
         padding=4,
         style=CardStyle.filled().copy_with(background="#E7E0EC"),

--- a/tests/test_material_default_style_resolution.py
+++ b/tests/test_material_default_style_resolution.py
@@ -3,17 +3,15 @@ from collections.abc import Iterator
 
 from nuiitivet.material import (
     Checkbox,
-    FilledTextField,
+    TextField,
     Icon,
     NavigationRail,
-    OutlinedTextField,
     RadioButton,
     RailItem,
     Switch,
     Text,
-    TextField,
 )
-from nuiitivet.material.card import FilledCard
+from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.material.theme.color_role import ColorRole
@@ -74,21 +72,21 @@ def test_text_field_defaults_to_default_text_field_style() -> None:
 
 
 def test_filled_text_field_defaults_to_filled_style() -> None:
-    tf = FilledTextField()
+    tf = TextField()
     assert tf.style == TextFieldStyle.filled()
 
 
 def test_outlined_text_field_defaults_to_outlined_style() -> None:
-    tf = OutlinedTextField()
+    tf = TextField(style=TextFieldStyle.outlined())
     assert tf.style == TextFieldStyle.outlined()
 
 
 def test_card_defaults() -> None:
-    c1 = FilledCard(Text(""), style=CardStyle.filled().copy_with(border_width=0))
-    # FilledCard default background is SURFACE_CONTAINER_HIGHEST
+    c1 = Card(Text(""), style=CardStyle.filled().copy_with(border_width=0))
+    # Card default background is SURFACE_CONTAINER_HIGHEST
     assert c1.bgcolor == ColorRole.SURFACE_CONTAINER_HIGHEST
 
-    _ = FilledCard(Text(""), style=CardStyle.filled().copy_with(border_width=1, border_color=None))
+    _ = Card(Text(""), style=CardStyle.filled().copy_with(border_width=1, border_color=None))
     # If border_color is None but width > 0, it should default to OUTLINE
     # However, CardStyle.filled() has no border by default.
     # If we explicitly set border_width=1 and border_color=None, Card logic might resolve it.

--- a/tests/test_text_field_style.py
+++ b/tests/test_text_field_style.py
@@ -1,7 +1,7 @@
 """Test TextField style integration."""
 
 from dataclasses import replace
-from nuiitivet.material.text_fields import FilledTextField, OutlinedTextField
+from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.theme import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
@@ -16,13 +16,13 @@ def test_text_field_uses_theme_default_style():
     try:
         manager.set_theme(light)
 
-        filled = FilledTextField()
+        filled = TextField()
         assert filled.style is not None
         assert isinstance(filled.style, TextFieldStyle)
         # Filled default
         assert filled.style.container_color == ColorRole.SURFACE_CONTAINER_HIGHEST
 
-        outlined = OutlinedTextField()
+        outlined = TextField(style=TextFieldStyle.outlined())
         assert outlined.style is not None
         # Outlined default
         assert outlined.style.container_color == (0, 0, 0, 0)
@@ -34,31 +34,27 @@ def test_text_field_uses_theme_default_style():
 def test_text_field_accepts_custom_style():
     """TextField with style parameter should use provided style."""
     custom_style = TextFieldStyle.outlined().copy_with(border_radius=8.0)
-    field = FilledTextField(style=custom_style)
+    field = TextField(style=custom_style)
     assert field._user_style is custom_style
     assert field.style.border_radius == 8.0
 
 
 def test_theme_with_custom_text_field_style():
-    """Theme can provide custom text field style."""
+    """Theme can override the default TextField style."""
     custom_filled = TextFieldStyle.filled().copy_with(border_radius=16.0)
-    custom_outlined = TextFieldStyle.outlined().copy_with(border_radius=12.0)
 
     light, _ = MaterialTheme.from_seed_pair("#FF0000")
 
     mat = light.extension(MaterialThemeData)
     assert mat is not None
-    new_material = mat.copy_with(_filled_text_field_style=custom_filled, _outlined_text_field_style=custom_outlined)
+    new_material = mat.copy_with(_filled_text_field_style=custom_filled)
     custom_theme = replace(light, extensions=[new_material])
 
     old_theme = manager.current
     try:
         manager.set_theme(custom_theme)
 
-        filled = FilledTextField()
+        filled = TextField()
         assert filled.style.border_radius == 16.0
-
-        outlined = OutlinedTextField()
-        assert outlined.style.border_radius == 12.0
     finally:
         manager.set_theme(old_theme)


### PR DESCRIPTION
Closes #77

Apply the style-driven preset API pattern (introduced for Button/ToggleButton in #100) to Card and TextField. Variant subclasses are removed; the visual variant is now expressed entirely through the `style` argument (`CardStyle` / `TextFieldStyle`).

## Breaking Changes

- Remove `FilledCard` / `OutlinedCard` / `ElevatedCard`
  - Migration: `Card(..., style=CardStyle.outlined())` / `CardStyle.elevated()`
- Remove `FilledTextField` / `OutlinedTextField`
  - Migration: `TextField(..., style=TextFieldStyle.outlined())`

## Changes

- Add `mode: Literal["filled", "outlined"]` field to `TextFieldStyle`. It controls container shape (top-rounded vs full rect) and indicator drawing (underline vs full border).
- Implement `TextField._draw_container` with mode-aware rendering (was previously a no-op placeholder).
- Remove `_variant` branching from `Card` / `TextField`.
- Export `CardStyle` / `TextFieldStyle` from `nuiitivet.material`.
- Migrate 16 sample files, 5 test files, 8 documentation files, and the README to the new API.

## Validation

- pytest: 1166 passed
- mypy: success
- flake8: clean