### PR TITLE
feat(buttons)!: extend unified Style system to icon buttons and split out Fab (#99)

### DIFF
--- a/docs/md3/floating_action_buttons.md
+++ b/docs/md3/floating_action_buttons.md
@@ -1,0 +1,117 @@
+<!-- markdownlint-disable MD060 -->
+
+# Floating Action Buttons MD3 Specs
+
+**Source:** <https://m3.material.io/components/floating-action-button/specs>  
+**Collected:** 2026-04-25
+
+## Summary
+
+- Material Design 3 FAB specifications covering three current tonal color variants and three current size variants (baseline 56 dp, medium 80 dp, large 96 dp).
+- Four interactive states documented for color variants: Enabled, Hovered, Focused, and Pressed.
+- Color values were scraped from the live FAB token viewer resources for the Default / Light expressive context.
+- Baseline (default) size measurements come from the Specs page Measurements section; live token viewer omits a dedicated `FAB - Size - Default` table, so values are sourced from the FAB measurements diagram.
+- Deprecated baseline token sets, including Small FAB and legacy surface variants, are excluded from this document.
+
+## Tokens & Specs
+
+### Token Sets Discovered
+
+| Token Set | Count | Type | Status |
+|---|---:|---|---|
+| FAB - Color - Tonal primary | 16 | Color | Active |
+| FAB - Color - Tonal secondary | 16 | Color | Active |
+| FAB - Color - Tonal tertiary | 16 | Color | Active |
+| FAB - Size - Default | 4 | Size | Active |
+| FAB - Size - Medium | 4 | Size | Active |
+| FAB - Size - Large | 4 | Size | Active |
+
+### FAB - Color - Tonal primary
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| FAB - Color - Tonal primary | Enabled | FAB tonal primary container shadow color | md.comp.fab.primary-container.container.shadow-color | md.sys.color.shadow | #000000 |  |
+| FAB - Color - Tonal primary | Focused | FAB tonal primary focused state layer color | md.comp.fab.primary-container.focused.state-layer.color | md.sys.color.on-primary-container | #4F378B |  |
+| FAB - Color - Tonal primary | Hovered | FAB tonal primary hovered state layer color | md.comp.fab.primary-container.hovered.state-layer.color | md.sys.color.on-primary-container | #4F378B |  |
+| FAB - Color - Tonal primary | Pressed | FAB tonal primary pressed state layer color | md.comp.fab.primary-container.pressed.state-layer.color | md.sys.color.on-primary-container | #4F378B |  |
+| FAB - Color - Tonal primary | Enabled | FAB tonal primary container elevation | md.comp.fab.primary-container.container.elevation | md.sys.elevation.level3 | 6dp |  |
+| FAB - Color - Tonal primary | Focused | FAB tonal primary focused state layer opacity | md.comp.fab.primary-container.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity | 0.1 |  |
+| FAB - Color - Tonal primary | Hovered | FAB tonal primary hovered state layer opacity | md.comp.fab.primary-container.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| FAB - Color - Tonal primary | Pressed | FAB tonal primary pressed state layer opacity | md.comp.fab.primary-container.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1 |  |
+| FAB - Color - Tonal primary | Focused | FAB tonal primary focused icon color | md.comp.fab.primary-container.focused.icon.color | md.sys.color.on-primary-container | #4F378B |  |
+| FAB - Color - Tonal primary | Hovered | FAB tonal primary hovered icon color | md.comp.fab.primary-container.hovered.icon.color | md.sys.color.on-primary-container | #4F378B |  |
+| FAB - Color - Tonal primary | Enabled | FAB tonal primary icon color | md.comp.fab.primary-container.icon.color | md.sys.color.on-primary-container | #4F378B |  |
+| FAB - Color - Tonal primary | Pressed | FAB tonal primary pressed icon color | md.comp.fab.primary-container.pressed.icon.color | md.sys.color.on-primary-container | #4F378B |  |
+| FAB - Color - Tonal primary | Enabled | FAB tonal primary container color | md.comp.fab.primary-container.container.color | md.sys.color.primary-container | #EADDFF |  |
+| FAB - Color - Tonal primary | Focused | FAB tonal primary focused container elevation | md.comp.fab.primary-container.focused.container.elevation | md.sys.elevation.level3 | 6dp |  |
+| FAB - Color - Tonal primary | Hovered | FAB tonal primary hovered container elevation | md.comp.fab.primary-container.hovered.container.elevation | md.sys.elevation.level4 | 8dp |  |
+| FAB - Color - Tonal primary | Pressed | FAB tonal primary pressed container elevation | md.comp.fab.primary-container.pressed.container.elevation | md.sys.elevation.level3 | 6dp |  |
+
+### FAB - Color - Tonal secondary
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| FAB - Color - Tonal secondary | Enabled | FAB tonal secondary container shadow color | md.comp.fab.secondary-container.container.shadow-color | md.sys.color.shadow | #000000 |  |
+| FAB - Color - Tonal secondary | Focused | FAB tonal secondary focused state layer color | md.comp.fab.secondary-container.focused.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| FAB - Color - Tonal secondary | Hovered | FAB tonal secondary hovered state layer color | md.comp.fab.secondary-container.hovered.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| FAB - Color - Tonal secondary | Pressed | FAB tonal secondary pressed state layer color | md.comp.fab.secondary-container.pressed.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| FAB - Color - Tonal secondary | Enabled | FAB tonal secondary container elevation | md.comp.fab.secondary-container.container.elevation | md.sys.elevation.level3 | 6dp |  |
+| FAB - Color - Tonal secondary | Focused | FAB tonal secondary focused state layer opacity | md.comp.fab.secondary-container.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity | 0.1 |  |
+| FAB - Color - Tonal secondary | Hovered | FAB tonal secondary hovered state layer opacity | md.comp.fab.secondary-container.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| FAB - Color - Tonal secondary | Pressed | FAB tonal secondary pressed state layer opacity | md.comp.fab.secondary-container.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1 |  |
+| FAB - Color - Tonal secondary | Focused | FAB tonal secondary focused icon color | md.comp.fab.secondary-container.focused.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| FAB - Color - Tonal secondary | Hovered | FAB tonal secondary hovered icon color | md.comp.fab.secondary-container.hovered.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| FAB - Color - Tonal secondary | Enabled | FAB tonal secondary icon color | md.comp.fab.secondary-container.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| FAB - Color - Tonal secondary | Pressed | FAB tonal secondary pressed icon color | md.comp.fab.secondary-container.pressed.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| FAB - Color - Tonal secondary | Enabled | FAB tonal secondary container color | md.comp.fab.secondary-container.container.color | md.sys.color.secondary-container | #E8DEF8 |  |
+| FAB - Color - Tonal secondary | Focused | FAB tonal secondary focused container elevation | md.comp.fab.secondary-container.focused.container.elevation | md.sys.elevation.level3 | 6dp |  |
+| FAB - Color - Tonal secondary | Hovered | FAB tonal secondary hovered container elevation | md.comp.fab.secondary-container.hovered.container.elevation | md.sys.elevation.level4 | 8dp |  |
+| FAB - Color - Tonal secondary | Pressed | FAB tonal secondary pressed container elevation | md.comp.fab.secondary-container.pressed.container.elevation | md.sys.elevation.level3 | 6dp |  |
+
+### FAB - Color - Tonal tertiary
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| FAB - Color - Tonal tertiary | Enabled | FAB tonal tertiary container shadow color | md.comp.fab.tertiary-container.container.shadow-color | md.sys.color.shadow | #000000 |  |
+| FAB - Color - Tonal tertiary | Focused | FAB tonal tertiary focused state layer color | md.comp.fab.tertiary-container.focused.state-layer.color | md.sys.color.on-tertiary-container | #633B48 |  |
+| FAB - Color - Tonal tertiary | Hovered | FAB tonal tertiary hovered state layer color | md.comp.fab.tertiary-container.hovered.state-layer.color | md.sys.color.on-tertiary-container | #633B48 |  |
+| FAB - Color - Tonal tertiary | Pressed | FAB tonal tertiary pressed state layer color | md.comp.fab.tertiary-container.pressed.state-layer.color | md.sys.color.on-tertiary-container | #633B48 |  |
+| FAB - Color - Tonal tertiary | Enabled | FAB tonal tertiary container elevation | md.comp.fab.tertiary-container.container.elevation | md.sys.elevation.level3 | 6dp |  |
+| FAB - Color - Tonal tertiary | Focused | FAB tonal tertiary focused state layer opacity | md.comp.fab.tertiary-container.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity | 0.1 |  |
+| FAB - Color - Tonal tertiary | Hovered | FAB tonal tertiary hovered state layer opacity | md.comp.fab.tertiary-container.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| FAB - Color - Tonal tertiary | Pressed | FAB tonal tertiary pressed state layer opacity | md.comp.fab.tertiary-container.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1 |  |
+| FAB - Color - Tonal tertiary | Focused | FAB tonal tertiary focused icon color | md.comp.fab.tertiary-container.focused.icon.color | md.sys.color.on-tertiary-container | #633B48 |  |
+| FAB - Color - Tonal tertiary | Hovered | FAB tonal tertiary hovered icon color | md.comp.fab.tertiary-container.hovered.icon.color | md.sys.color.on-tertiary-container | #633B48 |  |
+| FAB - Color - Tonal tertiary | Enabled | FAB tonal tertiary icon color | md.comp.fab.tertiary-container.icon.color | md.sys.color.on-tertiary-container | #633B48 |  |
+| FAB - Color - Tonal tertiary | Pressed | FAB tonal tertiary pressed icon color | md.comp.fab.tertiary-container.pressed.icon.color | md.sys.color.on-tertiary-container | #633B48 |  |
+| FAB - Color - Tonal tertiary | Enabled | FAB tonal tertiary container color | md.comp.fab.tertiary-container.container.color | md.sys.color.tertiary-container | #FFD8E4 |  |
+| FAB - Color - Tonal tertiary | Focused | FAB tonal tertiary focused container elevation | md.comp.fab.tertiary-container.focused.container.elevation | md.sys.elevation.level3 | 6dp |  |
+| FAB - Color - Tonal tertiary | Hovered | FAB tonal tertiary hovered container elevation | md.comp.fab.tertiary-container.hovered.container.elevation | md.sys.elevation.level4 | 8dp |  |
+| FAB - Color - Tonal tertiary | Pressed | FAB tonal tertiary pressed container elevation | md.comp.fab.tertiary-container.pressed.container.elevation | md.sys.elevation.level3 | 6dp |  |
+
+### FAB - Size - Default
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| FAB - Size - Default | Layout | FAB container height | md.comp.fab.container.height |  | 56dp | Baseline FAB size per Specs Measurements. |
+| FAB - Size - Default | Layout | FAB container width | md.comp.fab.container.width |  | 56dp | Baseline FAB size per Specs Measurements. |
+| FAB - Size - Default | Layout | FAB icon size | md.comp.fab.icon.size |  | 24dp | Baseline FAB icon size per Specs Measurements. |
+| FAB - Size - Default | Shape | FAB container shape | md.comp.fab.container.shape | md.sys.shape.corner.large | 16dp | Resolved as rounded corners. |
+
+### FAB - Size - Medium
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| FAB - Size - Medium | Layout | FAB medium container height | md.comp.fab.medium.container.height |  | 80dp |  |
+| FAB - Size - Medium | Layout | FAB medium container width | md.comp.fab.medium.container.width |  | 80dp |  |
+| FAB - Size - Medium | Layout | FAB medium icon size | md.comp.fab.medium.icon.size |  | 28dp |  |
+| FAB - Size - Medium | Shape | FAB medium container shape | md.comp.fab.medium.container.shape | md.sys.shape.corner.large-increased | 20dp | Resolved as rounded corners. |
+
+### FAB - Size - Large
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| FAB - Size - Large | Layout | FAB large container height | md.comp.fab.large.container.height |  | 96dp |  |
+| FAB - Size - Large | Layout | FAB large container width | md.comp.fab.large.container.width |  | 96dp |  |
+| FAB - Size - Large | Layout | FAB large icon size | md.comp.fab.large.icon.size |  | 36dp |  |
+| FAB - Size - Large | Shape | FAB large container shape | md.comp.fab.large.container.shape | md.sys.shape.corner.extra-large | 28dp | Resolved as rounded corners. |

--- a/docs/md3/icon_buttons.md
+++ b/docs/md3/icon_buttons.md
@@ -1,0 +1,275 @@
+<!-- markdownlint-disable MD060 -->
+
+# Icon Buttons MD3 Specs
+
+**Source:** <https://m3.material.io/components/icon-buttons/specs>  
+**Collected:** 2026-04-25
+
+## Summary
+
+- Material Design 3 icon button specifications covering four color variants (Filled, Tonal, Outlined, Standard) and five size variants (Xsmall, Small, Medium, Large, Xlarge).
+- Five interactive states documented for color variants: Enabled, Disabled, Hovered, Focused, and Pressed.
+- Toggle icon button selected and unselected states are included where present in the MD3 token set.
+- Values and source tokens were scraped from the live token viewer payload for the Default / Light context.
+
+## Tokens & Specs
+
+### Token Sets Discovered
+
+| Token Set | Count | Type | Status |
+|---|---:|---|---|
+| Icon button - Color - Filled | 31 | Color | Active |
+| Icon button - Color - Tonal | 31 | Color | Active |
+| Icon button - Color - Outlined | 33 | Color | Active |
+| Icon button - Color - Standard | 26 | Color | Active |
+| Icon button - Size - Xsmall | 16 | Size | Active |
+| Icon button - Size - Small | 16 | Size | Active |
+| Icon button - Size - Medium | 16 | Size | Active |
+| Icon button - Size - Large | 16 | Size | Active |
+| Icon button - Size - Xlarge | 16 | Size | Active |
+
+### Icon button - Color - Filled
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Color - Filled | Enabled | Icon button filled container color | md.comp.icon-button.filled.container.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Filled | Disabled | Icon button filled disabled container color | md.comp.icon-button.filled.disabled.container.color | md.sys.color.on-surface | #1D1B20 |  |
+| Icon button - Color - Filled | Hovered | Icon button filled hovered state layer color | md.comp.icon-button.filled.hovered.state-layer.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Focused | Icon button filled focused state layer color | md.comp.icon-button.filled.focused.state-layer.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Pressed | Icon button filled pressed state layer color | md.comp.icon-button.filled.pressed.state-layer.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Enabled / Toggle unselected | Icon button filled container color - toggle (unselected) | md.comp.icon-button.filled.unselected.container.color | md.sys.color.surface-container | #F3EDF7 |  |
+| Icon button - Color - Filled | Disabled | Icon button filled disabled container opacity | md.comp.icon-button.filled.disabled.container.opacity |  | 0.1 |  |
+| Icon button - Color - Filled | Focused / Toggle unselected | Icon button filled focused state layer color - toggle (unselected) | md.comp.icon-button.filled.unselected.focused.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Filled | Pressed / Toggle unselected | Icon button filled pressed state layer color - toggle (unselected) | md.comp.icon-button.filled.unselected.pressed.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Filled | Disabled | Icon button filled disabled icon color | md.comp.icon-button.filled.disabled.icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Icon button - Color - Filled | Focused / Toggle selected | Icon button filled focused state layer color - toggle (selected) | md.comp.icon-button.filled.selected.focused.state-layer.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Pressed / Toggle selected | Icon button filled pressed state layer color - toggle (selected) | md.comp.icon-button.filled.selected.pressed.state-layer.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Disabled | Icon button filled disabled icon opacity | md.comp.icon-button.filled.disabled.icon.opacity |  | 0.38 |  |
+| Icon button - Color - Filled | Hovered / Toggle unselected | Icon button filled hovered state layer color - toggle (unselected) | md.comp.icon-button.filled.unselected.hovered.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Filled | Focused | Icon button filled focused state layer opacity | md.comp.icon-button.filled.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Filled | Enabled / Toggle selected | Icon button filled container color - toggle (selected) | md.comp.icon-button.filled.selected.container.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Filled | Hovered / Toggle selected | Icon button filled hovered state layer color - toggle (selected) | md.comp.icon-button.filled.selected.hovered.state-layer.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Focused | Icon button filled focused icon color | md.comp.icon-button.filled.focused.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Enabled | Icon button filled icon color | md.comp.icon-button.filled.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Hovered | Icon button filled hovered state layer opacity | md.comp.icon-button.filled.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Icon button - Color - Filled | Pressed | Icon button filled pressed state layer opacity | md.comp.icon-button.filled.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Filled | Enabled / Toggle unselected | Icon button filled icon color - toggle (unselected) | md.comp.icon-button.filled.unselected.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Filled | Hovered | Icon button filled hovered icon color | md.comp.icon-button.filled.hovered.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Focused / Toggle unselected | Icon button filled focused icon color - toggle (unselected) | md.comp.icon-button.filled.unselected.focused.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Filled | Pressed | Icon button filled pressed icon color | md.comp.icon-button.filled.pressed.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Enabled / Toggle selected | Icon button filled icon color - toggle (selected) | md.comp.icon-button.filled.selected.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Hovered / Toggle unselected | Icon button filled hovered icon color - toggle (unselected) | md.comp.icon-button.filled.unselected.hovered.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Filled | Focused / Toggle selected | Icon button filled focused icon color - toggle (selected) | md.comp.icon-button.filled.selected.focused.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Pressed / Toggle unselected | Icon button filled pressed icon color - toggle (unselected) | md.comp.icon-button.filled.unselected.pressed.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Filled | Hovered / Toggle selected | Icon button filled hovered icon color - toggle (selected) | md.comp.icon-button.filled.selected.hovered.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+| Icon button - Color - Filled | Pressed / Toggle selected | Icon button filled pressed icon color - toggle (selected) | md.comp.icon-button.filled.selected.pressed.icon.color | md.sys.color.on-primary | #FFFFFF |  |
+
+### Icon button - Color - Tonal
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Color - Tonal | Pressed | Icon button tonal pressed state layer color | md.comp.icon-button.tonal.pressed.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Focused | Icon button tonal focused state layer color | md.comp.icon-button.tonal.focused.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Hovered | Icon button tonal hovered state layer color | md.comp.icon-button.tonal.hovered.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Disabled | Icon button tonal disabled container color | md.comp.icon-button.tonal.disabled.container.color | md.sys.color.on-surface | #1D1B20 |  |
+| Icon button - Color - Tonal | Enabled | Icon button tonal container color | md.comp.icon-button.tonal.container.color | md.sys.color.secondary-container | #E8DEF8 |  |
+| Icon button - Color - Tonal | Disabled | Icon button tonal disabled container opacity | md.comp.icon-button.tonal.disabled.container.opacity |  | 0.1 |  |
+| Icon button - Color - Tonal | Enabled / Toggle unselected | Icon button tonal container color - toggle (unselected) | md.comp.icon-button.tonal.unselected.container.color | md.sys.color.secondary-container | #E8DEF8 |  |
+| Icon button - Color - Tonal | Hovered / Toggle unselected | Icon button tonal hovered state layer color - toggle (unselected) | md.comp.icon-button.tonal.unselected.hovered.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Focused / Toggle unselected | Icon button tonal focused state layer color - toggle (unselected) | md.comp.icon-button.tonal.unselected.focused.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Pressed / Toggle unselected | Icon button tonal pressed state layer color - toggle (unselected) | md.comp.icon-button.tonal.unselected.pressed.state-layer.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Disabled | Icon button tonal disabled icon color | md.comp.icon-button.tonal.disabled.icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Icon button - Color - Tonal | Enabled / Toggle selected | Icon button tonal container color - toggle (selected) | md.comp.icon-button.tonal.selected.container.color | md.sys.color.secondary | #625B71 |  |
+| Icon button - Color - Tonal | Hovered / Toggle selected | Icon button tonal hovered state layer color - toggle (selected) | md.comp.icon-button.tonal.selected.hovered.state-layer.color | md.sys.color.on-secondary | #FFFFFF |  |
+| Icon button - Color - Tonal | Focused / Toggle selected | Icon button tonal focused state layer color - toggle (selected) | md.comp.icon-button.tonal.selected.focused.state-layer.color | md.sys.color.on-secondary | #FFFFFF |  |
+| Icon button - Color - Tonal | Pressed / Toggle selected | Icon button tonal pressed state layer color - toggle (selected) | md.comp.icon-button.tonal.selected.pressed.state-layer.color | md.sys.color.on-secondary | #FFFFFF |  |
+| Icon button - Color - Tonal | Pressed | Icon button tonal pressed state layer opacity | md.comp.icon-button.tonal.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Tonal | Disabled | Icon button tonal disabled icon opacity | md.comp.icon-button.tonal.disabled.icon.opacity |  | 0.38 |  |
+| Icon button - Color - Tonal | Focused | Icon button tonal focused state layer opacity | md.comp.icon-button.tonal.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Tonal | Enabled | Icon button tonal icon color | md.comp.icon-button.tonal.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Focused | Icon button tonal focused icon color | md.comp.icon-button.tonal.focused.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Enabled / Toggle unselected | Icon button tonal icon color - toggle (unselected) | md.comp.icon-button.tonal.unselected.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Pressed | Icon button tonal pressed icon color | md.comp.icon-button.tonal.pressed.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Enabled / Toggle selected | Icon button tonal icon color - toggle (selected) | md.comp.icon-button.tonal.selected.icon.color | md.sys.color.on-secondary | #FFFFFF |  |
+| Icon button - Color - Tonal | Focused / Toggle unselected | Icon button tonal focused icon color - toggle (unselected) | md.comp.icon-button.tonal.unselected.focused.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Hovered | Icon button tonal hovered state layer opacity | md.comp.icon-button.tonal.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Icon button - Color - Tonal | Focused / Toggle selected | Icon button tonal focused icon color - toggle (selected) | md.comp.icon-button.tonal.selected.focused.icon.color | md.sys.color.on-secondary | #FFFFFF |  |
+| Icon button - Color - Tonal | Pressed / Toggle unselected | Icon button tonal pressed icon color - toggle (unselected) | md.comp.icon-button.tonal.unselected.pressed.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Hovered | Icon button tonal hovered icon color | md.comp.icon-button.tonal.hovered.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Pressed / Toggle selected | Icon button tonal pressed icon color - toggle (selected) | md.comp.icon-button.tonal.selected.pressed.icon.color | md.sys.color.on-secondary | #FFFFFF |  |
+| Icon button - Color - Tonal | Hovered / Toggle unselected | Icon button tonal hovered icon color - toggle (unselected) | md.comp.icon-button.tonal.unselected.hovered.icon.color | md.sys.color.on-secondary-container | #4A4458 |  |
+| Icon button - Color - Tonal | Hovered / Toggle selected | Icon button tonal hovered icon color - toggle (selected) | md.comp.icon-button.tonal.selected.hovered.icon.color | md.sys.color.on-secondary | #FFFFFF |  |
+
+### Icon button - Color - Outlined
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Color - Outlined | Hovered | Icon button outlined hovered state layer color | md.comp.icon-button.outlined.hovered.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Focused | Icon button outlined focused state layer color | md.comp.icon-button.outlined.focused.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Enabled | Icon button outlined color | md.comp.icon-button.outlined.outline.color | md.sys.color.outline-variant | #CAC4D0 |  |
+| Icon button - Color - Outlined | Disabled | Icon button outlined disabled outline color | md.comp.icon-button.outlined.disabled.outline.color | md.sys.color.outline-variant | #CAC4D0 |  |
+| Icon button - Color - Outlined | Focused / Toggle unselected | Icon button outlined focused state layer color - toggle (unselected) | md.comp.icon-button.outlined.unselected.focused.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Enabled / Toggle unselected | Icon button outlined color - toggle (unselected) | md.comp.icon-button.outlined.unselected.outline.color | md.sys.color.outline-variant | #CAC4D0 |  |
+| Icon button - Color - Outlined | Disabled / Toggle unselected | Icon button outlined disabled outline color (unselected) | md.comp.icon-button.outlined.unselected.disabled.outline.color | md.sys.color.outline-variant | #CAC4D0 |  |
+| Icon button - Color - Outlined | Enabled / Toggle selected | Icon button outlined container color - toggle (selected) | md.comp.icon-button.outlined.selected.container.color | md.sys.color.inverse-surface | #322F35 |  |
+| Icon button - Color - Outlined | Focused / Toggle selected | Icon button outlined focused state layer color - toggle (selected) | md.comp.icon-button.outlined.selected.focused.state-layer.color | md.sys.color.inverse-on-surface | #F5EFF7 |  |
+| Icon button - Color - Outlined | Disabled / Toggle selected | Icon button outlined disabled container color (selected) | md.comp.icon-button.outlined.selected.disabled.container.color | md.sys.color.on-surface | #1D1B20 |  |
+| Icon button - Color - Outlined | Enabled | Icon button outlined icon color | md.comp.icon-button.outlined.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Pressed | Icon button outlined pressed state layer color | md.comp.icon-button.outlined.pressed.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Disabled / Toggle selected | Icon button outlined disabled container opacity (selected) | md.comp.icon-button.outlined.selected.disabled.container.opacity |  | 0.1 |  |
+| Icon button - Color - Outlined | Enabled / Toggle unselected | Icon button outlined icon color - toggle (unselected) | md.comp.icon-button.outlined.unselected.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Hovered / Toggle unselected | Icon button outlined hovered state layer color - toggle (unselected) | md.comp.icon-button.outlined.unselected.hovered.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Pressed / Toggle unselected | Icon button outlined pressed state layer color - toggle (unselected) | md.comp.icon-button.outlined.unselected.pressed.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Disabled | Icon button outlined disabled icon color | md.comp.icon-button.outlined.disabled.icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Icon button - Color - Outlined | Enabled / Toggle selected | Icon button outlined icon color - toggle (selected) | md.comp.icon-button.outlined.selected.icon.color | md.sys.color.inverse-on-surface | #F5EFF7 |  |
+| Icon button - Color - Outlined | Hovered / Toggle selected | Icon button outlined hovered state layer color - toggle (selected) | md.comp.icon-button.outlined.selected.hovered.state-layer.color | md.sys.color.inverse-on-surface | #F5EFF7 |  |
+| Icon button - Color - Outlined | Focused | Icon button outlined focused state layer opacity | md.comp.icon-button.outlined.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Outlined | Pressed / Toggle selected | Icon button outlined pressed state layer color - toggle (selected) | md.comp.icon-button.outlined.selected.pressed.state-layer.color | md.sys.color.inverse-on-surface | #F5EFF7 |  |
+| Icon button - Color - Outlined | Disabled | Icon button outlined disabled icon opacity | md.comp.icon-button.outlined.disabled.icon.opacity |  | 0.38 |  |
+| Icon button - Color - Outlined | Hovered | Icon button outlined hovered state layer opacity | md.comp.icon-button.outlined.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Icon button - Color - Outlined | Focused | Icon button outlined focused icon color | md.comp.icon-button.outlined.focused.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Hovered | Icon button outlined hovered icon color | md.comp.icon-button.outlined.hovered.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Focused / Toggle unselected | Icon button outlined focused icon color - toggle (unselected) | md.comp.icon-button.outlined.unselected.focused.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Pressed | Icon button outlined pressed state layer opacity | md.comp.icon-button.outlined.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Outlined | Hovered / Toggle unselected | Icon button outlined hovered icon color - toggle (unselected) | md.comp.icon-button.outlined.unselected.hovered.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Focused / Toggle selected | Icon button outlined focused icon color - toggle (selected) | md.comp.icon-button.outlined.selected.focused.icon.color | md.sys.color.inverse-on-surface | #F5EFF7 |  |
+| Icon button - Color - Outlined | Pressed | Icon button outlined pressed icon color | md.comp.icon-button.outlined.pressed.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Hovered / Toggle selected | Icon button outlined hovered icon color - toggle (selected) | md.comp.icon-button.outlined.selected.hovered.icon.color | md.sys.color.inverse-on-surface | #F5EFF7 |  |
+| Icon button - Color - Outlined | Pressed / Toggle unselected | Icon button outlined pressed icon color - toggle (unselected) | md.comp.icon-button.outlined.unselected.pressed.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Outlined | Pressed / Toggle selected | Icon button outlined pressed icon color - toggle (selected) | md.comp.icon-button.outlined.selected.pressed.icon.color | md.sys.color.inverse-on-surface | #F5EFF7 |  |
+
+### Icon button - Color - Standard
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Color - Standard | Disabled | Icon button disabled icon color | md.comp.icon-button.standard.disabled.icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Icon button - Color - Standard | Enabled | Icon button icon color | md.comp.icon-button.standard.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Hovered | Icon button hovered state layer color | md.comp.icon-button.standard.hovered.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Focused | Icon button focused state layer color | md.comp.icon-button.standard.focused.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Pressed | Icon button pressed state layer color | md.comp.icon-button.standard.pressed.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Disabled | Icon button disabled opacity | md.comp.icon-button.standard.disabled.icon.opacity |  | 0.38 |  |
+| Icon button - Color - Standard | Hovered / Toggle unselected | Icon button hovered state layer color - toggle (unselected) | md.comp.icon-button.standard.unselected.hovered.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Focused / Toggle unselected | Icon button focused state layer color - toggle (unselected) | md.comp.icon-button.standard.unselected.focused.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Enabled / Toggle unselected | Icon button icon color - toggle (unselected) | md.comp.icon-button.standard.unselected.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Hovered / Toggle selected | Icon button hovered state layer color - toggle (selected) | md.comp.icon-button.standard.selected.hovered.state-layer.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Standard | Focused / Toggle selected | Icon button focused state layer color - toggle (selected) | md.comp.icon-button.standard.selected.focused.state-layer.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Standard | Pressed / Toggle unselected | Icon button pressed state layer color - toggle (unselected) | md.comp.icon-button.standard.unselected.pressed.state-layer.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Enabled / Toggle selected | Icon button icon color - toggle (selected) | md.comp.icon-button.standard.selected.icon.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Standard | Focused | Icon button focused state layer opacity | md.comp.icon-button.standard.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Standard | Hovered | Icon button hovered state layer opacity | md.comp.icon-button.standard.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Icon button - Color - Standard | Pressed / Toggle selected | Icon button pressed state layer color - toggle (selected) | md.comp.icon-button.standard.selected.pressed.state-layer.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Standard | Pressed | Icon button pressed state layer opacity | md.comp.icon-button.standard.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1 |  |
+| Icon button - Color - Standard | Focused | Icon button focused icon color | md.comp.icon-button.standard.focused.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Hovered | Icon button hovered icon color | md.comp.icon-button.standard.hovered.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Pressed | Icon button pressed icon color | md.comp.icon-button.standard.pressed.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Hovered / Toggle unselected | Icon button hovered icon color - toggle (unselected) | md.comp.icon-button.standard.unselected.hovered.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Focused / Toggle unselected | Icon button focused icon color - toggle (unselected) | md.comp.icon-button.standard.unselected.focused.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Hovered / Toggle selected | Icon button hovered icon color - toggle (selected) | md.comp.icon-button.standard.selected.hovered.icon.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Standard | Focused / Toggle selected | Icon button focused icon color - toggle (selected) | md.comp.icon-button.standard.selected.focused.icon.color | md.sys.color.primary | #6750A4 |  |
+| Icon button - Color - Standard | Pressed / Toggle unselected | Icon button pressed icon color - toggle (unselected) | md.comp.icon-button.standard.unselected.pressed.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Icon button - Color - Standard | Pressed / Toggle selected | Icon button pressed icon color - toggle (selected) | md.comp.icon-button.standard.selected.pressed.icon.color | md.sys.color.primary | #6750A4 |  |
+
+### Icon button - Size - Xsmall
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Size - Xsmall | Layout | Icon button xsmall container height | md.comp.icon-button.xsmall.container.height |  | 32dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall icon size | md.comp.icon-button.xsmall.icon.size |  | 20dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall narrow leading space | md.comp.icon-button.xsmall.narrow.leading-space |  | 4dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall narrow trailing space | md.comp.icon-button.xsmall.narrow.trailing-space |  | 4dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall default leading space | md.comp.icon-button.xsmall.default.leading-space |  | 6dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall default trailing space | md.comp.icon-button.xsmall.default.trailing-space |  | 6dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall wide leading space | md.comp.icon-button.xsmall.wide.leading-space |  | 10dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall wide trailing space | md.comp.icon-button.xsmall.wide.trailing-space |  | 10dp |  |
+| Icon button - Size - Xsmall | Shape | Icon button xsmall container shape round | md.comp.icon-button.xsmall.container.shape.round | md.sys.shape.corner.full | Circular | Resolved from the token payload as a circular shape. |
+| Icon button - Size - Xsmall | Shape | Icon button xsmall container shape square | md.comp.icon-button.xsmall.container.shape.square | md.sys.shape.corner.medium | 12dp |  |
+| Icon button - Size - Xsmall | Layout | Icon button xsmall outline width | md.comp.icon-button.xsmall.outlined.outline.width |  | 1dp |  |
+| Icon button - Size - Xsmall | Shape (pressed) | Icon button xsmall shape pressed morph | md.comp.icon-button.xsmall.pressed.container.shape | md.sys.shape.corner.small | 8dp |  |
+| Icon button - Size - Xsmall | Motion | Icon button xsmall shape spring animation damping | md.comp.icon-button.xsmall.pressed.container.corner-size.motion.spring.damping | md.sys.motion.spring.fast.spatial.damping | 0.9 |  |
+| Icon button - Size - Xsmall | Motion | Icon button xsmall shape spring animation stiffness | md.comp.icon-button.xsmall.pressed.container.corner-size.motion.spring.stiffness | md.sys.motion.spring.fast.spatial.stiffness | 1400 |  |
+| Icon button - Size - Xsmall | Shape (selected) | Icon button xsmall selected container shape round | md.comp.icon-button.xsmall.selected.container.shape.round | md.sys.shape.corner.medium | 12dp |  |
+| Icon button - Size - Xsmall | Shape (selected) | Icon button xsmall selected container shape square | md.comp.icon-button.xsmall.selected.container.shape.square | md.sys.shape.corner.full | Circular | Selected square variant resolves to the inverse resting circular shape in the token payload. |
+
+### Icon button - Size - Small
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Size - Small | Layout | Icon button small container height | md.comp.icon-button.small.container.height |  | 40dp |  |
+| Icon button - Size - Small | Layout | Icon button small icon size | md.comp.icon-button.small.icon.size |  | 24dp |  |
+| Icon button - Size - Small | Layout | Icon button small narrow leading space | md.comp.icon-button.small.narrow.leading-space |  | 4dp |  |
+| Icon button - Size - Small | Layout | Icon button small narrow trailing space | md.comp.icon-button.small.narrow.trailing-space |  | 4dp |  |
+| Icon button - Size - Small | Layout | Icon button small default leading space | md.comp.icon-button.small.default.leading-space |  | 8dp |  |
+| Icon button - Size - Small | Layout | Icon button small default trailing space | md.comp.icon-button.small.default.trailing-space |  | 8dp |  |
+| Icon button - Size - Small | Layout | Icon button small wide leading space | md.comp.icon-button.small.wide.leading-space |  | 14dp |  |
+| Icon button - Size - Small | Layout | Icon button small wide trailing space | md.comp.icon-button.small.wide.trailing-space |  | 14dp |  |
+| Icon button - Size - Small | Shape | Icon button small container shape round | md.comp.icon-button.small.container.shape.round | md.sys.shape.corner.full | Circular | Resolved from the token payload as a circular shape. |
+| Icon button - Size - Small | Shape | Icon button small container shape square | md.comp.icon-button.small.container.shape.square | md.sys.shape.corner.medium | 12dp |  |
+| Icon button - Size - Small | Layout | Icon button small outline width | md.comp.icon-button.small.outlined.outline.width |  | 1dp |  |
+| Icon button - Size - Small | Shape (pressed) | Icon button small shape pressed morph | md.comp.icon-button.small.pressed.container.shape | md.sys.shape.corner.small | 8dp |  |
+| Icon button - Size - Small | Motion | Icon button small shape spring animation damping | md.comp.icon-button.small.pressed.container.corner-size.motion.spring.damping | md.sys.motion.spring.fast.spatial.damping | 0.9 |  |
+| Icon button - Size - Small | Motion | Icon button small shape spring animation stiffness | md.comp.icon-button.small.pressed.container.corner-size.motion.spring.stiffness | md.sys.motion.spring.fast.spatial.stiffness | 1400 |  |
+| Icon button - Size - Small | Shape (selected) | Icon button small selected container shape round | md.comp.icon-button.small.selected.container.shape.round | md.sys.shape.corner.medium | 12dp |  |
+| Icon button - Size - Small | Shape (selected) | Icon button small selected container shape square | md.comp.icon-button.small.selected.container.shape.square | md.sys.shape.corner.full | Circular | Selected square variant resolves to the inverse resting circular shape in the token payload. |
+
+### Icon button - Size - Medium
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Size - Medium | Layout | Icon button medium container height | md.comp.icon-button.medium.container.height |  | 56dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium icon size | md.comp.icon-button.medium.icon.size |  | 24dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium narrow leading space | md.comp.icon-button.medium.narrow.leading-space |  | 12dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium narrow trailing space | md.comp.icon-button.medium.narrow.trailing-space |  | 12dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium default leading space | md.comp.icon-button.medium.default.leading-space |  | 16dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium default trailing space | md.comp.icon-button.medium.default.trailing-space |  | 16dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium wide leading space | md.comp.icon-button.medium.wide.leading-space |  | 24dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium wide trailing space | md.comp.icon-button.medium.wide.trailing-space |  | 24dp |  |
+| Icon button - Size - Medium | Shape | Icon button medium container shape round | md.comp.icon-button.medium.container.shape.round | md.sys.shape.corner.full | Circular | Resolved from the token payload as a circular shape. |
+| Icon button - Size - Medium | Shape | Icon button medium container shape square | md.comp.icon-button.medium.container.shape.square | md.sys.shape.corner.large | 16dp |  |
+| Icon button - Size - Medium | Layout | Icon button medium outline width | md.comp.icon-button.medium.outlined.outline.width |  | 1dp |  |
+| Icon button - Size - Medium | Shape (pressed) | Icon button medium shape pressed morph | md.comp.icon-button.medium.pressed.container.shape | md.sys.shape.corner.medium | 12dp |  |
+| Icon button - Size - Medium | Motion | Icon button medium shape spring animation damping | md.comp.icon-button.medium.pressed.container.corner-size.motion.spring.damping | md.sys.motion.spring.fast.spatial.damping | 0.9 |  |
+| Icon button - Size - Medium | Motion | Icon button medium shape spring animation stiffness | md.comp.icon-button.medium.pressed.container.corner-size.motion.spring.stiffness | md.sys.motion.spring.fast.spatial.stiffness | 1400 |  |
+| Icon button - Size - Medium | Shape (selected) | Icon button medium selected container shape round | md.comp.icon-button.medium.selected.container.shape.round | md.sys.shape.corner.large | 16dp |  |
+| Icon button - Size - Medium | Shape (selected) | Icon button medium selected container shape square | md.comp.icon-button.medium.selected.container.shape.square | md.sys.shape.corner.full | Circular | Selected square variant resolves to the inverse resting circular shape in the token payload. |
+
+### Icon button - Size - Large
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Size - Large | Layout | Icon button large container height | md.comp.icon-button.large.container.height |  | 96dp |  |
+| Icon button - Size - Large | Layout | Icon button large icon size | md.comp.icon-button.large.icon.size |  | 32dp |  |
+| Icon button - Size - Large | Layout | Icon button large narrow leading space | md.comp.icon-button.large.narrow.leading-space |  | 16dp |  |
+| Icon button - Size - Large | Layout | Icon button large narrow trailing space | md.comp.icon-button.large.narrow.trailing-space |  | 16dp |  |
+| Icon button - Size - Large | Layout | Icon button large default leading space | md.comp.icon-button.large.default.leading-space |  | 32dp |  |
+| Icon button - Size - Large | Layout | Icon button large default trailing space | md.comp.icon-button.large.default.trailing-space |  | 32dp |  |
+| Icon button - Size - Large | Layout | Icon button large wide leading space | md.comp.icon-button.large.wide.leading-space |  | 48dp |  |
+| Icon button - Size - Large | Layout | Icon button large wide trailing space | md.comp.icon-button.large.wide.trailing-space |  | 48dp |  |
+| Icon button - Size - Large | Shape | Icon button large container shape round | md.comp.icon-button.large.container.shape.round | md.sys.shape.corner.full | Circular | Resolved from the token payload as a circular shape. |
+| Icon button - Size - Large | Shape | Icon button large container shape square | md.comp.icon-button.large.container.shape.square | md.sys.shape.corner.extra-large | 28dp |  |
+| Icon button - Size - Large | Layout | Icon button large outline width | md.comp.icon-button.large.outlined.outline.width |  | 2dp |  |
+| Icon button - Size - Large | Shape (pressed) | Icon button large shape pressed morph | md.comp.icon-button.large.pressed.container.shape | md.sys.shape.corner.large | 16dp |  |
+| Icon button - Size - Large | Motion | Icon button large shape spring animation damping | md.comp.icon-button.large.pressed.container.corner-size.motion.spring.damping | md.sys.motion.spring.fast.spatial.damping | 0.9 |  |
+| Icon button - Size - Large | Motion | Icon button large shape spring animation stiffness | md.comp.icon-button.large.pressed.container.corner-size.motion.spring.stiffness | md.sys.motion.spring.fast.spatial.stiffness | 1400 |  |
+| Icon button - Size - Large | Shape (selected) | Icon button large selected container shape round | md.comp.icon-button.large.selected.container.shape.round | md.sys.shape.corner.extra-large | 28dp |  |
+| Icon button - Size - Large | Shape (selected) | Icon button large selected container shape square | md.comp.icon-button.large.selected.container.shape.square | md.sys.shape.corner.full | Circular | Selected square variant resolves to the inverse resting circular shape in the token payload. |
+
+### Icon button - Size - Xlarge
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Icon button - Size - Xlarge | Layout | Icon button xlarge container height | md.comp.icon-button.xlarge.container.height |  | 136dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge icon size | md.comp.icon-button.xlarge.icon.size |  | 40dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge narrow leading space | md.comp.icon-button.xlarge.narrow.leading-space |  | 32dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge narrow trailing space | md.comp.icon-button.xlarge.narrow.trailing-space |  | 32dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge default leading space | md.comp.icon-button.xlarge.default.leading-space |  | 48dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge default trailing space | md.comp.icon-button.xlarge.default.trailing-space |  | 48dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge wide leading space | md.comp.icon-button.xlarge.wide.leading-space |  | 72dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge wide trailing space | md.comp.icon-button.xlarge.wide.trailing-space |  | 72dp |  |
+| Icon button - Size - Xlarge | Shape | Icon button xlarge container shape round | md.comp.icon-button.xlarge.container.shape.round | md.sys.shape.corner.full | Circular | Resolved from the token payload as a circular shape. |
+| Icon button - Size - Xlarge | Shape | Icon button xlarge container shape square | md.comp.icon-button.xlarge.container.shape.square | md.sys.shape.corner.extra-large | 28dp |  |
+| Icon button - Size - Xlarge | Layout | Icon button xlarge outline width | md.comp.icon-button.xlarge.outlined.outline.width |  | 3dp |  |
+| Icon button - Size - Xlarge | Shape (pressed) | Icon button xlarge shape pressed morph | md.comp.icon-button.xlarge.pressed.container.shape | md.sys.shape.corner.large | 16dp |  |
+| Icon button - Size - Xlarge | Motion | Icon button xlarge shape spring animation damping | md.comp.icon-button.xlarge.pressed.container.corner-size.motion.spring.damping | md.sys.motion.spring.fast.spatial.damping | 0.9 |  |
+| Icon button - Size - Xlarge | Motion | Icon button xlarge shape spring animation stiffness | md.comp.icon-button.xlarge.pressed.container.corner-size.motion.spring.stiffness | md.sys.motion.spring.fast.spatial.stiffness | 1400 |  |
+| Icon button - Size - Xlarge | Shape (selected) | Icon button xlarge selected container shape round | md.comp.icon-button.xlarge.selected.container.shape.round | md.sys.shape.corner.extra-large | 28dp |  |
+| Icon button - Size - Xlarge | Shape (selected) | Icon button xlarge selected container shape square | md.comp.icon-button.xlarge.selected.container.shape.square | md.sys.shape.corner.full | Circular | Selected square variant resolves to the inverse resting circular shape in the token payload. |

--- a/scripts/debug/instrument_and_render.py
+++ b/scripts/debug/instrument_and_render.py
@@ -109,7 +109,7 @@ TARGETS = [
     ("nuiitivet.material.buttons", "ElevatedButton", ("preferred_size", "paint")),
     ("nuiitivet.material.buttons", "TextButton", ("preferred_size", "paint")),
     ("nuiitivet.material.buttons", "OutlinedButton", ("preferred_size", "paint")),
-    ("nuiitivet.material.buttons", "FloatingActionButton", ("preferred_size", "paint")),
+    ("nuiitivet.material.buttons", "Fab", ("preferred_size", "paint")),
 ]
 
 

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -10,13 +10,14 @@ if TYPE_CHECKING:
     from .divider import Divider
     from .buttons import (
         Button,
-        FloatingActionButton,
+        Fab,
         IconButton,
         IconToggleButton,
         ToggleButton,
     )
     from .styles.button_style import ButtonStyle, IconButtonStyle, IconToggleButtonStyle
-    from .styles.button_size import ButtonSize
+    from .styles.button_size import ButtonSize, FabSize
+    from .styles.fab_style import FabStyle
     from .styles.toggle_button_style import ToggleButtonStyle
     from .card import Card
     from .styles.card_style import CardStyle
@@ -91,7 +92,7 @@ __all__ = [
     "SuggestionChip",
     "Button",
     "ToggleButton",
-    "FloatingActionButton",
+    "Fab",
     "IconButton",
     "IconToggleButton",
     "ButtonStyle",
@@ -99,6 +100,8 @@ __all__ = [
     "IconButtonStyle",
     "IconToggleButtonStyle",
     "ButtonSize",
+    "FabStyle",
+    "FabSize",
     "TextField",
     "TextFieldStyle",
     "NavigationRail",
@@ -172,7 +175,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "SuggestionChip": ("chip", "SuggestionChip"),
     "Button": ("buttons", "Button"),
     "ToggleButton": ("buttons", "ToggleButton"),
-    "FloatingActionButton": ("buttons", "FloatingActionButton"),
+    "Fab": ("buttons", "Fab"),
     "IconButton": ("buttons", "IconButton"),
     "IconToggleButton": ("buttons", "IconToggleButton"),
     "ButtonStyle": ("styles.button_style", "ButtonStyle"),
@@ -180,6 +183,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "IconToggleButtonStyle": ("styles.button_style", "IconToggleButtonStyle"),
     "ToggleButtonStyle": ("styles.toggle_button_style", "ToggleButtonStyle"),
     "ButtonSize": ("styles.button_size", "ButtonSize"),
+    "FabStyle": ("styles.fab_style", "FabStyle"),
+    "FabSize": ("styles.button_size", "FabSize"),
     "TextField": ("text_fields", "TextField"),
     "TextFieldStyle": ("styles.text_field_style", "TextFieldStyle"),
     "NavigationRail": ("navigation_rail", "NavigationRail"),

--- a/src/nuiitivet/material/buttons.py
+++ b/src/nuiitivet/material/buttons.py
@@ -9,7 +9,7 @@ This module contains the unified Material Design 3 button widgets:
   :class:`ToggleButtonStyle` that carries both selected and unselected
   state tokens.
 - :class:`IconButton`, :class:`IconToggleButton` -- icon-only variants.
-- :class:`FloatingActionButton` -- FAB.
+- :class:`Fab` -- Floating Action Button.
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
 from nuiitivet.animation import Animatable, LinearMotion, RgbaTupleConverter
 from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL
 from nuiitivet.material.styles.button_style import ButtonStyle, IconButtonStyle, IconToggleButtonStyle
+from nuiitivet.material.styles.fab_style import FabStyle
 from nuiitivet.material.styles.toggle_button_style import ToggleButtonStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.interactive_widget import InteractiveWidget
@@ -740,7 +741,6 @@ class IconButton(MaterialButtonBase):
         *,
         on_click: Optional[Callable[[], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
-        size: int = 40,
         style: Optional[ButtonStyle] = None,
     ):
         """Initialize IconButton.
@@ -749,35 +749,30 @@ class IconButton(MaterialButtonBase):
             icon: Icon glyph source.
             on_click: Callback invoked when the button is clicked.
             disabled: Whether the button is disabled.
-            size: Visual container size in pixels.
-            style: Icon button style preset or custom style.
+            style: Icon button style preset or custom style.  Defaults to
+                :meth:`IconButtonStyle.standard` (size ``"s"``, 40dp).  Use
+                size-aware factories such as ``IconButtonStyle.filled("m")``
+                to control container/icon sizing.
         """
-        resolved_size = max(1, int(size))
-        base_style = style if style is not None else IconButtonStyle.standard()
-        effective_style = base_style.copy_with(
-            container_height=resolved_size,
-            corner_radius=resolved_size // 2,
-            min_width=max(int(getattr(base_style, "min_width", 48) or 48), 48, resolved_size),
-            min_height=max(int(getattr(base_style, "min_height", 48) or 48), 48, resolved_size),
-        )
+        effective_style = style if style is not None else IconButtonStyle.standard()
 
         self._user_style = effective_style
         self._user_padding = None
-        self._user_height = resolved_size
+        self._user_height = effective_style.container_height
 
         child_widget = build_button_child(
             label=None,
             icon=icon,
             foreground=effective_style.foreground if effective_style else ColorRole.ON_SURFACE,
-            button_height=resolved_size,
+            button_height=effective_style.container_height,
             style=effective_style,
         )
 
-        params = resolve_button_style_params(effective_style, None, resolved_size, disabled)
+        params = resolve_button_style_params(effective_style, None, effective_style.container_height, disabled)
         super().__init__(
             child=child_widget,
             on_click=on_click,
-            width=resolved_size,
+            width=effective_style.container_height,
             disabled=disabled,
             **params,
         )
@@ -1016,7 +1011,6 @@ class IconToggleButton(ToggleButtonBase):
         selected: bool | ObservableProtocol[bool] = False,
         on_change: Optional[Callable[[bool], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
-        size: int = 40,
         style: Optional[IconToggleButtonStyle] = None,
     ):
         """Initialize IconToggleButton.
@@ -1026,11 +1020,14 @@ class IconToggleButton(ToggleButtonBase):
             selected: Selected state value or observable.
             on_change: Callback invoked with the new selected state.
             disabled: Whether the button is disabled.
-            size: Visual container size in pixels.
             style: Toggle style pair for selected and unselected states.
+                Defaults to :meth:`IconToggleButtonStyle.standard` (size
+                ``"s"``).  Use size-aware factories such as
+                ``IconToggleButtonStyle.filled("m")`` to control sizing.
         """
-        self._icon_size = max(1, int(size))
         self._icon_toggle_style = style if style is not None else IconToggleButtonStyle.standard()
+        # Both selected/unselected share container_height per factory contract.
+        self._icon_size = self._icon_toggle_style.unselected.container_height
 
         super().__init__(
             label=None,
@@ -1044,18 +1041,11 @@ class IconToggleButton(ToggleButtonBase):
         )
 
     def _resolve_style_for_selected(self, selected: bool) -> ButtonStyle:
-        base_style = self._icon_toggle_style.selected if selected else self._icon_toggle_style.unselected
-        return base_style.copy_with(
-            container_height=self._icon_size,
-            corner_radius=self._icon_size // 2,
-            min_width=max(int(getattr(base_style, "min_width", 48) or 48), 48, self._icon_size),
-            min_height=max(int(getattr(base_style, "min_height", 48) or 48), 48, self._icon_size),
-            padding=0,
-        )
+        return self._icon_toggle_style.selected if selected else self._icon_toggle_style.unselected
 
 
-class FloatingActionButton(MaterialButtonBase):
-    """Minimal Floating Action Button (rectangular for now)."""
+class Fab(MaterialButtonBase):
+    """Material Design 3 Floating Action Button (FAB)."""
 
     def __init__(
         self,
@@ -1063,26 +1053,30 @@ class FloatingActionButton(MaterialButtonBase):
         *,
         on_click: Optional[Callable[[], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
-        size: int = 56,
         padding: Optional[Union[int, Tuple[int, int, int, int]]] = None,
-        style: Optional[ButtonStyle] = None,
+        style: Optional[FabStyle] = None,
     ):
-        """Initialize FloatingActionButton.
+        """Initialize Fab.
 
         Args:
             icon: Icon for the button.
             on_click: Callback to be invoked when the button is clicked.
             disabled: Whether the button is disabled.
-            size: Size of the FAB (width and height).
-            padding: Padding specification.
-            style: Custom ButtonStyle.
+            padding: Padding specification.  When ``None``, ``style.padding``
+                is used.
+            style: FAB style preset.  Defaults to :meth:`FabStyle.primary`
+                (size ``"s"``, 56dp).  Use ``FabStyle.primary("m")`` /
+                ``FabStyle.primary("l")`` for the 80dp / 96dp variants, or
+                ``FabStyle.secondary`` / ``FabStyle.tertiary`` for alternative
+                tonal colour sets.
         """
-        self._user_style = style if style is not None else ButtonStyle.fab()
+        self._user_style: FabStyle = style if style is not None else FabStyle.primary()
         self._user_padding = padding
+        size = self._user_style.container_height
         self._user_height = size
 
         effective_style = self.style
-        text_color = effective_style.foreground if effective_style else ColorRole.ON_PRIMARY
+        text_color = effective_style.foreground if effective_style else ColorRole.ON_PRIMARY_CONTAINER
 
         child_widget = build_button_child(
             None,

--- a/src/nuiitivet/material/styles/button_size.py
+++ b/src/nuiitivet/material/styles/button_size.py
@@ -2,10 +2,15 @@
 
 Provides the :data:`ButtonSize` literal and :data:`BUTTON_SIZE_TOKENS` table
 used by ``ButtonStyle``, ``ToggleButtonStyle`` and ``ButtonGroupStyle``
-factories.  All values follow the M3 Button spec:
-https://m3.material.io/components/buttons/specs
+factories, plus :data:`ICON_BUTTON_SIZE_TOKENS` for ``IconButtonStyle`` /
+``IconToggleButtonStyle`` and :data:`FAB_SIZE_TOKENS` for ``Fab``.
 
-The table intentionally models the *round* shape variant only (circular
+All values follow the M3 component specs:
+- https://m3.material.io/components/buttons/specs
+- https://m3.material.io/components/icon-buttons/specs
+- https://m3.material.io/components/floating-action-button/specs
+
+The tables intentionally model the *round* shape variant only (circular
 corner radius).  Shape morphing and square variants are out of scope for
 the initial style-driven refactor.
 """
@@ -85,4 +90,117 @@ BUTTON_SIZE_TOKENS: dict[ButtonSize, ButtonSizeTokens] = {
 }
 
 
-__all__ = ["ButtonSize", "ButtonSizeTokens", "BUTTON_SIZE_TOKENS"]
+__all__ = [
+    "ButtonSize",
+    "ButtonSizeTokens",
+    "BUTTON_SIZE_TOKENS",
+    "IconButtonSizeTokens",
+    "ICON_BUTTON_SIZE_TOKENS",
+    "FabSize",
+    "FabSizeTokens",
+    "FAB_SIZE_TOKENS",
+]
+
+
+class IconButtonSizeTokens(TypedDict):
+    """Typed view over a single :data:`ICON_BUTTON_SIZE_TOKENS` row."""
+
+    container_height: int
+    icon_size: int
+    leading_space: int
+    trailing_space: int
+    corner_radius: int
+    outline_width: float
+
+
+# Values from https://m3.material.io/components/icon-buttons/specs
+# (default leading/trailing spacing; round variant; circular corner radius).
+ICON_BUTTON_SIZE_TOKENS: dict[ButtonSize, IconButtonSizeTokens] = {
+    "xs": {
+        "container_height": 32,
+        "icon_size": 20,
+        "leading_space": 6,
+        "trailing_space": 6,
+        "corner_radius": 16,
+        "outline_width": 1.0,
+    },
+    "s": {
+        "container_height": 40,
+        "icon_size": 24,
+        "leading_space": 8,
+        "trailing_space": 8,
+        "corner_radius": 20,
+        "outline_width": 1.0,
+    },
+    "m": {
+        "container_height": 56,
+        "icon_size": 24,
+        "leading_space": 16,
+        "trailing_space": 16,
+        "corner_radius": 28,
+        "outline_width": 1.0,
+    },
+    "l": {
+        "container_height": 96,
+        "icon_size": 32,
+        "leading_space": 32,
+        "trailing_space": 32,
+        "corner_radius": 48,
+        "outline_width": 2.0,
+    },
+    "xl": {
+        "container_height": 136,
+        "icon_size": 40,
+        "leading_space": 48,
+        "trailing_space": 48,
+        "corner_radius": 68,
+        "outline_width": 3.0,
+    },
+}
+
+
+FabSize = Literal["s", "m", "l"]
+"""Framework-unified FAB size preset.
+
+The literal values follow the project-wide ``s``/``m``/``l`` convention rather
+than the MD3 spec wording (``FAB`` / ``Medium FAB`` / ``Large FAB``):
+
+- ``"s"`` corresponds to the baseline 56dp FAB (MD3 "FAB").
+- ``"m"`` corresponds to the 80dp Medium FAB.
+- ``"l"`` corresponds to the 96dp Large FAB.
+
+The deprecated 40dp Small FAB is intentionally not represented.
+"""
+
+
+class FabSizeTokens(TypedDict):
+    """Typed view over a single :data:`FAB_SIZE_TOKENS` row."""
+
+    container_height: int
+    container_width: int
+    icon_size: int
+    corner_radius: int
+
+
+# Values from https://m3.material.io/components/floating-action-button/specs.
+# The Small FAB (40dp) is deprecated and excluded.
+FAB_SIZE_TOKENS: dict[FabSize, FabSizeTokens] = {
+    "s": {
+        "container_height": 56,
+        "container_width": 56,
+        "icon_size": 24,
+        "corner_radius": 16,
+    },
+    "m": {
+        "container_height": 80,
+        "container_width": 80,
+        "icon_size": 28,
+        "corner_radius": 20,
+    },
+    "l": {
+        "container_height": 96,
+        "container_width": 96,
+        "icon_size": 36,
+        "corner_radius": 28,
+    },
+}

--- a/src/nuiitivet/material/styles/button_style.py
+++ b/src/nuiitivet/material/styles/button_style.py
@@ -4,16 +4,23 @@
 for all visual variants).  Variant-specific styling is delivered through
 size-aware factory methods: :meth:`ButtonStyle.filled`,
 :meth:`ButtonStyle.outlined`, :meth:`ButtonStyle.text`,
-:meth:`ButtonStyle.elevated`, :meth:`ButtonStyle.tonal`.
+:meth:`ButtonStyle.elevated`, and :meth:`ButtonStyle.tonal`.
 
 The companion :class:`IconButtonStyle` / :class:`IconToggleButtonStyle`
-presets remain for the icon-only button family (out of scope for Issue #77).
+presets share the same ``ButtonSize`` token set as Button, but pull
+container / icon / spacing values from
+:data:`ICON_BUTTON_SIZE_TOKENS`.  FAB styling lives in
+:mod:`nuiitivet.material.styles.fab_style`.
 """
 
 from dataclasses import dataclass, replace
 from typing import Optional, Union, TYPE_CHECKING
 
-from .button_size import BUTTON_SIZE_TOKENS, ButtonSize
+from .button_size import (
+    BUTTON_SIZE_TOKENS,
+    ButtonSize,
+    ICON_BUTTON_SIZE_TOKENS,
+)
 from ..theme.color_role import ColorRole
 from nuiitivet.theme.types import ColorSpec
 
@@ -223,174 +230,138 @@ class ButtonStyle:
             overlay_alpha=0.08,
         )
 
-    # -- Non-size-aware factories (retained out of #77 scope) ---------------
-
-    @classmethod
-    def fab(cls) -> "ButtonStyle":
-        """Return the style used by :class:`FloatingActionButton`.
-
-        FAB is out of scope for the Issue #77 refactor and keeps a single
-        preset for now.
-        """
-        return cls(
-            background=ColorRole.PRIMARY,
-            foreground=ColorRole.ON_PRIMARY,
-            border_width=0.0,
-            corner_radius=16,
-            padding=(8, 8, 8, 8),
-            container_height=56,
-            min_width=56,
-            min_height=56,
-            label_font_size=14,
-            icon_size=24,
-            elevation=6.0,
-            overlay_color=ColorRole.ON_SURFACE,
-            overlay_alpha=0.08,
-        )
-
 
 class IconButtonStyle:
-    """Preset factories for icon-only button styles."""
+    """Preset factories for icon-only button styles.
+
+    Each factory accepts a :data:`ButtonSize` argument that drives container
+    size, icon size, corner radius, and outline width from
+    :data:`ICON_BUTTON_SIZE_TOKENS`.  Defaults to ``"s"`` (40dp).
+    """
+
+    @staticmethod
+    def _base(size: ButtonSize) -> dict:
+        """Return common size-driven keyword arguments for IconButton styles."""
+        t = ICON_BUTTON_SIZE_TOKENS[size]
+        h = t["container_height"]
+        return dict(
+            corner_radius=t["corner_radius"],
+            container_height=h,
+            padding=0,
+            min_width=max(48, h),
+            min_height=max(48, h),
+            icon_size=t["icon_size"],
+        )
 
     @classmethod
-    def standard(cls) -> ButtonStyle:
-        """Return the standard icon-button style."""
+    def standard(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the standard icon-button style at the given M3 size."""
         return ButtonStyle(
             background=None,
             foreground=ColorRole.ON_SURFACE_VARIANT,
             border_width=0.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
             elevation=0.0,
             overlay_color=ColorRole.ON_SURFACE,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
     @classmethod
-    def filled(cls) -> ButtonStyle:
-        """Return the filled icon-button style."""
+    def filled(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the filled icon-button style at the given M3 size."""
         return ButtonStyle(
             background=ColorRole.PRIMARY,
             foreground=ColorRole.ON_PRIMARY,
             border_width=0.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
             elevation=0.0,
             overlay_color=ColorRole.ON_PRIMARY,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
     @classmethod
-    def outlined(cls) -> ButtonStyle:
-        """Return the outlined icon-button style."""
+    def outlined(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the outlined icon-button style at the given M3 size."""
+        t = ICON_BUTTON_SIZE_TOKENS[size]
         return ButtonStyle(
             background=None,
             foreground=ColorRole.ON_SURFACE_VARIANT,
             border_color=ColorRole.OUTLINE,
-            border_width=1.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
+            border_width=t["outline_width"],
             elevation=0.0,
             overlay_color=ColorRole.ON_SURFACE,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
     @classmethod
-    def tonal(cls) -> ButtonStyle:
-        """Return the tonal icon-button style."""
+    def tonal(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the tonal icon-button style at the given M3 size."""
         return ButtonStyle(
             background=ColorRole.SECONDARY_CONTAINER,
             foreground=ColorRole.ON_SECONDARY_CONTAINER,
             border_width=0.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
             elevation=0.0,
             overlay_color=ColorRole.ON_SECONDARY_CONTAINER,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
     @classmethod
-    def vibrant(cls) -> ButtonStyle:
-        """Return the vibrant icon-button style.
+    def vibrant(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the vibrant icon-button style at the given M3 size.
 
-        This is intended for use on vibrant containers such as a vibrant toolbar.
+        Intended for use on vibrant containers such as a vibrant toolbar.
         """
         return ButtonStyle(
             background=None,
             foreground=ColorRole.ON_PRIMARY_CONTAINER,
             border_width=0.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
             elevation=0.0,
             overlay_color=ColorRole.ON_PRIMARY_CONTAINER,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
     @classmethod
-    def filled_vibrant(cls) -> ButtonStyle:
-        """Return the filled vibrant icon-button style."""
+    def filled_vibrant(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the filled vibrant icon-button style at the given M3 size."""
         return ButtonStyle(
             background=ColorRole.PRIMARY,
             foreground=ColorRole.ON_PRIMARY,
             border_width=0.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
             elevation=0.0,
             overlay_color=ColorRole.ON_PRIMARY,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
     @classmethod
-    def outlined_vibrant(cls) -> ButtonStyle:
-        """Return the outlined vibrant icon-button style."""
+    def outlined_vibrant(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the outlined vibrant icon-button style at the given M3 size."""
+        t = ICON_BUTTON_SIZE_TOKENS[size]
         return ButtonStyle(
             background=None,
             foreground=ColorRole.ON_PRIMARY_CONTAINER,
             border_color=ColorRole.ON_PRIMARY_CONTAINER,
-            border_width=1.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
+            border_width=t["outline_width"],
             elevation=0.0,
             overlay_color=ColorRole.ON_PRIMARY_CONTAINER,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
     @classmethod
-    def tonal_vibrant(cls) -> ButtonStyle:
-        """Return the tonal vibrant icon-button style."""
+    def tonal_vibrant(cls, size: ButtonSize = "s") -> ButtonStyle:
+        """Return the tonal vibrant icon-button style at the given M3 size."""
         return ButtonStyle(
             background=ColorRole.SURFACE_CONTAINER_HIGHEST,
             foreground=ColorRole.ON_SURFACE,
             border_width=0.0,
-            corner_radius=20,
-            container_height=40,
-            padding=0,
-            min_width=48,
-            min_height=48,
             elevation=0.0,
             overlay_color=ColorRole.ON_SURFACE,
             overlay_alpha=0.12,
+            **cls._base(size),
         )
 
 
@@ -402,95 +373,80 @@ class IconToggleButtonStyle:
     unselected: ButtonStyle
 
     @classmethod
-    def standard(cls) -> "IconToggleButtonStyle":
+    def standard(cls, size: ButtonSize = "s") -> "IconToggleButtonStyle":
         """Return styles for the standard icon-toggle button variant."""
+        base = IconButtonStyle._base(size)
         return cls(
             selected=ButtonStyle(
                 background=ColorRole.SECONDARY_CONTAINER,
                 foreground=ColorRole.ON_SECONDARY_CONTAINER,
                 border_width=0.0,
-                corner_radius=20,
-                container_height=40,
-                padding=0,
-                min_width=48,
-                min_height=48,
                 elevation=0.0,
                 overlay_color=ColorRole.ON_SECONDARY_CONTAINER,
                 overlay_alpha=0.12,
+                **base,
             ),
-            unselected=IconButtonStyle.standard(),
+            unselected=IconButtonStyle.standard(size),
         )
 
     @classmethod
-    def filled(cls) -> "IconToggleButtonStyle":
+    def filled(cls, size: ButtonSize = "s") -> "IconToggleButtonStyle":
         """Return styles for the filled icon-toggle button variant."""
+        base = IconButtonStyle._base(size)
         return cls(
-            selected=IconButtonStyle.filled(),
+            selected=IconButtonStyle.filled(size),
             unselected=ButtonStyle(
                 background=ColorRole.SURFACE_CONTAINER_HIGHEST,
                 foreground=ColorRole.ON_SURFACE_VARIANT,
                 border_width=0.0,
-                corner_radius=20,
-                container_height=40,
-                padding=0,
-                min_width=48,
-                min_height=48,
                 elevation=0.0,
                 overlay_color=ColorRole.ON_SURFACE,
                 overlay_alpha=0.12,
+                **base,
             ),
         )
 
     @classmethod
-    def outlined(cls) -> "IconToggleButtonStyle":
+    def outlined(cls, size: ButtonSize = "s") -> "IconToggleButtonStyle":
         """Return styles for the outlined icon-toggle button variant."""
+        t = ICON_BUTTON_SIZE_TOKENS[size]
+        base = IconButtonStyle._base(size)
         return cls(
             selected=ButtonStyle(
                 background=ColorRole.INVERSE_SURFACE,
                 foreground=ColorRole.INVERSE_ON_SURFACE,
                 border_color=ColorRole.INVERSE_SURFACE,
-                border_width=1.0,
-                corner_radius=20,
-                container_height=40,
-                padding=0,
-                min_width=48,
-                min_height=48,
+                border_width=t["outline_width"],
                 elevation=0.0,
                 overlay_color=ColorRole.INVERSE_ON_SURFACE,
                 overlay_alpha=0.12,
+                **base,
             ),
-            unselected=IconButtonStyle.outlined(),
+            unselected=IconButtonStyle.outlined(size),
         )
 
     @classmethod
-    def tonal(cls) -> "IconToggleButtonStyle":
+    def tonal(cls, size: ButtonSize = "s") -> "IconToggleButtonStyle":
         """Return styles for the tonal icon-toggle button variant."""
+        base = IconButtonStyle._base(size)
         return cls(
             selected=ButtonStyle(
                 background=ColorRole.TERTIARY_CONTAINER,
                 foreground=ColorRole.ON_TERTIARY_CONTAINER,
                 border_width=0.0,
-                corner_radius=20,
-                container_height=40,
-                padding=0,
-                min_width=48,
-                min_height=48,
                 elevation=0.0,
                 overlay_color=ColorRole.ON_TERTIARY_CONTAINER,
                 overlay_alpha=0.12,
+                **base,
             ),
             unselected=ButtonStyle(
                 background=ColorRole.SECONDARY_CONTAINER,
                 foreground=ColorRole.ON_SECONDARY_CONTAINER,
                 border_width=0.0,
-                corner_radius=20,
-                container_height=40,
-                padding=0,
-                min_width=48,
-                min_height=48,
                 elevation=0.0,
                 overlay_color=ColorRole.ON_SECONDARY_CONTAINER,
                 overlay_alpha=0.12,
+                **base,
             ),
         )
 

--- a/src/nuiitivet/material/styles/fab_style.py
+++ b/src/nuiitivet/material/styles/fab_style.py
@@ -1,0 +1,77 @@
+"""Style preset for the Material Design 3 :class:`Fab` widget.
+
+``FabStyle`` is a thin :class:`ButtonStyle` subclass that exposes the three
+*tonal* color variants defined by the current MD3 spec:
+
+- :meth:`FabStyle.primary` -- ``primary container`` / ``on primary container``
+- :meth:`FabStyle.secondary` -- ``secondary container`` / ``on secondary container``
+- :meth:`FabStyle.tertiary` -- ``tertiary container`` / ``on tertiary container``
+
+Each factory accepts a :data:`FabSize` (``"s"`` / ``"m"`` / ``"l"``) that
+selects container / icon / corner-radius tokens from
+:data:`FAB_SIZE_TOKENS`.  The default size is ``"s"`` (the 56dp baseline FAB).
+"""
+
+from dataclasses import dataclass
+
+from .button_size import FAB_SIZE_TOKENS, FabSize
+from .button_style import ButtonStyle
+from ..theme.color_role import ColorRole
+
+
+@dataclass(frozen=True)
+class FabStyle(ButtonStyle):
+    """Style preset used by the :class:`Fab` widget.
+
+    Inherits the field set of :class:`ButtonStyle` so that ``Fab`` can reuse
+    the shared ``resolve_button_style_params`` machinery without changes.
+    """
+
+    @staticmethod
+    def _base(size: FabSize) -> dict:
+        t = FAB_SIZE_TOKENS[size]
+        return dict(
+            border_width=0.0,
+            corner_radius=t["corner_radius"],
+            padding=(8, 8, 8, 8),
+            container_height=t["container_height"],
+            min_width=t["container_width"],
+            min_height=t["container_height"],
+            label_font_size=14,
+            icon_size=t["icon_size"],
+            elevation=6.0,
+            overlay_alpha=0.08,
+        )
+
+    @classmethod
+    def primary(cls, size: FabSize = "s") -> "FabStyle":
+        """Return the tonal-primary FAB style at the given size."""
+        return cls(
+            background=ColorRole.PRIMARY_CONTAINER,
+            foreground=ColorRole.ON_PRIMARY_CONTAINER,
+            overlay_color=ColorRole.ON_PRIMARY_CONTAINER,
+            **cls._base(size),
+        )
+
+    @classmethod
+    def secondary(cls, size: FabSize = "s") -> "FabStyle":
+        """Return the tonal-secondary FAB style at the given size."""
+        return cls(
+            background=ColorRole.SECONDARY_CONTAINER,
+            foreground=ColorRole.ON_SECONDARY_CONTAINER,
+            overlay_color=ColorRole.ON_SECONDARY_CONTAINER,
+            **cls._base(size),
+        )
+
+    @classmethod
+    def tertiary(cls, size: FabSize = "s") -> "FabStyle":
+        """Return the tonal-tertiary FAB style at the given size."""
+        return cls(
+            background=ColorRole.TERTIARY_CONTAINER,
+            foreground=ColorRole.ON_TERTIARY_CONTAINER,
+            overlay_color=ColorRole.ON_TERTIARY_CONTAINER,
+            **cls._base(size),
+        )
+
+
+__all__ = ["FabStyle"]

--- a/src/nuiitivet/material/theme/theme_data.py
+++ b/src/nuiitivet/material/theme/theme_data.py
@@ -10,6 +10,7 @@ from nuiitivet.theme.types import ThemeExtension
 
 if TYPE_CHECKING:
     from nuiitivet.material.styles.button_style import ButtonStyle
+    from nuiitivet.material.styles.fab_style import FabStyle
     from nuiitivet.material.styles.card_style import CardStyle
     from nuiitivet.material.styles.checkbox_style import CheckboxStyle
     from nuiitivet.material.styles.chip_style import ChipStyle
@@ -42,7 +43,7 @@ class MaterialThemeData(ThemeExtension):
     _text_button_style: "ButtonStyle | None" = None
     _elevated_button_style: "ButtonStyle | None" = None
     _tonal_button_style: "ButtonStyle | None" = None
-    _fab_style: "ButtonStyle | None" = None
+    _fab_style: "FabStyle | None" = None
 
     # Card variants
     _filled_card_style: "CardStyle | None" = None
@@ -120,13 +121,13 @@ class MaterialThemeData(ThemeExtension):
         return ButtonStyle.tonal()
 
     @property
-    def fab_style(self) -> "ButtonStyle":
-        """Get FAB ButtonStyle for this theme."""
+    def fab_style(self) -> "FabStyle":
+        """Get FAB style for this theme."""
         if self._fab_style is not None:
             return self._fab_style
-        from nuiitivet.material.styles.button_style import ButtonStyle
+        from nuiitivet.material.styles.fab_style import FabStyle
 
-        return ButtonStyle.fab()
+        return FabStyle.primary()
 
     @property
     def filled_card_style(self) -> "CardStyle":

--- a/src/samples/icon_buttons_demo.py
+++ b/src/samples/icon_buttons_demo.py
@@ -6,7 +6,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material import Text
 from nuiitivet.material import App
-from nuiitivet.material.buttons import FloatingActionButton, IconButton, IconToggleButton
+from nuiitivet.material.buttons import Fab, IconButton, IconToggleButton
 from nuiitivet.material.styles import IconButtonStyle, IconToggleButtonStyle
 from nuiitivet.observable import Observable
 from nuiitivet.widgets.box import Box
@@ -92,9 +92,9 @@ class IconButtonsDemoWidget:
                     Text("FAB (shape + expressive press)"),
                     Row(
                         [
-                            FloatingActionButton("add"),
-                            FloatingActionButton("edit"),
-                            FloatingActionButton("delete", disabled=True),
+                            Fab("add"),
+                            Fab("edit"),
+                            Fab("delete", disabled=True),
                         ],
                         gap=12,
                     ),

--- a/src/samples/my_widget.py
+++ b/src/samples/my_widget.py
@@ -25,7 +25,7 @@ from nuiitivet.layout.row import Row
 from nuiitivet.layout.scroller import Scroller
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.material.symbols import Symbols
-from nuiitivet.material.buttons import FloatingActionButton, Button
+from nuiitivet.material.buttons import Fab, Button
 from nuiitivet.theme import manager as theme_manager
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.scrollbar import ScrollbarBehavior
@@ -265,7 +265,7 @@ class MyWidget(ComposableWidget):
                         ),
                         Row(
                             [
-                                FloatingActionButton(Symbols.add, on_click=self.model.add_grid_item),
+                                Fab(Symbols.add, on_click=self.model.add_grid_item),
                                 Button(
                                     "Remove (Grid)",
                                     on_click=self.model.remove_grid_item,

--- a/tests/test_button_api.py
+++ b/tests/test_button_api.py
@@ -1,5 +1,5 @@
 import pytest
-from nuiitivet.material.buttons import FloatingActionButton, Button
+from nuiitivet.material.buttons import Fab, Button
 from nuiitivet.material.text import Text
 from nuiitivet.material.icon import Icon
 from nuiitivet.layout.row import Row
@@ -34,7 +34,7 @@ def test_filled_button_label_and_icon():
 
 
 def test_fab_icon_only():
-    fab = FloatingActionButton(icon="add")
+    fab = Fab(icon="add")
     assert len(fab.children) == 1
     child = fab.children[0]
     assert isinstance(child, Icon)

--- a/tests/test_button_disabled.py
+++ b/tests/test_button_disabled.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.observable.value import _ObservableValue
-from nuiitivet.material.buttons import (FloatingActionButton, Button)
+from nuiitivet.material.buttons import (Fab, Button)
 from nuiitivet.widgets.interaction import FocusNode
 from tests.helpers.pointer import send_pointer_event_for_test
 from nuiitivet.material import ButtonStyle
@@ -90,9 +90,9 @@ def test_tonal_button_disabled():
 
 
 def test_fab_disabled():
-    """FloatingActionButton should support disabled state."""
+    """Fab should support disabled state."""
     clicked = []
-    button = FloatingActionButton(icon="add", disabled=True, on_click=lambda: clicked.append(1))
+    button = Fab(icon="add", disabled=True, on_click=lambda: clicked.append(1))
     result = send_pointer_event_for_test(button, PointerEventType.PRESS)
     assert result is False
     assert len(clicked) == 0

--- a/tests/test_button_text_colors_m3.py
+++ b/tests/test_button_text_colors_m3.py
@@ -6,10 +6,10 @@ M3 Button Text Color Specifications:
 - TextButton: PRIMARY
 - ElevatedButton: ON_SURFACE
 - FilledTonalButton: ON_SURFACE_VARIANT
-- FloatingActionButton (FAB): ON_PRIMARY
+- Fab (FAB): ON_PRIMARY
 """
 
-from nuiitivet.material.buttons import FloatingActionButton, Button
+from nuiitivet.material.buttons import Fab, Button
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.material_theme import MaterialTheme
@@ -70,14 +70,14 @@ def test_filled_tonal_button_text_color():
 
 
 def test_fab_text_color():
-    """FloatingActionButton should use ON_PRIMARY for text per M3 spec."""
-    btn = FloatingActionButton("Test")
+    """Fab should use ON_PRIMARY_CONTAINER for the icon per MD3 spec."""
+    btn = Fab("Test")
     assert len(btn.children) == 1
     child = btn.children[0]
     from nuiitivet.material.icon import Icon
 
     assert isinstance(child, Icon)
-    assert child.style.color == ColorRole.ON_PRIMARY
+    assert child.style.color == ColorRole.ON_PRIMARY_CONTAINER
 
 
 def test_text_widget_default_color():

--- a/tests/test_fab_additional.py
+++ b/tests/test_fab_additional.py
@@ -1,8 +1,8 @@
-"""Additional unit tests for FloatingActionButton behavior."""
+"""Additional unit tests for Fab behavior."""
 
 import pytest
 
-from nuiitivet.material.buttons import FloatingActionButton
+from nuiitivet.material.buttons import Fab
 from nuiitivet.material.icon import Icon
 from nuiitivet.widgets.text import TextBase as Text
 
@@ -11,20 +11,20 @@ def test_fab_preserves_icon_instance():
     """Passing an Icon instance is not supported for Material buttons."""
     icon = Icon("add", size=24)
     with pytest.raises(TypeError):
-        FloatingActionButton(icon=icon)
+        Fab(icon=icon)
 
 
 def test_fab_builds_icon_child_from_string():
-    fab = FloatingActionButton(icon="add")
+    fab = Fab(icon="add")
     assert len(fab.children) == 1
     assert isinstance(fab.children[0], Icon)
 
 
 def test_fab_child_override_not_supported():
     with pytest.raises(TypeError):
-        FloatingActionButton(icon="add", child=Text("X"))
+        Fab(icon="add", child=Text("X"))
 
 
 def test_fab_body_override_not_supported():
     with pytest.raises(TypeError):
-        FloatingActionButton(icon="add", body=Text("X"))
+        Fab(icon="add", body=Text("X"))

--- a/tests/test_other_buttons.py
+++ b/tests/test_other_buttons.py
@@ -1,5 +1,5 @@
 from nuiitivet.input.pointer import PointerEventType
-from nuiitivet.material.buttons import FloatingActionButton, Button
+from nuiitivet.material.buttons import Fab, Button
 from nuiitivet.material.styles.button_style import ButtonStyle
 from tests.helpers.pointer import send_pointer_event_for_test
 
@@ -44,6 +44,6 @@ def test_tonal():
 
 def test_fab():
     def _fab(label, **kw):
-        return FloatingActionButton(icon="add", **kw)
+        return Fab(icon="add", **kw)
 
     _basic_button_behavior(_fab)

--- a/tests/test_overlay_logic.py
+++ b/tests/test_overlay_logic.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nuiitivet.material import FloatingActionButton, Button
+from nuiitivet.material import Fab, Button
 from nuiitivet.material.styles.button_style import ButtonStyle
 
 
@@ -22,7 +22,7 @@ def test_resolve_overlay_defaults():
         (lambda: Button(label="lbl", style=ButtonStyle.filled()), 0.08, 0.04),
         (lambda: Button(label="lbl", style=ButtonStyle.outlined()), 0.08, 0.04),
         (lambda: Button(label="lbl", style=ButtonStyle.tonal()), 0.08, 0.04),
-        (lambda: FloatingActionButton(icon="add"), 0.08, 0.04),
+        (lambda: Fab(icon="add"), 0.08, 0.04),
         (lambda: Button(label="lbl", style=ButtonStyle.text()), 0.08, 0.04),
         (lambda: Button(label="lbl", style=ButtonStyle.elevated()), 0.08, 0.04),
     ],


### PR DESCRIPTION
## Summary

Resolves #99 by extending the Style-driven unified API introduced in #77 to `IconButton` / `IconToggleButton` / FAB. Also reorganizes the FAB surface:

- Renames `FloatingActionButton` to `Fab` (matches the official MD3 wording).
- Adds a dedicated `FabStyle(ButtonStyle)` with three tonal variants (`primary` / `secondary` / `tertiary`).
- Aligns `FabSize` with the framework-wide `s` / `m` / `l` (56 / 80 / 96 dp).

## Changes

### IconButton family
- Removed `size: int` from `IconButton` / `IconToggleButton`. Size is now driven by `style`.
- Added `ICON_BUTTON_SIZE_TOKENS` (xs/s/m/l/xl, 32/40/56/96/136 dp) following the MD3 round variant default leading/trailing spacing and circular corner radius.
- Added `size: ButtonSize = "s"` to every `IconButtonStyle.*` / `IconToggleButtonStyle.*` factory.

### Fab
- Renamed `FloatingActionButton` to `Fab`.
- Removed `ButtonStyle.fab()`; added `FabStyle(ButtonStyle)` in `styles/fab_style.py`.
- Provides `FabStyle.primary("s"|"m"|"l")` / `.secondary(...)` / `.tertiary(...)`.
- Changed `FabSize` literal from `"medium"`/`"large"` to `"s"`/`"m"`/`"l"` (`s` = 56 dp baseline, `m` = 80 dp Medium, `l` = 96 dp Large). The deprecated 40 dp Small FAB is excluded.
- `MaterialThemeData.fab_style` now returns `FabStyle`, defaulting to `FabStyle.primary()`.

### Docs
- Added `docs/md3/icon_buttons.md` (collected MD3 spec).
- Added `docs/md3/floating_action_buttons.md`. Filled in the `FAB - Size - Default` (56 dp baseline) row from the Specs Measurements section.

## Breaking Changes

| Before | After |
| --- | --- |
| `FloatingActionButton(...)` | `Fab(...)` |
| `ButtonStyle.fab()` | `FabStyle.primary("s")` (also `secondary` / `tertiary`, sizes `s`/`m`/`l`) |
| `IconButton(icon, size=40)` | `IconButton(icon, style=IconButtonStyle.standard("s"))` |
| `IconToggleButton(icon, size=56)` | `IconToggleButton(icon, style=IconToggleButtonStyle.standard("m"))` |
| `FabSize = "medium" \| "large"` | `FabSize = "s" \| "m" \| "l"` |

## Validation

- `uv run pytest` — **1166 passed**
- `uv run mypy` — **Success: no issues found in 501 source files**
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` — **clean**

## Spec References

- https://m3.material.io/components/icon-buttons/specs
- https://m3.material.io/components/floating-action-button/specs

Closes #99
