### PR TITLE
feat: split RailItem.badge into small_badge / large_badge

### DIFF
--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -4,7 +4,7 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from .badge import BadgeValue, LargeBadge, SmallBadge
+    from .badge import LargeBadge, SmallBadge
     from .app import MaterialApp
     from .app import MaterialApp as App
     from .divider import Divider
@@ -70,7 +70,6 @@ __all__ = [
     "ThemeFactory",
     "SmallBadge",
     "LargeBadge",
-    "BadgeValue",
     "Divider",
     "Text",
     "Icon",
@@ -153,7 +152,6 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "ThemeFactory": ("theme", "MaterialTheme"),
     "SmallBadge": ("badge", "SmallBadge"),
     "LargeBadge": ("badge", "LargeBadge"),
-    "BadgeValue": ("badge", "BadgeValue"),
     "Divider": ("divider", "Divider"),
     "Text": ("text", "Text"),
     "Icon": ("icon", "Icon"),

--- a/src/nuiitivet/material/badge.py
+++ b/src/nuiitivet/material/badge.py
@@ -1,9 +1,8 @@
-"""Material Design 3 badge widgets and value objects."""
+"""Material Design 3 badge widgets."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 from nuiitivet.material.styles.badge_style import LargeBadgeStyle, SmallBadgeStyle
 from nuiitivet.material.styles.text_style import TextStyle
@@ -65,13 +64,12 @@ class SmallBadge(Box):
 
 
 class LargeBadge(Box):
-    """Large text/count badge widget."""
+    """Large text badge widget."""
 
     def __init__(
         self,
-        count: int,
+        text: str,
         *,
-        max: int = 999,
         width: SizingLike = None,
         height: SizingLike = None,
         padding: Union[int, Tuple[int, int], Tuple[int, int, int, int], None] = None,
@@ -80,27 +78,23 @@ class LargeBadge(Box):
         """Initialize LargeBadge.
 
         Args:
-            count: Badge count. Must be >= 1.
-            max: Overflow threshold. When count > max, shows ``"{max}+"``.
+            text: Badge text to display. Must be non-empty.
             width: Badge width sizing.
             height: Badge height sizing. Defaults to style height.
             padding: External badge padding. Defaults to style padding.
             style: Optional style override.
         """
-        if int(count) < 1:
-            raise ValueError("count must be >= 1")
-        if int(max) < 1:
-            raise ValueError("max must be >= 1")
+        if not text:
+            raise ValueError("text must be non-empty")
 
-        self.count = int(count)
-        self.max = int(max)
+        self.text = text
 
         effective_style = style or LargeBadgeStyle()
         resolved_height = height if height is not None else Sizing.fixed(effective_style.height)
         resolved_padding = effective_style.padding if padding is None else padding
 
         label = Text(
-            self.format_count(self.count, self.max),
+            text,
             style=TextStyle(
                 color=effective_style.content_color,
                 font_size=effective_style.font_size,
@@ -135,63 +129,3 @@ class LargeBadge(Box):
             anchor="bottom-left",
             offset=(-12.0, 14.0),
         )
-
-    @staticmethod
-    def format_count(count: int, max_value: int) -> str:
-        """Format badge count with overflow cap.
-
-        Args:
-            count: Raw count value.
-            max_value: Overflow threshold.
-
-        Returns:
-            Formatted count string.
-        """
-        return f"{max_value}+" if int(count) > int(max_value) else str(int(count))
-
-
-@dataclass(frozen=True, slots=True)
-class BadgeValue:
-    """Value object representing badge state for declarative APIs."""
-
-    kind: Literal["none", "small", "large"]
-    count: Optional[int] = None
-    max: int = 999
-
-    @classmethod
-    def none(cls) -> "BadgeValue":
-        """Create the hidden badge state."""
-        return cls(kind="none")
-
-    @classmethod
-    def small(cls) -> "BadgeValue":
-        """Create the small dot badge state."""
-        return cls(kind="small")
-
-    @classmethod
-    def large(cls, count: int, *, max: int = 999) -> "BadgeValue":
-        """Create the large count badge state.
-
-        Args:
-            count: Badge count. Must be >= 1.
-            max: Overflow threshold. Must be >= 1.
-        """
-        if int(count) < 1:
-            raise ValueError("count must be >= 1")
-        if int(max) < 1:
-            raise ValueError("max must be >= 1")
-        return cls(kind="large", count=int(count), max=int(max))
-
-    def to_widget(self) -> Optional[Widget]:
-        """Create a concrete badge widget from this value.
-
-        Returns:
-            Badge widget instance, or None when kind is ``none``.
-        """
-        if self.kind == "none":
-            return None
-        if self.kind == "small":
-            return SmallBadge()
-        if self.count is None:
-            raise ValueError("large badge requires count")
-        return LargeBadge(self.count, max=self.max)

--- a/src/nuiitivet/material/navigation_rail.py
+++ b/src/nuiitivet/material/navigation_rail.py
@@ -20,7 +20,7 @@ from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.rendering.skia import make_paint, make_rect, draw_round_rect
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.theme.resolver import resolve_color_to_rgba
-from nuiitivet.material.badge import BadgeValue, LargeBadge
+from nuiitivet.material.badge import LargeBadge, SmallBadge
 from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL, EXPRESSIVE_DEFAULT_EFFECTS
 from nuiitivet.modifiers.transform import rotate
 
@@ -40,7 +40,8 @@ class RailItem(Widget):
         icon: str,
         label: str,
         *,
-        badge: Optional[ReadOnlyObservableProtocol[BadgeValue]] = None,
+        small_badge: Optional[ReadOnlyObservableProtocol[bool]] = None,
+        large_badge: Optional[ReadOnlyObservableProtocol[Optional[str]]] = None,
         style: Optional[NavigationRailStyle] = None,
     ) -> None:
         """Initialize RailItem.
@@ -48,8 +49,10 @@ class RailItem(Widget):
         Args:
             icon: The icon name to display.
             label: The label text to display.
-            badge: Optional Observable badge value. Use ``BadgeValue.small()``,
-                ``BadgeValue.large(count)`` or ``BadgeValue.none()``.
+            small_badge: Optional Observable controlling small dot badge visibility.
+            large_badge: Optional Observable with badge text. ``None`` or ``""`` hides the badge.
+                When both ``small_badge`` and ``large_badge`` are provided,
+                ``large_badge`` takes precedence.
             style: Optional style override for this item.
         """
         super().__init__()
@@ -61,7 +64,8 @@ class RailItem(Widget):
 
         self.icon_spec = icon
         self.label_spec = label
-        self._badge_observable: Optional[ReadOnlyObservableProtocol[BadgeValue]] = badge
+        self._small_badge_observable: Optional[ReadOnlyObservableProtocol[bool]] = small_badge
+        self._large_badge_observable: Optional[ReadOnlyObservableProtocol[Optional[str]]] = large_badge
         self._style = style
 
         self._icon_widget: Widget
@@ -108,9 +112,14 @@ class RailItem(Widget):
         return self._label_widget
 
     @property
-    def badge_observable(self) -> Optional[ReadOnlyObservableProtocol[BadgeValue]]:
-        """Get the optional badge observable."""
-        return self._badge_observable
+    def small_badge_observable(self) -> Optional[ReadOnlyObservableProtocol[bool]]:
+        """Get the optional small badge observable."""
+        return self._small_badge_observable
+
+    @property
+    def large_badge_observable(self) -> Optional[ReadOnlyObservableProtocol[Optional[str]]]:
+        """Get the optional large badge observable."""
+        return self._large_badge_observable
 
 
 def _clamp01(value: float) -> float:
@@ -190,7 +199,10 @@ class _RailItemButton(InteractiveWidget):
         # Badge state
         self._badge_widget: Optional[Widget] = None
         self._badge_rect: Optional[Tuple[int, int, int, int]] = None
-        self._badge_subscription = None
+        self._small_badge_value: bool = False
+        self._large_badge_value: Optional[str] = None
+        self._small_badge_subscription = None
+        self._large_badge_subscription = None
 
         super().__init__(
             child=None,
@@ -211,31 +223,51 @@ class _RailItemButton(InteractiveWidget):
         # Sync interaction state
         self.state.selected = selected
 
-        # Subscribe to badge observable if provided.
-        badge_observable = rail_item.badge_observable
-        if badge_observable is not None:
-            self._update_badge_widget(badge_observable.value)
-            self._badge_subscription = badge_observable.subscribe(self._on_badge_changed)
+        # Subscribe to badge observables if provided.
+        small_badge_obs = rail_item.small_badge_observable
+        large_badge_obs = rail_item.large_badge_observable
+        if small_badge_obs is not None:
+            self._small_badge_value = small_badge_obs.value
+            self._small_badge_subscription = small_badge_obs.subscribe(self._on_small_badge_changed)
+        if large_badge_obs is not None:
+            self._large_badge_value = large_badge_obs.value
+            self._large_badge_subscription = large_badge_obs.subscribe(self._on_large_badge_changed)
+        self._refresh_badge_widget()
 
         self.on_dispose(self._dispose_badge)
 
     # Bindings are automatically disposed by BindingHostMixin/observe.
 
     def _dispose_badge(self) -> None:
-        if self._badge_subscription is not None:
-            self._badge_subscription.dispose()
-            self._badge_subscription = None
+        if self._small_badge_subscription is not None:
+            self._small_badge_subscription.dispose()
+            self._small_badge_subscription = None
+        if self._large_badge_subscription is not None:
+            self._large_badge_subscription.dispose()
+            self._large_badge_subscription = None
 
-    def _on_badge_changed(self, value: BadgeValue) -> None:
-        """React to badge observable changes."""
-        self._update_badge_widget(value)
-        # Request layout so _place_badge() runs in the layout phase before paint.
+    def _on_small_badge_changed(self, value: bool) -> None:
+        """React to small_badge observable changes."""
+        self._small_badge_value = value
+        self._refresh_badge_widget()
         self.mark_needs_layout()
         self.invalidate()
 
-    def _update_badge_widget(self, value: BadgeValue) -> None:
-        """Create or clear the badge widget from a BadgeValue."""
-        self._badge_widget = value.to_widget()
+    def _on_large_badge_changed(self, value: Optional[str]) -> None:
+        """React to large_badge observable changes."""
+        self._large_badge_value = value
+        self._refresh_badge_widget()
+        self.mark_needs_layout()
+        self.invalidate()
+
+    def _refresh_badge_widget(self) -> None:
+        """Compute current badge widget. large_badge takes precedence over small_badge."""
+        if self._large_badge_value:
+            self._badge_widget = LargeBadge(self._large_badge_value)
+        elif self._small_badge_value:
+            self._badge_widget = SmallBadge()
+        else:
+            self._badge_widget = None
         self._badge_rect = None
 
     def _apply_colors(self, *, selected: bool, rail_style: Optional[NavigationRailStyle] = None) -> None:

--- a/src/samples/badge_demo.py
+++ b/src/samples/badge_demo.py
@@ -21,8 +21,8 @@ def main() -> None:
 
     plain = Icon(icon_base, size=32)
     small = Icon(icon_base, size=32).modifier(SmallBadge().stick_modifier())
-    large = Icon(icon_base, size=32).modifier(LargeBadge(12).stick_modifier())
-    overflow = Icon(icon_base, size=32).modifier(LargeBadge(1200, max=999).stick_modifier())
+    large = Icon(icon_base, size=32).modifier(LargeBadge("12").stick_modifier())
+    overflow = Icon(icon_base, size=32).modifier(LargeBadge("999+").stick_modifier())
 
     content = Column(
         children=[

--- a/src/samples/navigation_rail_demo.py
+++ b/src/samples/navigation_rail_demo.py
@@ -1,9 +1,10 @@
 """NavigationRail sample demonstrating basic usage and mode toggling."""
 
 from enum import IntEnum
+from typing import Optional
 
 from nuiitivet.material import App
-from nuiitivet.material import BadgeValue, Text, Button
+from nuiitivet.material import Text, Button
 from nuiitivet.material.navigation_rail import NavigationRail, RailItem
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.column import Column
@@ -31,43 +32,37 @@ class NavigationRailDemo(ComposableWidget):
         super().__init__()
         self.selected_section = _ObservableValue(Section.HOME)
         self.rail_expanded = _ObservableValue(False)
-        self.home_badge = _ObservableValue(BadgeValue.small())
-        self.search_badge = _ObservableValue(BadgeValue.large(3))
-        self.library_badge = _ObservableValue(BadgeValue.large(1))
+        self.home_small_badge = _ObservableValue(True)
+        self.search_large_badge: _ObservableValue[Optional[str]] = _ObservableValue("3")
+        self.library_large_badge: _ObservableValue[Optional[str]] = _ObservableValue("1")
         self.library_count = 1
 
     def _increment_library_badge(self) -> None:
         self.library_count += 1
-        self.library_badge.value = BadgeValue.large(self.library_count)
+        self.library_large_badge.value = str(self.library_count)
 
     def _clear_library_badge(self) -> None:
         self.library_count = 0
-        self.library_badge.value = BadgeValue.none()
+        self.library_large_badge.value = None
 
     def _toggle_home_badge(self) -> None:
-        if self.home_badge.value.kind == "none":
-            self.home_badge.value = BadgeValue.small()
-            return
-        self.home_badge.value = BadgeValue.none()
+        self.home_small_badge.value = not self.home_small_badge.value
 
     def _toggle_search_badge(self) -> None:
-        if self.search_badge.value.kind == "none":
-            self.search_badge.value = BadgeValue.large(3)
-            return
-        self.search_badge.value = BadgeValue.none()
+        self.search_large_badge.value = None if self.search_large_badge.value else "3"
 
     def build(self) -> Widget:
         section_label = self.selected_section.map(lambda idx: f"Section: {Section(int(idx)).name}")
-        library_badge_label = self.library_badge.map(
-            lambda b: "Library badge: none" if b.kind == "none" else f"Library badge: {b.kind}"
+        library_badge_label = self.library_large_badge.map(
+            lambda b: "Library badge: none" if not b else f"Library badge: {b}"
         )
 
         # Navigation rail
         rail = NavigationRail(
             children=[
-                RailItem(icon="home", label="Home", badge=self.home_badge),
-                RailItem(icon="search", label="Search Results", badge=self.search_badge),
-                RailItem(icon="library_books", label="Library Collection", badge=self.library_badge),
+                RailItem(icon="home", label="Home", small_badge=self.home_small_badge),
+                RailItem(icon="search", label="Search Results", large_badge=self.search_large_badge),
+                RailItem(icon="library_books", label="Library Collection", large_badge=self.library_large_badge),
                 RailItem(icon="settings", label="Settings"),
             ],
             index=self.selected_section,

--- a/tests/test_badge.py
+++ b/tests/test_badge.py
@@ -1,8 +1,8 @@
-"""Tests for badge widgets and BadgeValue."""
+"""Tests for badge widgets."""
 
 import pytest
 
-from nuiitivet.material.badge import BadgeValue, LargeBadge, SmallBadge
+from nuiitivet.material.badge import LargeBadge, SmallBadge
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -16,41 +16,14 @@ class _FixedWidget(Widget):
         return (self._pref_w, self._pref_h)
 
 
-def test_large_badge_format_count_within_max() -> None:
-    assert LargeBadge.format_count(9, 999) == "9"
+def test_large_badge_creates_with_text() -> None:
+    badge = LargeBadge("42")
+    assert badge.text == "42"
 
 
-def test_large_badge_format_count_over_max() -> None:
-    assert LargeBadge.format_count(1000, 999) == "999+"
-
-
-def test_large_badge_validates_count() -> None:
+def test_large_badge_validates_empty_text() -> None:
     with pytest.raises(ValueError):
-        LargeBadge(0)
-
-
-def test_badge_value_none_to_widget() -> None:
-    assert BadgeValue.none().to_widget() is None
-    assert BadgeValue.none().to_widget() is None
-
-
-def test_badge_value_small_to_widget() -> None:
-    widget = BadgeValue.small().to_widget()
-    assert isinstance(widget, SmallBadge)
-
-
-def test_badge_value_large_to_widget() -> None:
-    widget = BadgeValue.large(1200, max=999).to_widget()
-    assert isinstance(widget, LargeBadge)
-    assert widget.count == 1200
-    assert widget.max == 999
-
-
-def test_badge_value_large_validates() -> None:
-    with pytest.raises(ValueError):
-        BadgeValue.large(0)
-    with pytest.raises(ValueError):
-        BadgeValue.large(1, max=0)
+        LargeBadge("")
 
 
 def test_small_badge_stick_modifier_defaults() -> None:
@@ -61,7 +34,7 @@ def test_small_badge_stick_modifier_defaults() -> None:
 
 
 def test_large_badge_stick_modifier_defaults() -> None:
-    modifier = LargeBadge(1).stick_modifier()
+    modifier = LargeBadge("1").stick_modifier()
     assert modifier.alignment == "top-right"
     assert modifier.anchor == "bottom-left"
     assert modifier.offset == (-12.0, 14.0)
@@ -86,7 +59,7 @@ def test_small_badge_stick_modifier_layout_matches_spec_vector() -> None:
 
 def test_large_badge_stick_modifier_layout_matches_spec_vector() -> None:
     target = _FixedWidget(24, 24)
-    badge = LargeBadge(12)
+    badge = LargeBadge("12")
     wrapped = target.modifier(badge.stick_modifier())
 
     wrapped.layout(24, 24)

--- a/tests/test_navigation_rail.py
+++ b/tests/test_navigation_rail.py
@@ -1,10 +1,11 @@
 """Test NavigationRail widget."""
 
 from enum import IntEnum
+from typing import Optional
 
 import pytest
 
-from nuiitivet.material.badge import BadgeValue, LargeBadge, SmallBadge
+from nuiitivet.material.badge import LargeBadge, SmallBadge
 from nuiitivet.material.navigation_rail import NavigationRail, RailItem
 from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.widgets.interaction import FocusNode
@@ -317,17 +318,25 @@ def test_rail_item_selection_state():
 # ---------------------------------------------------------------------------
 
 
-def test_rail_item_badge_observable_is_none_by_default():
-    """RailItem should have no badge observable by default."""
+def test_rail_item_badge_observables_are_none_by_default():
+    """RailItem should have no badge observables by default."""
     item = RailItem(icon="home", label="Home")
-    assert item.badge_observable is None
+    assert item.small_badge_observable is None
+    assert item.large_badge_observable is None
 
 
-def test_rail_item_badge_observable_stored():
-    """RailItem should store the provided badge observable."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.small())
-    item = RailItem(icon="home", label="Home", badge=badge_obs)
-    assert item.badge_observable is badge_obs
+def test_rail_item_small_badge_observable_stored():
+    """RailItem should store the provided small_badge observable."""
+    small_obs: _ObservableValue[bool] = _ObservableValue(True)
+    item = RailItem(icon="home", label="Home", small_badge=small_obs)
+    assert item.small_badge_observable is small_obs
+
+
+def test_rail_item_large_badge_observable_stored():
+    """RailItem should store the provided large_badge observable."""
+    large_obs: _ObservableValue[Optional[str]] = _ObservableValue("5")
+    item = RailItem(icon="home", label="Home", large_badge=large_obs)
+    assert item.large_badge_observable is large_obs
 
 
 def test_rail_item_button_no_badge_when_not_provided():
@@ -340,9 +349,9 @@ def test_rail_item_button_no_badge_when_not_provided():
 
 
 def test_rail_item_button_small_badge_created():
-    """_RailItemButton should create SmallBadge for BadgeValue.small()."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.small())
-    items = [RailItem(icon="home", label="Home", badge=badge_obs)]
+    """_RailItemButton should create SmallBadge when small_badge is True."""
+    small_obs: _ObservableValue[bool] = _ObservableValue(True)
+    items = [RailItem(icon="home", label="Home", small_badge=small_obs)]
     rail = NavigationRail(children=items)
 
     button = rail._item_buttons[0]
@@ -350,47 +359,58 @@ def test_rail_item_button_small_badge_created():
 
 
 def test_rail_item_button_large_badge_created():
-    """_RailItemButton should create LargeBadge for BadgeValue.large()."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.large(5))
-    items = [RailItem(icon="home", label="Home", badge=badge_obs)]
+    """_RailItemButton should create LargeBadge when large_badge has text."""
+    large_obs: _ObservableValue[Optional[str]] = _ObservableValue("5")
+    items = [RailItem(icon="home", label="Home", large_badge=large_obs)]
     rail = NavigationRail(children=items)
 
     button = rail._item_buttons[0]
     assert isinstance(button._badge_widget, LargeBadge)
-    assert button._badge_widget.count == 5
+    assert button._badge_widget.text == "5"
 
 
-def test_rail_item_button_none_badge_hides_widget():
-    """_RailItemButton should clear badge widget when BadgeValue.none() is set."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.small())
-    items = [RailItem(icon="home", label="Home", badge=badge_obs)]
+def test_rail_item_button_small_badge_false_hides_widget():
+    """_RailItemButton should clear badge widget when small_badge becomes False."""
+    small_obs: _ObservableValue[bool] = _ObservableValue(True)
+    items = [RailItem(icon="home", label="Home", small_badge=small_obs)]
     rail = NavigationRail(children=items)
 
     button = rail._item_buttons[0]
     assert button._badge_widget is not None
 
-    badge_obs.value = BadgeValue.none()
+    small_obs.value = False
     assert button._badge_widget is None
 
 
-def test_rail_item_badge_updates_from_small_to_large():
-    """_RailItemButton should switch from SmallBadge to LargeBadge on value change."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.small())
-    items = [RailItem(icon="home", label="Home", badge=badge_obs)]
+def test_rail_item_button_large_badge_none_hides_widget():
+    """_RailItemButton should clear badge widget when large_badge becomes None."""
+    large_obs: _ObservableValue[Optional[str]] = _ObservableValue("3")
+    items = [RailItem(icon="home", label="Home", large_badge=large_obs)]
     rail = NavigationRail(children=items)
 
     button = rail._item_buttons[0]
-    assert isinstance(button._badge_widget, SmallBadge)
+    assert button._badge_widget is not None
 
-    badge_obs.value = BadgeValue.large(42)
+    large_obs.value = None
+    assert button._badge_widget is None
+
+
+def test_rail_item_large_badge_takes_precedence():
+    """large_badge takes precedence over small_badge when both are provided."""
+    small_obs: _ObservableValue[bool] = _ObservableValue(True)
+    large_obs: _ObservableValue[Optional[str]] = _ObservableValue("42")
+    items = [RailItem(icon="home", label="Home", small_badge=small_obs, large_badge=large_obs)]
+    rail = NavigationRail(children=items)
+
+    button = rail._item_buttons[0]
     assert isinstance(button._badge_widget, LargeBadge)
-    assert button._badge_widget.count == 42
+    assert button._badge_widget.text == "42"
 
 
 def test_rail_item_badge_layout_small():
     """Badge rect is computed using MD3 small badge stick offsets (top-right of icon)."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.small())
-    items = [RailItem(icon="home", label="Home", badge=badge_obs)]
+    small_obs: _ObservableValue[bool] = _ObservableValue(True)
+    items = [RailItem(icon="home", label="Home", small_badge=small_obs)]
     rail = NavigationRail(children=items)
 
     button = rail._item_buttons[0]
@@ -404,8 +424,8 @@ def test_rail_item_badge_layout_small():
 
 def test_rail_item_badge_layout_large():
     """Badge rect is computed using MD3 large badge stick offsets (top-right of icon)."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.large(3))
-    items = [RailItem(icon="home", label="Home", badge=badge_obs)]
+    large_obs: _ObservableValue[Optional[str]] = _ObservableValue("3")
+    items = [RailItem(icon="home", label="Home", large_badge=large_obs)]
     rail = NavigationRail(children=items)
 
     button = rail._item_buttons[0]
@@ -417,13 +437,16 @@ def test_rail_item_badge_layout_large():
 
 
 def test_rail_item_badge_subscription_disposed():
-    """Badge subscription should be cleaned up on button dispose."""
-    badge_obs: _ObservableValue[BadgeValue] = _ObservableValue(BadgeValue.small())
-    items = [RailItem(icon="home", label="Home", badge=badge_obs)]
+    """Badge subscriptions should be cleaned up on button dispose."""
+    small_obs: _ObservableValue[bool] = _ObservableValue(True)
+    large_obs: _ObservableValue[Optional[str]] = _ObservableValue("1")
+    items = [RailItem(icon="home", label="Home", small_badge=small_obs, large_badge=large_obs)]
     rail = NavigationRail(children=items)
 
     button = rail._item_buttons[0]
-    assert button._badge_subscription is not None
+    assert button._small_badge_subscription is not None
+    assert button._large_badge_subscription is not None
 
     button._dispose_badge()
-    assert button._badge_subscription is None
+    assert button._small_badge_subscription is None
+    assert button._large_badge_subscription is None


### PR DESCRIPTION
Closes #106

## Summary

Split `RailItem.badge: Observable[BadgeValue]` into two separate observables (`small_badge` / `large_badge`). The badge kind is now expressed at declaration time rather than carried inside the value, which makes the API easier to read.

## Changes

### Breaking changes

- Remove `RailItem.badge`. Use `small_badge: Observable[bool]` and `large_badge: Observable[Optional[str]]` instead.
- `LargeBadge(count: int, *, max: int)` → `LargeBadge(text: str)`.
- `BadgeValue.large(count, max)` → `BadgeValue.large(text)` and then `BadgeValue` itself was removed.
- Count formatting (e.g. `"999+"`) is now the caller's responsibility.

### Behavior

- When both `small_badge` and `large_badge` are provided, `large_badge` takes precedence.
- A `large_badge` value of `None` or `""` hides the badge.
- `_RailItemButton` subscribes to both observables independently and rebuilds the badge on change.

### Updated

- `src/nuiitivet/material/badge.py` — update `LargeBadge`; remove `BadgeValue`.
- `src/nuiitivet/material/navigation_rail.py` — refresh `RailItem` / `_RailItemButton` API.
- `src/nuiitivet/material/__init__.py` — drop `BadgeValue` export.
- `src/samples/navigation_rail_demo.py`, `src/samples/badge_demo.py` — follow the new API.
- `tests/test_badge.py`, `tests/test_navigation_rail.py` — refreshed.

## Verification

- [x] `uv run mypy` — Success: no issues found in 501 source files
- [x] `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` — clean
- [x] `uv run pytest` — 1163 passed