### PR TITLE
feat(modifiers): add visible() modifier for conditional widget presence

### DIFF
--- a/docs/design/MODIFIER.md
+++ b/docs/design/MODIFIER.md
@@ -76,6 +76,53 @@ For details on the node-based interaction system, see [INTERACTION_ARCHITECTURE.
 * **Callback**: `on_will_pop` is an `async` function that returns `True` (allow pop) or `False` (cancel pop).
 * **Usage**: Commonly used to show an `AlertDialog` for confirming unsaved changes before leaving a screen. For more details on navigation flow, see [NAVIGATION.md](NAVIGATION.md).
 
+### Visibility
+
+* **`visible(condition, transition=None)`**: Toggles a widget's *presence* in the layout tree.
+
+#### Semantics
+
+* When `condition` is `True`, the child is mounted, laid out, painted, and receives input normally.
+* When `condition` is `False`, the child is removed from layout (zero width and height — "gone" semantics, equivalent to CSS `display: none`) and ignores all input events (click, hover, focus, keyboard, tab traversal).
+* `condition` accepts a static `bool` or an `Observable[bool]` for reactive toggling.
+
+#### Lazy Mount
+
+When `condition` starts as `False`, the child is *not* built or mounted until the first transition to `True`. Subsequent hides fully unmount the child, so widget-local state is **not** preserved across hide/show cycles. If state preservation is required, keep the widget mounted and use `opacity()` instead.
+
+#### Animated Visibility
+
+Pass an optional `transition: TransitionDefinition` to animate enter and exit:
+
+```python
+widget.modifier(
+    visible(
+        self.vm.is_open,
+        transition=TransitionDefinition(
+            motion=LinearMotion(0.2),
+            pattern=FadePattern() | ScalePattern(),
+        ),
+    )
+)
+```
+
+The widget is mounted immediately on show and runs the enter animation. On hide, the exit animation runs first; the widget is unmounted only after the animation completes. **Input is blocked from the moment `condition` flips to `False`**, even while the exit animation is still playing.
+
+#### `visible()` vs `opacity(0.0)`
+
+| Behavior | `visible(False)` | `opacity(0.0)` |
+|----------|------------------|----------------|
+| Layout space | None (zero size) | Reserved (full size) |
+| Receives input | No | Yes |
+| Child mounted | No (lazy) | Yes |
+| State preservation | No (remount on show) | Yes |
+
+Choose `visible()` to remove a widget entirely; choose `opacity()` to make it invisible while keeping its layout slot and interactivity.
+
+#### Layout Caveat
+
+Although the project's general rule is that *modifiers do not handle layout*, `visible()` is a deliberate exception: it does not deform layout, but conditionally *includes* a widget. Conceptually it is closer to `ForEach` (presence toggling) than to `padding` (geometry deformation), and it remains the only modifier permitted to influence presence in the layout tree.
+
 ### Layout
 
 Modifiers do not handle layout in `nuiitivet`.

--- a/src/nuiitivet/modifiers/__init__.py
+++ b/src/nuiitivet/modifiers/__init__.py
@@ -11,6 +11,7 @@ from .scroll import scrollable
 from .shadow import shadow
 from .stick import stick
 from .transform import opacity, rotate, scale, translate
+from .visible import visible
 from .will_pop import will_pop
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "shadow",
     "stick",
     "translate",
+    "visible",
     "will_pop",
 ]

--- a/src/nuiitivet/modifiers/visible.py
+++ b/src/nuiitivet/modifiers/visible.py
@@ -1,0 +1,469 @@
+"""visible() modifier - conditional widget presence with optional animation.
+
+Toggles a widget's *presence* in the layout tree based on a bool or
+``Observable[bool]``. When hidden, the widget contributes zero layout size and
+no input events ("gone" semantics). When shown again, the widget is freshly
+mounted (lazy mount).
+
+An optional ``transition`` parameter accepts a ``TransitionDefinition`` (a
+``Motion`` + ``TransitionPattern``) and animates enter/exit using the existing
+animation infrastructure. During the exit animation, the widget continues to be
+laid out and painted with the animation's interpolated visuals applied, but
+input is blocked from the moment the condition flips to ``False``.
+
+Usage::
+
+    widget.modifier(visible(self.vm.is_open))
+
+    widget.modifier(
+        visible(
+            self.vm.is_open,
+            transition=TransitionDefinition(
+                motion=LinearMotion(0.2),
+                pattern=FadePattern(start_alpha=0.0, end_alpha=1.0),
+            ),
+        )
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+from nuiitivet.animation.animatable import Animatable
+from nuiitivet.animation.transition_definition import TransitionDefinition
+from nuiitivet.animation.transition_pattern import TransitionVisuals
+from nuiitivet.common.logging_once import exception_once
+from nuiitivet.observable import ReadOnlyObservableProtocol
+from nuiitivet.rendering.sizing import Sizing
+from nuiitivet.widgeting.modifier import ModifierElement
+from nuiitivet.widgeting.widget import Widget
+
+if TYPE_CHECKING:
+    from nuiitivet.observable.protocols import Disposable
+
+
+logger = logging.getLogger(__name__)
+
+
+VisibleConditionLike = Union[bool, ReadOnlyObservableProtocol[bool]]
+
+
+_HIDDEN_SIZING = Sizing.fixed(0)
+
+
+class VisibleBox(Widget):
+    """Wrapper widget that toggles the presence of a child based on a condition.
+
+    The child is *lazy-mounted*: when the initial condition is ``False`` the
+    child is not added to the tree at all. It is mounted on the first
+    transition to ``True`` and unmounted again after exit (or immediately when
+    no transition is provided).
+    """
+
+    def __init__(
+        self,
+        child: Widget,
+        condition: VisibleConditionLike,
+        *,
+        transition: Optional[TransitionDefinition] = None,
+    ) -> None:
+        # Inherit sizing from the child so layout matches when visible.
+        super().__init__(
+            width=child.width_sizing,
+            height=child.height_sizing,
+            max_children=1,
+            overflow_policy="replace_last",
+        )
+        self._child_widget: Widget = child
+        self._condition: VisibleConditionLike = condition
+        self._transition: Optional[TransitionDefinition] = transition
+
+        # User-facing logical visibility (drives input).
+        self._logical_visible: bool = self._read_initial_condition(condition)
+        # Whether the child is currently mounted in the tree.
+        self._physical_present: bool = False
+        # Saved sizing to restore when becoming visible.
+        self._user_width_sizing: Sizing = self.width_sizing
+        self._user_height_sizing: Sizing = self.height_sizing
+
+        # Animation state (only used when transition is provided).
+        self._animatable: Optional[Animatable[float]] = None
+        self._animatable_subscription: Optional["Disposable"] = None
+        self._progress: float = 1.0 if self._logical_visible else 0.0
+
+        if self._logical_visible:
+            self._mount_child()
+            self._progress = 1.0
+        else:
+            self._apply_hidden_sizing()
+
+    # ------------------------------------------------------------------
+    # Sizing helpers
+    # ------------------------------------------------------------------
+
+    def _apply_hidden_sizing(self) -> None:
+        self.width_sizing = _HIDDEN_SIZING
+        self.height_sizing = _HIDDEN_SIZING
+
+    def _apply_visible_sizing(self) -> None:
+        self.width_sizing = self._user_width_sizing
+        self.height_sizing = self._user_height_sizing
+
+    # ------------------------------------------------------------------
+    # Initial condition / observation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _read_initial_condition(condition: VisibleConditionLike) -> bool:
+        if isinstance(condition, ReadOnlyObservableProtocol):
+            try:
+                return bool(condition.value)
+            except Exception:
+                exception_once(
+                    logger,
+                    "visible_box_initial_condition_exc",
+                    "Failed to read initial condition observable",
+                )
+                return False
+        return bool(condition)
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        # Re-apply sizing to match current state once we have an app reference.
+        if self._physical_present:
+            self._apply_visible_sizing()
+        else:
+            self._apply_hidden_sizing()
+
+        if isinstance(self._condition, ReadOnlyObservableProtocol):
+            self.observe(self._condition, self._on_condition_changed)
+
+    def on_unmount(self) -> None:
+        self._stop_animation_subscription()
+        super().on_unmount()
+
+    # ------------------------------------------------------------------
+    # State transitions
+    # ------------------------------------------------------------------
+
+    def _on_condition_changed(self, value: bool) -> None:
+        next_visible = bool(value)
+        if next_visible == self._logical_visible:
+            return
+        self._logical_visible = next_visible
+        if next_visible:
+            self._handle_show()
+        else:
+            self._handle_hide()
+
+    def _handle_show(self) -> None:
+        # Always lazy-mount before animating.
+        if not self._physical_present:
+            self._mount_child()
+
+        if self._transition is None:
+            self._progress = 1.0
+            self._stop_animation_subscription()
+            self.invalidate()
+            return
+
+        animatable = self._ensure_animatable()
+        animatable.target = 1.0
+        self.invalidate()
+
+    def _handle_hide(self) -> None:
+        if not self._physical_present:
+            # Already hidden; nothing to do.
+            return
+
+        if self._transition is None:
+            self._unmount_child()
+            self._progress = 0.0
+            self.invalidate()
+            return
+
+        animatable = self._ensure_animatable()
+        animatable.target = 0.0
+        self.invalidate()
+
+    # ------------------------------------------------------------------
+    # Child mount / unmount
+    # ------------------------------------------------------------------
+
+    def _mount_child(self) -> None:
+        if self._physical_present:
+            return
+        self._apply_visible_sizing()
+        self.add_child(self._child_widget)
+        self._physical_present = True
+        self.mark_needs_layout()
+        self.invalidate()
+
+    def _unmount_child(self) -> None:
+        if not self._physical_present:
+            return
+        try:
+            self.remove_child(self._child_widget)
+        except Exception:
+            exception_once(
+                logger,
+                "visible_box_remove_child_exc",
+                "VisibleBox failed to remove child during hide",
+            )
+        self._physical_present = False
+        self._apply_hidden_sizing()
+        self.mark_needs_layout()
+        self.invalidate()
+
+    # ------------------------------------------------------------------
+    # Animation driver
+    # ------------------------------------------------------------------
+
+    def _ensure_animatable(self) -> Animatable[float]:
+        if self._animatable is not None:
+            return self._animatable
+
+        assert self._transition is not None
+        initial = self._progress
+        animatable: Animatable[float] = Animatable(initial, motion=self._transition.motion)
+        self._animatable = animatable
+
+        def _on_progress(value: float) -> None:
+            self._progress = float(value)
+            self.invalidate()
+            # Detect exit completion: hidden requested and animation reached 0.
+            if not self._logical_visible and self._progress <= 0.0 and self._physical_present:
+                self._unmount_child()
+
+        sub = animatable.subscribe(_on_progress)
+        self._animatable_subscription = sub
+        return animatable
+
+    def _stop_animation_subscription(self) -> None:
+        sub = self._animatable_subscription
+        if sub is None:
+            return
+        try:
+            dispose = getattr(sub, "dispose", None)
+            if callable(dispose):
+                dispose()
+        except Exception:
+            exception_once(
+                logger,
+                "visible_box_animation_unsubscribe_exc",
+                "VisibleBox failed to dispose animation subscription",
+            )
+        self._animatable_subscription = None
+
+    # ------------------------------------------------------------------
+    # Visuals from transition pattern
+    # ------------------------------------------------------------------
+
+    def _resolve_transition_visuals(self) -> Optional[TransitionVisuals]:
+        if self._transition is None:
+            return None
+        try:
+            return self._transition.pattern.resolve(self._progress)
+        except Exception:
+            exception_once(
+                logger,
+                "visible_box_resolve_visuals_exc",
+                "TransitionPattern.resolve raised in VisibleBox",
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Widget overrides
+    # ------------------------------------------------------------------
+
+    def preferred_size(
+        self,
+        max_width: Optional[int] = None,
+        max_height: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        if not self._physical_present:
+            return (0, 0)
+        try:
+            return self._child_widget.preferred_size(max_width=max_width, max_height=max_height)
+        except Exception:
+            exception_once(
+                logger,
+                "visible_box_preferred_size_exc",
+                "Child preferred_size raised in VisibleBox",
+            )
+            return (0, 0)
+
+    def layout(self, width: int, height: int) -> None:
+        super().layout(width, height)
+        if not self._physical_present:
+            return
+        try:
+            self._child_widget.layout(width, height)
+            self._child_widget.set_layout_rect(0, 0, width, height)
+        except Exception:
+            exception_once(
+                logger,
+                "visible_box_layout_exc",
+                "Child layout raised in VisibleBox",
+            )
+
+    def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        if not self._physical_present:
+            return
+
+        visuals = self._resolve_transition_visuals()
+        if visuals is None or canvas is None or not _has_visual_effect(visuals):
+            try:
+                self._child_widget.set_last_rect(x, y, width, height)
+                self._child_widget.paint(canvas, x, y, width, height)
+            except Exception:
+                exception_once(
+                    logger,
+                    "visible_box_paint_no_visuals_exc",
+                    "Child paint raised in VisibleBox",
+                )
+            return
+
+        # Apply transition visuals (opacity + transforms) around child paint.
+        opacity = _clamp_unit(visuals.opacity) if visuals.opacity is not None else 1.0
+        scale_x = visuals.scale_x if visuals.scale_x is not None else 1.0
+        scale_y = visuals.scale_y if visuals.scale_y is not None else 1.0
+        translate_x = visuals.translate_x if visuals.translate_x is not None else 0.0
+        translate_y = visuals.translate_y if visuals.translate_y is not None else 0.0
+        if visuals.translate_x_fraction is not None:
+            translate_x += visuals.translate_x_fraction * float(width)
+        if visuals.translate_y_fraction is not None:
+            translate_y += visuals.translate_y_fraction * float(height)
+
+        needs_opacity = opacity < 1.0
+        try:
+            canvas.save()
+            if needs_opacity:
+                try:
+                    from nuiitivet.rendering.skia.color import make_opacity_paint
+
+                    layer_paint = make_opacity_paint(opacity)
+                    if layer_paint is not None:
+                        canvas.saveLayer(None, layer_paint)
+                except Exception:
+                    exception_once(
+                        logger,
+                        "visible_box_opacity_layer_exc",
+                        "VisibleBox failed to apply opacity layer",
+                    )
+
+            if translate_x != 0.0 or translate_y != 0.0:
+                canvas.translate(translate_x, translate_y)
+            if scale_x != 1.0 or scale_y != 1.0:
+                cx = float(x) + float(width) / 2.0
+                cy = float(y) + float(height) / 2.0
+                canvas.translate(cx, cy)
+                canvas.scale(scale_x, scale_y)
+                canvas.translate(-cx, -cy)
+
+            self._child_widget.set_last_rect(x, y, width, height)
+            self._child_widget.paint(canvas, x, y, width, height)
+        except Exception:
+            exception_once(
+                logger,
+                "visible_box_paint_exc",
+                "VisibleBox paint raised",
+            )
+        finally:
+            try:
+                if needs_opacity:
+                    canvas.restore()  # opacity layer
+                canvas.restore()  # geometric transforms
+            except Exception:
+                exception_once(
+                    logger,
+                    "visible_box_restore_exc",
+                    "VisibleBox canvas.restore failed",
+                )
+
+    def hit_test(self, x: int, y: int):
+        # Block all input the moment the condition flips to False, even while
+        # an exit animation is still playing.
+        if not self._logical_visible or not self._physical_present:
+            return None
+        try:
+            hit = self._child_widget.hit_test(x, y)
+            if hit is not None:
+                return hit
+        except Exception:
+            exception_once(
+                logger,
+                "visible_box_hit_test_exc",
+                "Child hit_test raised in VisibleBox",
+            )
+        return super().hit_test(x, y)
+
+
+def _clamp_unit(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _has_visual_effect(visuals: TransitionVisuals) -> bool:
+    return any(
+        v is not None
+        for v in (
+            visuals.opacity,
+            visuals.scale_x,
+            visuals.scale_y,
+            visuals.translate_x,
+            visuals.translate_y,
+            visuals.translate_x_fraction,
+            visuals.translate_y_fraction,
+        )
+    )
+
+
+@dataclass(slots=True)
+class VisibleModifier(ModifierElement):
+    """Modifier that conditionally shows/hides a widget with optional animation."""
+
+    condition: VisibleConditionLike
+    transition: Optional[TransitionDefinition] = None
+
+    def apply(self, widget: Widget) -> Widget:
+        return VisibleBox(widget, self.condition, transition=self.transition)
+
+
+def visible(
+    condition: VisibleConditionLike,
+    *,
+    transition: Optional[TransitionDefinition] = None,
+) -> VisibleModifier:
+    """Toggle a widget's presence in the layout tree.
+
+    When *condition* is ``False`` the widget is removed from layout (zero
+    width/height) and no longer receives input events. When ``True`` the
+    widget is mounted and laid out normally.
+
+    Args:
+        condition: Static ``bool`` or an ``Observable[bool]`` driving visibility.
+        transition: Optional :class:`TransitionDefinition` that animates enter
+            and exit. When omitted, mount/unmount happens immediately.
+
+    Returns:
+        A :class:`VisibleModifier` to apply via ``widget.modifier(...)``.
+
+    Note:
+        Visibility uses *lazy mount*: when *condition* starts ``False`` the
+        child is not built until the first transition to ``True``. Subsequent
+        hides will fully unmount the child, so widget-local state is not
+        preserved across hide/show cycles. For "invisible but interactive"
+        behavior, use :func:`opacity` ``(0.0)`` instead.
+    """
+    return VisibleModifier(condition=condition, transition=transition)
+
+
+__all__ = [
+    "VisibleBox",
+    "VisibleModifier",
+    "visible",
+]

--- a/src/samples/visible_demo.py
+++ b/src/samples/visible_demo.py
@@ -1,0 +1,126 @@
+"""visible() Modifier Demo
+
+Demonstrates the three core usages of the visible() modifier:
+
+1. Static visibility   - constant True/False at construction time
+2. Observable toggle   - reactive show/hide driven by Observable[bool]
+3. Animated visibility - enter/exit animation via TransitionDefinition
+
+When hidden, the widget is removed from layout (zero size) and ignores input
+("gone" semantics). Use opacity(0.0) instead when the widget should remain
+laid out and interactive while invisible.
+"""
+
+from __future__ import annotations
+
+from nuiitivet.animation import LinearMotion
+from nuiitivet.animation.transition_definition import TransitionDefinition
+from nuiitivet.animation.transition_pattern import FadePattern, ScalePattern
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.row import Row
+from nuiitivet.material import App, Text
+from nuiitivet.material.buttons import Button
+from nuiitivet.material import ButtonStyle
+from nuiitivet.material.styles.text_style import TextStyle
+from nuiitivet.modifiers import background, corner_radius, visible
+from nuiitivet.observable import Observable
+from nuiitivet.widgets.box import Box
+from nuiitivet.widgeting.widget import ComposableWidget, Widget
+
+_FADE_SCALE = TransitionDefinition(
+    motion=LinearMotion(0.25),
+    pattern=FadePattern(start_alpha=0.0, end_alpha=1.0)
+    | ScalePattern(start_scale_x=0.9, start_scale_y=0.9, end_scale_x=1.0, end_scale_y=1.0),
+)
+
+
+def _panel(label: str, color: str) -> Widget:
+    return Box(
+        child=Text(label, style=TextStyle(font_size=14, color=(255, 255, 255, 255))),
+        padding=16,
+        width=200,
+    ).modifier(background(color) | corner_radius(8))
+
+
+def _section_label(text: str) -> Widget:
+    return Text(text, style=TextStyle(font_size=11, color=(100, 100, 100, 255)))
+
+
+class _ObservableToggleDemo(ComposableWidget):
+    is_visible: Observable[bool] = Observable(True)
+
+    def build(self) -> Widget:
+        def toggle() -> None:
+            self.is_visible.value = not self.is_visible.value
+
+        return Column(
+            children=[
+                _section_label("Observable toggle (no animation, gone semantics)"),
+                Button("Toggle", on_click=toggle, style=ButtonStyle.filled()),
+                _panel("Hello", "#2196F3").modifier(visible(self.is_visible)),
+                Text("Below sibling", style=TextStyle(font_size=12)),
+            ],
+            gap=12,
+            cross_alignment="start",
+        )
+
+
+class _AnimatedToggleDemo(ComposableWidget):
+    is_visible: Observable[bool] = Observable(True)
+
+    def build(self) -> Widget:
+        def toggle() -> None:
+            self.is_visible.value = not self.is_visible.value
+
+        return Column(
+            children=[
+                _section_label("Animated toggle (fade + scale, gone after exit)"),
+                Button("Toggle", on_click=toggle, style=ButtonStyle.filled()),
+                _panel("Animated", "#4CAF50").modifier(visible(self.is_visible, transition=_FADE_SCALE)),
+                Text("Below sibling", style=TextStyle(font_size=12)),
+            ],
+            gap=12,
+            cross_alignment="start",
+        )
+
+
+def _static_demo() -> Widget:
+    return Column(
+        children=[
+            _section_label("Static visibility"),
+            Row(
+                children=[
+                    _panel("Always shown", "#FF5722").modifier(visible(True)),
+                    _panel("Never shown", "#9C27B0").modifier(visible(False)),
+                    _panel("Trailing sibling", "#607D8B"),
+                ],
+                gap=12,
+            ),
+        ],
+        gap=12,
+        cross_alignment="start",
+    )
+
+
+def main(png: str = "") -> None:
+    content = Column(
+        children=[
+            _static_demo(),
+            _ObservableToggleDemo(),
+            _AnimatedToggleDemo(),
+        ],
+        gap=24,
+        padding=24,
+        cross_alignment="start",
+    )
+
+    app = App(content=content, width=520, height=520)
+    if png:
+        app.render_to_png(png)
+        print(f"Rendered {png}")
+        return
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_visible.py
+++ b/tests/test_visible.py
@@ -1,0 +1,223 @@
+"""Tests for visible() modifier."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from nuiitivet.animation import LinearMotion
+from nuiitivet.animation.transition_definition import TransitionDefinition
+from nuiitivet.animation.transition_pattern import FadePattern
+from nuiitivet.modifiers.visible import VisibleBox, visible
+from nuiitivet.observable import runtime as observable_runtime
+from nuiitivet.observable.value import _ObservableValue
+from nuiitivet.rendering.sizing import Sizing
+from nuiitivet.widgets.box import Box
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self._intervals: list[Callable[[float], None]] = []
+
+    def schedule_once(self, fn: Callable[[float], None], delay: float) -> None:
+        del fn, delay
+
+    def schedule_interval(self, fn: Callable[[float], None], interval: float) -> None:
+        del interval
+        if fn not in self._intervals:
+            self._intervals.append(fn)
+
+    def unschedule(self, fn: Callable[[float], None]) -> None:
+        self._intervals = [cb for cb in self._intervals if cb is not fn]
+
+    def advance(self, dt: float) -> None:
+        for cb in list(self._intervals):
+            cb(dt)
+
+
+class _DummyApp:
+    def __init__(self) -> None:
+        self.invalidated = 0
+
+    def invalidate(self, immediate: bool = False) -> None:
+        del immediate
+        self.invalidated += 1
+
+
+def _make_child() -> Box:
+    return Box(width=Sizing.fixed(100), height=Sizing.fixed(50))
+
+
+def test_visible_static_true_mounts_child() -> None:
+    child = _make_child()
+    box = child.modifier(visible(True))
+
+    assert isinstance(box, VisibleBox)
+    assert box._physical_present is True
+    assert box._logical_visible is True
+    assert box.preferred_size() == (100, 50)
+
+
+def test_visible_static_false_does_not_mount_child() -> None:
+    child = _make_child()
+    box = child.modifier(visible(False))
+
+    assert isinstance(box, VisibleBox)
+    assert box._physical_present is False
+    assert box._logical_visible is False
+    assert box.preferred_size() == (0, 0)
+    # Sizing collapses to 0 so parents allocate no space.
+    assert box.width_sizing.kind == "fixed"
+    assert box.width_sizing.value == 0
+    assert box.height_sizing.kind == "fixed"
+    assert box.height_sizing.value == 0
+
+
+def test_visible_observable_show_then_hide_no_transition() -> None:
+    cond = _ObservableValue(False)
+    child = _make_child()
+    box = child.modifier(visible(cond))
+    assert isinstance(box, VisibleBox)
+
+    app = _DummyApp()
+    box.mount(app)
+
+    assert box._physical_present is False
+    assert box.preferred_size() == (0, 0)
+
+    cond.value = True
+    assert box._physical_present is True
+    assert box._logical_visible is True
+    assert box.preferred_size() == (100, 50)
+
+    cond.value = False
+    assert box._physical_present is False
+    assert box._logical_visible is False
+    assert box.preferred_size() == (0, 0)
+
+
+def test_visible_initial_true_observable_is_mounted() -> None:
+    cond = _ObservableValue(True)
+    child = _make_child()
+    box = child.modifier(visible(cond))
+    assert isinstance(box, VisibleBox)
+
+    assert box._physical_present is True
+    assert box.preferred_size() == (100, 50)
+
+
+def test_visible_hidden_blocks_hit_test() -> None:
+    cond = _ObservableValue(False)
+    child = _make_child()
+    box = child.modifier(visible(cond))
+    assert isinstance(box, VisibleBox)
+
+    box.layout(0, 0)
+    assert box.hit_test(0, 0) is None
+
+
+def test_visible_with_transition_keeps_mounted_during_exit() -> None:
+    prev_clock = observable_runtime.clock
+    fake_clock = _FakeClock()
+    observable_runtime.set_clock(fake_clock)
+    try:
+        cond = _ObservableValue(True)
+        child = _make_child()
+        transition = TransitionDefinition(
+            motion=LinearMotion(1.0),
+            pattern=FadePattern(start_alpha=0.0, end_alpha=1.0),
+        )
+        box = child.modifier(visible(cond, transition=transition))
+        assert isinstance(box, VisibleBox)
+
+        app = _DummyApp()
+        box.mount(app)
+
+        # Initially visible: progress=1.0, child mounted.
+        assert box._physical_present is True
+        assert box._progress == 1.0
+
+        # Trigger hide.
+        cond.value = False
+
+        # Logical visibility flipped immediately, but child remains mounted
+        # while exit animation runs.
+        assert box._logical_visible is False
+        assert box._physical_present is True
+
+        # Hit-testing is blocked even before animation completes.
+        box.layout(100, 50)
+        assert box.hit_test(50, 25) is None
+
+        # Halfway through: progress should be ~0.5, still mounted.
+        fake_clock.advance(0.5)
+        assert 0.4 <= box._progress <= 0.6
+        assert box._physical_present is True
+
+        # Animation completes: progress hits 0.0 -> child unmounted.
+        fake_clock.advance(0.5)
+        assert box._progress == 0.0
+        assert box._physical_present is False
+    finally:
+        observable_runtime.set_clock(prev_clock)
+
+
+def test_visible_with_transition_enter_animates_progress() -> None:
+    prev_clock = observable_runtime.clock
+    fake_clock = _FakeClock()
+    observable_runtime.set_clock(fake_clock)
+    try:
+        cond = _ObservableValue(False)
+        child = _make_child()
+        transition = TransitionDefinition(
+            motion=LinearMotion(1.0),
+            pattern=FadePattern(start_alpha=0.0, end_alpha=1.0),
+        )
+        box = child.modifier(visible(cond, transition=transition))
+        assert isinstance(box, VisibleBox)
+
+        app = _DummyApp()
+        box.mount(app)
+
+        # Trigger show.
+        cond.value = True
+
+        # Mounted immediately; progress starts at 0 and animates up.
+        assert box._physical_present is True
+        assert box._logical_visible is True
+
+        fake_clock.advance(0.5)
+        assert 0.4 <= box._progress <= 0.6
+
+        fake_clock.advance(0.5)
+        assert box._progress == 1.0
+        assert box._physical_present is True
+    finally:
+        observable_runtime.set_clock(prev_clock)
+
+
+def test_visible_show_after_hide_remounts_child() -> None:
+    cond = _ObservableValue(True)
+    child = _make_child()
+    box = child.modifier(visible(cond))
+    assert isinstance(box, VisibleBox)
+
+    app = _DummyApp()
+    box.mount(app)
+
+    cond.value = False
+    assert box._physical_present is False
+
+    cond.value = True
+    assert box._physical_present is True
+    assert box.preferred_size() == (100, 50)
+
+
+def test_visible_modifier_chains_with_other_modifiers() -> None:
+    from nuiitivet.modifiers import opacity
+
+    cond = _ObservableValue(True)
+    child = _make_child()
+    # Apply visible after opacity. Result should be a VisibleBox at the top.
+    wrapped = child.modifier(opacity(0.5) | visible(cond))
+    assert isinstance(wrapped, VisibleBox)
+    assert wrapped._physical_present is True


### PR DESCRIPTION
Closes #110

## Summary

Introduces a `visible()` modifier that toggles a widget's *presence* in the layout tree based on a `bool` or `Observable[bool]`, with optional enter/exit animation support.

## Semantics

- **`True`**: child is mounted, laid out, painted, and receives input normally.
- **`False`**: child is removed from layout (zero size, "gone" semantics, equivalent to CSS `display: none`) and all input events (click, hover, focus, keyboard, tab traversal) are blocked.
- **Lazy mount**: when the initial condition is `False`, the child is not built or mounted until the first transition to `True`.

## API

```python
widget.modifier(visible(condition))

widget.modifier(
    visible(
        condition,
        transition=TransitionDefinition(
            motion=LinearMotion(0.2),
            pattern=FadePattern() | ScalePattern(),
        ),
    )
)
```

- `condition: bool | Observable[bool]`
- `transition: TransitionDefinition | None`

## Animation

When `transition=` is provided, an `Animatable` drives a 0..1 progress value through the supplied `Motion`. The `TransitionPattern` resolves opacity / scale / translate visuals that are applied around the child paint.

- On show: child is mounted immediately, then enter animation runs.
- On hide: input is blocked the moment the condition flips to `False`; the exit animation runs, and the child is unmounted only after the animation completes.

## `visible()` vs `opacity(0.0)`

| Behavior | `visible(False)` | `opacity(0.0)` |
|----------|------------------|----------------|
| Layout space | None (zero size) | Reserved |
| Receives input | No | Yes |
| Child mounted | No (lazy) | Yes |
| State preservation | No | Yes |

## Known Limitation

The animation only affects paint-time visuals (opacity / scale / translate). Layout size is binary (full ↔ 0), so sibling widgets snap into place at the moment the exit animation completes rather than transitioning smoothly. Smooth layout interpolation (e.g. animated height) is intentionally out of scope and may be addressed by a future `AnimatedSize`-style widget.

## Changes

- `src/nuiitivet/modifiers/visible.py`: new `VisibleBox` + `VisibleModifier`
- `src/nuiitivet/modifiers/__init__.py`: export `visible`
- `tests/test_visible.py`: 9 tests (static / observable / animated / hit-test gating / chaining)
- `src/samples/visible_demo.py`: static / observable / animated demos
- `docs/design/MODIFIER.md`: Visibility section with `opacity(0)` comparison and layout-rule exception note

## Validation

- pytest: **1172 passed**
- mypy: **504 files, no issues**
- flake8: clean