### PR TITLE
refactor(modifiers): make visible() a thin composition over opacity() + ignore_pointer()

### DIFF
--- a/docs/design/MODIFIER.md
+++ b/docs/design/MODIFIER.md
@@ -78,17 +78,32 @@ For details on the node-based interaction system, see [INTERACTION_ARCHITECTURE.
 
 ### Visibility
 
-* **`visible(condition, transition=None)`**: Toggles a widget's *presence* in the layout tree.
+* **`visible(condition, transition=None)`**: Toggles a widget's *visibility* via paint and input.
+* **`ignore_pointer(condition=True)`**: Blocks hit-testing for the wrapped subtree.
+
+#### `visible()` is a Thin Composition
+
+`visible()` is a lightweight convenience that composes two existing primitives:
+
+* `opacity()` — drives the visual fade between hidden (`0.0`) and shown (`1.0`).
+* `ignore_pointer()` — blocks hit-testing while the widget is logically hidden.
+
+When `transition` is omitted, `visible(condition)` expands to literally
+`opacity(condition_as_float) | ignore_pointer(not condition)`. With a
+`transition` provided, an internal animation driver retargets an
+`Animatable` on each condition change to drive `opacity` (and any
+pattern-driven `scale` / `translate`) on enter / exit.
 
 #### Semantics
 
-* When `condition` is `True`, the child is mounted, laid out, painted, and receives input normally.
-* When `condition` is `False`, the child is removed from layout (zero width and height — "gone" semantics, equivalent to CSS `display: none`) and ignores all input events (click, hover, focus, keyboard, tab traversal).
+* When `condition` is `True`, the child is fully opaque and receives input normally.
+* When `condition` is `False`, the child is rendered fully transparent and
+  ignores all input events (click, hover, focus, keyboard, tab traversal).
+* The child **continues to occupy its normal layout space** in both states.
+  `visible()` does not collapse layout to zero size.
+* The child is **always eagerly mounted**; widget-local state is preserved
+  across hide / show cycles.
 * `condition` accepts a static `bool` or an `Observable[bool]` for reactive toggling.
-
-#### Lazy Mount
-
-When `condition` starts as `False`, the child is *not* built or mounted until the first transition to `True`. Subsequent hides fully unmount the child, so widget-local state is **not** preserved across hide/show cycles. If state preservation is required, keep the widget mounted and use `opacity()` instead.
 
 #### Animated Visibility
 
@@ -106,22 +121,23 @@ widget.modifier(
 )
 ```
 
-The widget is mounted immediately on show and runs the enter animation. On hide, the exit animation runs first; the widget is unmounted only after the animation completes. **Input is blocked from the moment `condition` flips to `False`**, even while the exit animation is still playing.
+The pattern's resolved `TransitionVisuals` (`opacity`, `scale_x` / `scale_y`,
+`translate_x` / `translate_y`, `translate_x_fraction` / `translate_y_fraction`)
+are applied during paint; **input is blocked from the moment `condition`
+flips to `False`**, even while the exit animation is still playing.
 
-#### `visible()` vs `opacity(0.0)`
+#### `visible(False)` vs `opacity(0.0)` vs `ignore_pointer()`
 
-| Behavior | `visible(False)` | `opacity(0.0)` |
-|----------|------------------|----------------|
-| Layout space | None (zero size) | Reserved (full size) |
-| Receives input | No | Yes |
-| Child mounted | No (lazy) | Yes |
-| State preservation | No (remount on show) | Yes |
+| Behavior | `opacity(0.0)` | `ignore_pointer()` | `visible(False)` |
+|----------|----------------|--------------------|------------------|
+| Visually hidden | Yes | No | Yes |
+| Receives input | Yes | No | No |
+| Layout space | Reserved | Reserved | Reserved |
 
-Choose `visible()` to remove a widget entirely; choose `opacity()` to make it invisible while keeping its layout slot and interactivity.
-
-#### Layout Caveat
-
-Although the project's general rule is that *modifiers do not handle layout*, `visible()` is a deliberate exception: it does not deform layout, but conditionally *includes* a widget. Conceptually it is closer to `ForEach` (presence toggling) than to `padding` (geometry deformation), and it remains the only modifier permitted to influence presence in the layout tree.
+`visible()` is essentially the union of the other two columns: hidden *and*
+non-interactive, while still occupying its layout slot. For animated
+layout-size changes (e.g. collapsing a side sheet to zero width), use a
+dedicated layout-aware Widget.
 
 ### Layout
 

--- a/src/nuiitivet/modifiers/__init__.py
+++ b/src/nuiitivet/modifiers/__init__.py
@@ -5,6 +5,7 @@ from .clip import clip
 from .corner_radius import corner_radius
 from .focus import focusable
 from .hover import hoverable
+from .ignore_pointer import ignore_pointer
 from .popup import modeless, light_dismiss
 from .tooltip import tooltip
 from .scroll import scrollable
@@ -22,6 +23,7 @@ __all__ = [
     "corner_radius",
     "focusable",
     "hoverable",
+    "ignore_pointer",
     "opacity",
     "modeless",
     "light_dismiss",

--- a/src/nuiitivet/modifiers/ignore_pointer.py
+++ b/src/nuiitivet/modifiers/ignore_pointer.py
@@ -1,0 +1,156 @@
+"""ignore_pointer() modifier - block hit-testing for the child subtree.
+
+A single-responsibility primitive: while *condition* is truthy, the wrapped
+widget (and its entire subtree) does not respond to pointer / hit events.
+Layout and painting are unaffected.
+
+Typical use cases:
+
+* Disabled previews that must look interactive but ignore clicks.
+* Drag-source ghosts that should not consume hover/click events.
+* Composition target for higher-level modifiers such as :func:`visible`.
+
+Usage::
+
+    widget.modifier(ignore_pointer())              # always block input
+    widget.modifier(ignore_pointer(self.vm.busy))  # observable-driven
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+from nuiitivet.common.logging_once import exception_once
+from nuiitivet.observable import ReadOnlyObservableProtocol
+from nuiitivet.widgeting.modifier import ModifierElement
+from nuiitivet.widgeting.widget import Widget
+
+logger = logging.getLogger(__name__)
+
+
+IgnorePointerConditionLike = Union[bool, ReadOnlyObservableProtocol[bool]]
+
+
+class IgnorePointerBox(Widget):
+    """Wrapper widget that blocks hit-testing for its child while *active*."""
+
+    def __init__(self, child: Widget, condition: IgnorePointerConditionLike = True) -> None:
+        super().__init__(
+            width=child.width_sizing,
+            height=child.height_sizing,
+            max_children=1,
+            overflow_policy="replace_last",
+        )
+        self._condition: IgnorePointerConditionLike = condition
+        self._active: bool = self._read_initial(condition)
+        self.add_child(child)
+
+    @staticmethod
+    def _read_initial(condition: IgnorePointerConditionLike) -> bool:
+        if isinstance(condition, ReadOnlyObservableProtocol):
+            try:
+                return bool(condition.value)
+            except Exception:
+                exception_once(
+                    logger,
+                    "ignore_pointer_initial_condition_exc",
+                    "Failed to read ignore_pointer initial condition observable",
+                )
+                return True
+        return bool(condition)
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if isinstance(self._condition, ReadOnlyObservableProtocol):
+            self.observe(self._condition, self._set_active)
+
+    def _set_active(self, value: bool) -> None:
+        next_active = bool(value)
+        if next_active == self._active:
+            return
+        self._active = next_active
+        self.invalidate()
+
+    def _child(self) -> Optional[Widget]:
+        if not self.children:
+            return None
+        child = self.children[0]
+        if isinstance(child, Widget):
+            return child
+        return None
+
+    def preferred_size(
+        self,
+        max_width: Optional[int] = None,
+        max_height: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        child = self._child()
+        if child is None:
+            return super().preferred_size(max_width=max_width, max_height=max_height)
+        try:
+            return child.preferred_size(max_width=max_width, max_height=max_height)
+        except Exception:
+            exception_once(
+                logger,
+                "ignore_pointer_preferred_size_exc",
+                "Child preferred_size raised in IgnorePointerBox",
+            )
+            return super().preferred_size(max_width=max_width, max_height=max_height)
+
+    def layout(self, width: int, height: int) -> None:
+        super().layout(width, height)
+        child = self._child()
+        if child is None:
+            return
+        try:
+            child.layout(width, height)
+            child.set_layout_rect(0, 0, width, height)
+        except Exception:
+            exception_once(
+                logger,
+                "ignore_pointer_layout_exc",
+                "Child layout raised in IgnorePointerBox",
+            )
+
+    def hit_test(self, x: int, y: int):
+        if self._active:
+            return None
+        return super().hit_test(x, y)
+
+
+@dataclass(slots=True)
+class IgnorePointerModifier(ModifierElement):
+    """Modifier that blocks hit-testing for the wrapped subtree when *condition* is truthy."""
+
+    condition: IgnorePointerConditionLike = True
+
+    def apply(self, widget: Widget) -> Widget:
+        return IgnorePointerBox(widget, self.condition)
+
+
+def ignore_pointer(condition: IgnorePointerConditionLike = True) -> IgnorePointerModifier:
+    """Return a modifier that blocks hit-testing for the child subtree.
+
+    Args:
+        condition: Static ``bool`` or an ``Observable[bool]``. When truthy the
+            child subtree does not receive pointer / hit events. Defaults to
+            ``True`` (always block).
+
+    Returns:
+        An :class:`IgnorePointerModifier` to apply via ``widget.modifier(...)``.
+
+    Note:
+        This modifier only affects hit-testing. Layout space, painting, focus
+        traversal and keyboard handling are unaffected. Combine with
+        :func:`opacity` to also hide the widget visually.
+    """
+    return IgnorePointerModifier(condition=condition)
+
+
+__all__ = [
+    "IgnorePointerBox",
+    "IgnorePointerModifier",
+    "ignore_pointer",
+]

--- a/src/nuiitivet/modifiers/visible.py
+++ b/src/nuiitivet/modifiers/visible.py
@@ -1,15 +1,21 @@
-"""visible() modifier - conditional widget presence with optional animation.
+"""visible() modifier - conditional widget visibility with optional animation.
 
-Toggles a widget's *presence* in the layout tree based on a bool or
-``Observable[bool]``. When hidden, the widget contributes zero layout size and
-no input events ("gone" semantics). When shown again, the widget is freshly
-mounted (lazy mount).
+``visible()`` is a *thin composition* over two paint-time / input primitives:
 
-An optional ``transition`` parameter accepts a ``TransitionDefinition`` (a
-``Motion`` + ``TransitionPattern``) and animates enter/exit using the existing
-animation infrastructure. During the exit animation, the widget continues to be
-laid out and painted with the animation's interpolated visuals applied, but
-input is blocked from the moment the condition flips to ``False``.
+* :func:`opacity` — drives the visual fade between hidden (``0.0``) and shown
+  (``1.0``).
+* :func:`ignore_pointer` — blocks hit-testing while the widget is logically
+  hidden so that invisible widgets do not consume input.
+
+The wrapped widget continues to occupy its normal layout space while hidden;
+``visible()`` no longer collapses layout to zero size. Use a layout-aware
+Widget for animated layout-size changes.
+
+When *condition* is a static ``bool`` or an ``Observable[bool]`` and no
+*transition* is provided, ``visible()`` collapses to ``opacity(...) |
+ignore_pointer(...)`` exactly. With a *transition* provided, an internal
+animation driver wires the ``opacity`` (and any pattern-driven ``scale`` /
+``translate``) to an :class:`Animatable` retargeted on each condition change.
 
 Usage::
 
@@ -37,9 +43,12 @@ from nuiitivet.animation.transition_definition import TransitionDefinition
 from nuiitivet.animation.transition_pattern import TransitionVisuals
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.observable import ReadOnlyObservableProtocol
-from nuiitivet.rendering.sizing import Sizing
-from nuiitivet.widgeting.modifier import ModifierElement
+from nuiitivet.observable.computed import ComputedObservable
+from nuiitivet.widgeting.modifier import Modifier, ModifierElement
 from nuiitivet.widgeting.widget import Widget
+
+from .ignore_pointer import IgnorePointerBox, ignore_pointer
+from .transform import opacity
 
 if TYPE_CHECKING:
     from nuiitivet.observable.protocols import Disposable
@@ -51,93 +60,52 @@ logger = logging.getLogger(__name__)
 VisibleConditionLike = Union[bool, ReadOnlyObservableProtocol[bool]]
 
 
-_HIDDEN_SIZING = Sizing.fixed(0)
+def _read_initial_condition(condition: VisibleConditionLike) -> bool:
+    if isinstance(condition, ReadOnlyObservableProtocol):
+        try:
+            return bool(condition.value)
+        except Exception:
+            exception_once(
+                logger,
+                "visible_initial_condition_exc",
+                "Failed to read visible() initial condition observable",
+            )
+            return False
+    return bool(condition)
 
 
-class VisibleBox(Widget):
-    """Wrapper widget that toggles the presence of a child based on a condition.
+class _AnimatedVisibleBox(Widget):
+    """Single-child paint wrapper that animates pattern visuals on visibility change.
 
-    The child is *lazy-mounted*: when the initial condition is ``False`` the
-    child is not added to the tree at all. It is mounted on the first
-    transition to ``True`` and unmounted again after exit (or immediately when
-    no transition is provided).
+    The child is always mounted and occupies its natural layout space. Visuals
+    (opacity / scale / translate, and translate-as-fraction-of-size) are
+    derived from the supplied :class:`TransitionDefinition` and applied at
+    paint time. Hit-test blocking while hidden is the responsibility of an
+    outer ``ignore_pointer`` wrapper applied by :class:`_AnimatedVisibleModifier`.
     """
 
     def __init__(
         self,
         child: Widget,
         condition: VisibleConditionLike,
-        *,
-        transition: Optional[TransitionDefinition] = None,
+        transition: TransitionDefinition,
     ) -> None:
-        # Inherit sizing from the child so layout matches when visible.
         super().__init__(
             width=child.width_sizing,
             height=child.height_sizing,
             max_children=1,
             overflow_policy="replace_last",
         )
-        self._child_widget: Widget = child
         self._condition: VisibleConditionLike = condition
-        self._transition: Optional[TransitionDefinition] = transition
-
-        # User-facing logical visibility (drives input).
-        self._logical_visible: bool = self._read_initial_condition(condition)
-        # Whether the child is currently mounted in the tree.
-        self._physical_present: bool = False
-        # Saved sizing to restore when becoming visible.
-        self._user_width_sizing: Sizing = self.width_sizing
-        self._user_height_sizing: Sizing = self.height_sizing
-
-        # Animation state (only used when transition is provided).
+        self._transition: TransitionDefinition = transition
+        self._logical_visible: bool = _read_initial_condition(condition)
+        self._progress: float = 1.0 if self._logical_visible else 0.0
         self._animatable: Optional[Animatable[float]] = None
         self._animatable_subscription: Optional["Disposable"] = None
-        self._progress: float = 1.0 if self._logical_visible else 0.0
-
-        if self._logical_visible:
-            self._mount_child()
-            self._progress = 1.0
-        else:
-            self._apply_hidden_sizing()
-
-    # ------------------------------------------------------------------
-    # Sizing helpers
-    # ------------------------------------------------------------------
-
-    def _apply_hidden_sizing(self) -> None:
-        self.width_sizing = _HIDDEN_SIZING
-        self.height_sizing = _HIDDEN_SIZING
-
-    def _apply_visible_sizing(self) -> None:
-        self.width_sizing = self._user_width_sizing
-        self.height_sizing = self._user_height_sizing
-
-    # ------------------------------------------------------------------
-    # Initial condition / observation
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _read_initial_condition(condition: VisibleConditionLike) -> bool:
-        if isinstance(condition, ReadOnlyObservableProtocol):
-            try:
-                return bool(condition.value)
-            except Exception:
-                exception_once(
-                    logger,
-                    "visible_box_initial_condition_exc",
-                    "Failed to read initial condition observable",
-                )
-                return False
-        return bool(condition)
+        self.add_child(child)
 
     def on_mount(self) -> None:
         super().on_mount()
-        # Re-apply sizing to match current state once we have an app reference.
-        if self._physical_present:
-            self._apply_visible_sizing()
-        else:
-            self._apply_hidden_sizing()
-
         if isinstance(self._condition, ReadOnlyObservableProtocol):
             self.observe(self._condition, self._on_condition_changed)
 
@@ -145,101 +113,26 @@ class VisibleBox(Widget):
         self._stop_animation_subscription()
         super().on_unmount()
 
-    # ------------------------------------------------------------------
-    # State transitions
-    # ------------------------------------------------------------------
-
     def _on_condition_changed(self, value: bool) -> None:
         next_visible = bool(value)
         if next_visible == self._logical_visible:
             return
         self._logical_visible = next_visible
-        if next_visible:
-            self._handle_show()
-        else:
-            self._handle_hide()
-
-    def _handle_show(self) -> None:
-        # Always lazy-mount before animating.
-        if not self._physical_present:
-            self._mount_child()
-
-        if self._transition is None:
-            self._progress = 1.0
-            self._stop_animation_subscription()
-            self.invalidate()
-            return
-
         animatable = self._ensure_animatable()
-        animatable.target = 1.0
+        animatable.target = 1.0 if next_visible else 0.0
         self.invalidate()
-
-    def _handle_hide(self) -> None:
-        if not self._physical_present:
-            # Already hidden; nothing to do.
-            return
-
-        if self._transition is None:
-            self._unmount_child()
-            self._progress = 0.0
-            self.invalidate()
-            return
-
-        animatable = self._ensure_animatable()
-        animatable.target = 0.0
-        self.invalidate()
-
-    # ------------------------------------------------------------------
-    # Child mount / unmount
-    # ------------------------------------------------------------------
-
-    def _mount_child(self) -> None:
-        if self._physical_present:
-            return
-        self._apply_visible_sizing()
-        self.add_child(self._child_widget)
-        self._physical_present = True
-        self.mark_needs_layout()
-        self.invalidate()
-
-    def _unmount_child(self) -> None:
-        if not self._physical_present:
-            return
-        try:
-            self.remove_child(self._child_widget)
-        except Exception:
-            exception_once(
-                logger,
-                "visible_box_remove_child_exc",
-                "VisibleBox failed to remove child during hide",
-            )
-        self._physical_present = False
-        self._apply_hidden_sizing()
-        self.mark_needs_layout()
-        self.invalidate()
-
-    # ------------------------------------------------------------------
-    # Animation driver
-    # ------------------------------------------------------------------
 
     def _ensure_animatable(self) -> Animatable[float]:
         if self._animatable is not None:
             return self._animatable
-
-        assert self._transition is not None
-        initial = self._progress
-        animatable: Animatable[float] = Animatable(initial, motion=self._transition.motion)
+        animatable: Animatable[float] = Animatable(self._progress, motion=self._transition.motion)
         self._animatable = animatable
 
         def _on_progress(value: float) -> None:
             self._progress = float(value)
             self.invalidate()
-            # Detect exit completion: hidden requested and animation reached 0.
-            if not self._logical_visible and self._progress <= 0.0 and self._physical_present:
-                self._unmount_child()
 
-        sub = animatable.subscribe(_on_progress)
-        self._animatable_subscription = sub
+        self._animatable_subscription = animatable.subscribe(_on_progress)
         return animatable
 
     def _stop_animation_subscription(self) -> None:
@@ -253,154 +146,137 @@ class VisibleBox(Widget):
         except Exception:
             exception_once(
                 logger,
-                "visible_box_animation_unsubscribe_exc",
-                "VisibleBox failed to dispose animation subscription",
+                "visible_animation_unsubscribe_exc",
+                "_AnimatedVisibleBox failed to dispose animation subscription",
             )
         self._animatable_subscription = None
 
-    # ------------------------------------------------------------------
-    # Visuals from transition pattern
-    # ------------------------------------------------------------------
-
-    def _resolve_transition_visuals(self) -> Optional[TransitionVisuals]:
-        if self._transition is None:
+    def _child(self) -> Optional[Widget]:
+        if not self.children:
             return None
+        child = self.children[0]
+        if isinstance(child, Widget):
+            return child
+        return None
+
+    def _resolve_visuals(self) -> Optional[TransitionVisuals]:
         try:
             return self._transition.pattern.resolve(self._progress)
         except Exception:
             exception_once(
                 logger,
-                "visible_box_resolve_visuals_exc",
-                "TransitionPattern.resolve raised in VisibleBox",
+                "visible_resolve_visuals_exc",
+                "TransitionPattern.resolve raised in _AnimatedVisibleBox",
             )
             return None
-
-    # ------------------------------------------------------------------
-    # Widget overrides
-    # ------------------------------------------------------------------
 
     def preferred_size(
         self,
         max_width: Optional[int] = None,
         max_height: Optional[int] = None,
     ) -> Tuple[int, int]:
-        if not self._physical_present:
-            return (0, 0)
+        child = self._child()
+        if child is None:
+            return super().preferred_size(max_width=max_width, max_height=max_height)
         try:
-            return self._child_widget.preferred_size(max_width=max_width, max_height=max_height)
+            return child.preferred_size(max_width=max_width, max_height=max_height)
         except Exception:
             exception_once(
                 logger,
-                "visible_box_preferred_size_exc",
-                "Child preferred_size raised in VisibleBox",
+                "visible_preferred_size_exc",
+                "Child preferred_size raised in _AnimatedVisibleBox",
             )
-            return (0, 0)
+            return super().preferred_size(max_width=max_width, max_height=max_height)
 
     def layout(self, width: int, height: int) -> None:
         super().layout(width, height)
-        if not self._physical_present:
+        child = self._child()
+        if child is None:
             return
         try:
-            self._child_widget.layout(width, height)
-            self._child_widget.set_layout_rect(0, 0, width, height)
+            child.layout(width, height)
+            child.set_layout_rect(0, 0, width, height)
         except Exception:
             exception_once(
                 logger,
-                "visible_box_layout_exc",
-                "Child layout raised in VisibleBox",
+                "visible_layout_exc",
+                "Child layout raised in _AnimatedVisibleBox",
             )
 
     def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
         self.set_last_rect(x, y, width, height)
-        if not self._physical_present:
+        child = self._child()
+        if child is None:
             return
 
-        visuals = self._resolve_transition_visuals()
+        visuals = self._resolve_visuals()
         if visuals is None or canvas is None or not _has_visual_effect(visuals):
             try:
-                self._child_widget.set_last_rect(x, y, width, height)
-                self._child_widget.paint(canvas, x, y, width, height)
+                child.set_last_rect(x, y, width, height)
+                child.paint(canvas, x, y, width, height)
             except Exception:
                 exception_once(
                     logger,
-                    "visible_box_paint_no_visuals_exc",
-                    "Child paint raised in VisibleBox",
+                    "visible_paint_no_visuals_exc",
+                    "Child paint raised in _AnimatedVisibleBox",
                 )
             return
 
-        # Apply transition visuals (opacity + transforms) around child paint.
-        opacity = _clamp_unit(visuals.opacity) if visuals.opacity is not None else 1.0
-        scale_x = visuals.scale_x if visuals.scale_x is not None else 1.0
-        scale_y = visuals.scale_y if visuals.scale_y is not None else 1.0
-        translate_x = visuals.translate_x if visuals.translate_x is not None else 0.0
-        translate_y = visuals.translate_y if visuals.translate_y is not None else 0.0
+        op = _clamp_unit(visuals.opacity) if visuals.opacity is not None else 1.0
+        sx = visuals.scale_x if visuals.scale_x is not None else 1.0
+        sy = visuals.scale_y if visuals.scale_y is not None else 1.0
+        tx = visuals.translate_x if visuals.translate_x is not None else 0.0
+        ty = visuals.translate_y if visuals.translate_y is not None else 0.0
         if visuals.translate_x_fraction is not None:
-            translate_x += visuals.translate_x_fraction * float(width)
+            tx += visuals.translate_x_fraction * float(width)
         if visuals.translate_y_fraction is not None:
-            translate_y += visuals.translate_y_fraction * float(height)
+            ty += visuals.translate_y_fraction * float(height)
 
-        needs_opacity = opacity < 1.0
+        needs_opacity = op < 1.0
         try:
             canvas.save()
             if needs_opacity:
                 try:
                     from nuiitivet.rendering.skia.color import make_opacity_paint
 
-                    layer_paint = make_opacity_paint(opacity)
+                    layer_paint = make_opacity_paint(op)
                     if layer_paint is not None:
                         canvas.saveLayer(None, layer_paint)
                 except Exception:
                     exception_once(
                         logger,
-                        "visible_box_opacity_layer_exc",
-                        "VisibleBox failed to apply opacity layer",
+                        "visible_opacity_layer_exc",
+                        "_AnimatedVisibleBox failed to apply opacity layer",
                     )
 
-            if translate_x != 0.0 or translate_y != 0.0:
-                canvas.translate(translate_x, translate_y)
-            if scale_x != 1.0 or scale_y != 1.0:
+            if tx != 0.0 or ty != 0.0:
+                canvas.translate(tx, ty)
+            if sx != 1.0 or sy != 1.0:
                 cx = float(x) + float(width) / 2.0
                 cy = float(y) + float(height) / 2.0
                 canvas.translate(cx, cy)
-                canvas.scale(scale_x, scale_y)
+                canvas.scale(sx, sy)
                 canvas.translate(-cx, -cy)
 
-            self._child_widget.set_last_rect(x, y, width, height)
-            self._child_widget.paint(canvas, x, y, width, height)
+            child.set_last_rect(x, y, width, height)
+            child.paint(canvas, x, y, width, height)
         except Exception:
             exception_once(
                 logger,
-                "visible_box_paint_exc",
-                "VisibleBox paint raised",
+                "visible_paint_exc",
+                "_AnimatedVisibleBox paint raised",
             )
         finally:
             try:
                 if needs_opacity:
-                    canvas.restore()  # opacity layer
-                canvas.restore()  # geometric transforms
+                    canvas.restore()
+                canvas.restore()
             except Exception:
                 exception_once(
                     logger,
-                    "visible_box_restore_exc",
-                    "VisibleBox canvas.restore failed",
+                    "visible_restore_exc",
+                    "_AnimatedVisibleBox canvas.restore failed",
                 )
-
-    def hit_test(self, x: int, y: int):
-        # Block all input the moment the condition flips to False, even while
-        # an exit animation is still playing.
-        if not self._logical_visible or not self._physical_present:
-            return None
-        try:
-            hit = self._child_widget.hit_test(x, y)
-            if hit is not None:
-                return hit
-        except Exception:
-            exception_once(
-                logger,
-                "visible_box_hit_test_exc",
-                "Child hit_test raised in VisibleBox",
-            )
-        return super().hit_test(x, y)
 
 
 def _clamp_unit(value: float) -> float:
@@ -422,48 +298,72 @@ def _has_visual_effect(visuals: TransitionVisuals) -> bool:
     )
 
 
+def _hidden_observable(
+    condition: VisibleConditionLike,
+) -> Union[bool, ReadOnlyObservableProtocol[bool]]:
+    if isinstance(condition, ReadOnlyObservableProtocol):
+        source = condition
+        return ComputedObservable(lambda: not bool(source.value))
+    return not bool(condition)
+
+
+def _opacity_observable(
+    condition: VisibleConditionLike,
+) -> Union[float, ReadOnlyObservableProtocol[float]]:
+    if isinstance(condition, ReadOnlyObservableProtocol):
+        source = condition
+        return ComputedObservable(lambda: 1.0 if bool(source.value) else 0.0)
+    return 1.0 if bool(condition) else 0.0
+
+
 @dataclass(slots=True)
-class VisibleModifier(ModifierElement):
-    """Modifier that conditionally shows/hides a widget with optional animation."""
+class _AnimatedVisibleModifier(ModifierElement):
+    """Animated branch of :func:`visible`. Wraps with a paint box and ignore_pointer."""
 
     condition: VisibleConditionLike
-    transition: Optional[TransitionDefinition] = None
+    transition: TransitionDefinition
 
     def apply(self, widget: Widget) -> Widget:
-        return VisibleBox(widget, self.condition, transition=self.transition)
+        paint_box = _AnimatedVisibleBox(widget, self.condition, self.transition)
+        return IgnorePointerBox(paint_box, _hidden_observable(self.condition))
 
 
 def visible(
     condition: VisibleConditionLike,
     *,
     transition: Optional[TransitionDefinition] = None,
-) -> VisibleModifier:
-    """Toggle a widget's presence in the layout tree.
+) -> ModifierElement:
+    """Toggle a widget's visibility as a thin composition of ``opacity()`` + ``ignore_pointer()``.
 
-    When *condition* is ``False`` the widget is removed from layout (zero
-    width/height) and no longer receives input events. When ``True`` the
-    widget is mounted and laid out normally.
+    When *condition* is ``False`` the widget is rendered fully transparent and
+    ignores pointer / hit events; when ``True`` it is fully opaque and
+    interactive. The widget continues to occupy its normal layout space in
+    both states (use a layout-aware Widget if you need the layout to collapse).
 
     Args:
         condition: Static ``bool`` or an ``Observable[bool]`` driving visibility.
-        transition: Optional :class:`TransitionDefinition` that animates enter
-            and exit. When omitted, mount/unmount happens immediately.
+        transition: Optional :class:`TransitionDefinition` whose pattern drives
+            the ``opacity`` (and optional ``scale`` / ``translate``) animation
+            on enter / exit. When omitted, visibility flips instantly.
 
     Returns:
-        A :class:`VisibleModifier` to apply via ``widget.modifier(...)``.
+        A :class:`ModifierElement` to apply via ``widget.modifier(...)``. With
+        no *transition* this is literally ``opacity(...) | ignore_pointer(...)``.
 
     Note:
-        Visibility uses *lazy mount*: when *condition* starts ``False`` the
-        child is not built until the first transition to ``True``. Subsequent
-        hides will fully unmount the child, so widget-local state is not
-        preserved across hide/show cycles. For "invisible but interactive"
-        behavior, use :func:`opacity` ``(0.0)`` instead.
+        ``visible()`` is a paint-time / input-time convenience and does *not*
+        manage layout. The child is always eagerly mounted and keeps its
+        layout space while hidden. Widget-local state is therefore preserved
+        across hide / show cycles.
     """
-    return VisibleModifier(condition=condition, transition=transition)
+    if transition is None:
+        composed: Modifier = Modifier()
+        composed = composed.then(opacity(_opacity_observable(condition)))
+        composed = composed.then(ignore_pointer(_hidden_observable(condition)))
+        return composed
+    return _AnimatedVisibleModifier(condition=condition, transition=transition)
 
 
 __all__ = [
-    "VisibleBox",
-    "VisibleModifier",
     "visible",
 ]

--- a/src/samples/visible_demo.py
+++ b/src/samples/visible_demo.py
@@ -6,9 +6,10 @@ Demonstrates the three core usages of the visible() modifier:
 2. Observable toggle   - reactive show/hide driven by Observable[bool]
 3. Animated visibility - enter/exit animation via TransitionDefinition
 
-When hidden, the widget is removed from layout (zero size) and ignores input
-("gone" semantics). Use opacity(0.0) instead when the widget should remain
-laid out and interactive while invisible.
+When hidden, the widget is rendered fully transparent and ignores input, but
+it continues to occupy its normal layout space (visible() is a thin
+composition of opacity() + ignore_pointer()). For layout-size animations,
+use a dedicated layout-aware Widget instead.
 """
 
 from __future__ import annotations
@@ -55,7 +56,7 @@ class _ObservableToggleDemo(ComposableWidget):
 
         return Column(
             children=[
-                _section_label("Observable toggle (no animation, gone semantics)"),
+                _section_label("Observable toggle (no animation, layout space preserved)"),
                 Button("Toggle", on_click=toggle, style=ButtonStyle.filled()),
                 _panel("Hello", "#2196F3").modifier(visible(self.is_visible)),
                 Text("Below sibling", style=TextStyle(font_size=12)),
@@ -74,7 +75,7 @@ class _AnimatedToggleDemo(ComposableWidget):
 
         return Column(
             children=[
-                _section_label("Animated toggle (fade + scale, gone after exit)"),
+                _section_label("Animated toggle (fade + scale, layout space preserved)"),
                 Button("Toggle", on_click=toggle, style=ButtonStyle.filled()),
                 _panel("Animated", "#4CAF50").modifier(visible(self.is_visible, transition=_FADE_SCALE)),
                 Text("Below sibling", style=TextStyle(font_size=12)),
@@ -114,7 +115,7 @@ def main(png: str = "") -> None:
         cross_alignment="start",
     )
 
-    app = App(content=content, width=520, height=520)
+    app = App(content=content, width=680, height=520)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/tests/test_ignore_pointer.py
+++ b/tests/test_ignore_pointer.py
@@ -1,0 +1,70 @@
+"""Tests for ignore_pointer() modifier."""
+
+from __future__ import annotations
+
+from nuiitivet.modifiers.ignore_pointer import IgnorePointerBox, ignore_pointer
+from nuiitivet.observable.value import _ObservableValue
+from nuiitivet.rendering.sizing import Sizing
+from nuiitivet.widgets.box import Box
+
+
+class _DummyApp:
+    def __init__(self) -> None:
+        self.invalidated = 0
+
+    def invalidate(self, immediate: bool = False) -> None:
+        del immediate
+        self.invalidated += 1
+
+
+def _make_child() -> Box:
+    return Box(width=Sizing.fixed(100), height=Sizing.fixed(50))
+
+
+def test_ignore_pointer_default_blocks_hit_test() -> None:
+    child = _make_child()
+    wrapped = child.modifier(ignore_pointer())
+    assert isinstance(wrapped, IgnorePointerBox)
+    assert wrapped._active is True
+
+    wrapped.layout(100, 50)
+    assert wrapped.hit_test(50, 25) is None
+
+
+def test_ignore_pointer_static_false_does_not_block() -> None:
+    child = _make_child()
+    wrapped = child.modifier(ignore_pointer(False))
+    assert isinstance(wrapped, IgnorePointerBox)
+    assert wrapped._active is False
+
+    wrapped.layout(100, 50)
+    # When inactive, hit testing reaches the child / box itself.
+    assert wrapped.hit_test(50, 25) is not None
+
+
+def test_ignore_pointer_observable_toggles_active() -> None:
+    cond = _ObservableValue(False)
+    child = _make_child()
+    wrapped = child.modifier(ignore_pointer(cond))
+    assert isinstance(wrapped, IgnorePointerBox)
+
+    app = _DummyApp()
+    wrapped.mount(app)
+    wrapped.layout(100, 50)
+
+    assert wrapped._active is False
+    assert wrapped.hit_test(50, 25) is not None
+
+    cond.value = True
+    assert wrapped._active is True
+    assert wrapped.hit_test(50, 25) is None
+
+    cond.value = False
+    assert wrapped._active is False
+    assert wrapped.hit_test(50, 25) is not None
+
+
+def test_ignore_pointer_preserves_layout_size() -> None:
+    child = _make_child()
+    wrapped = child.modifier(ignore_pointer())
+    assert wrapped.preferred_size() == (100, 50)

--- a/tests/test_visible.py
+++ b/tests/test_visible.py
@@ -1,4 +1,4 @@
-"""Tests for visible() modifier."""
+"""Tests for visible() modifier (composition of opacity + ignore_pointer)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,9 @@ from typing import Callable
 from nuiitivet.animation import LinearMotion
 from nuiitivet.animation.transition_definition import TransitionDefinition
 from nuiitivet.animation.transition_pattern import FadePattern
-from nuiitivet.modifiers.visible import VisibleBox, visible
+from nuiitivet.modifiers.ignore_pointer import IgnorePointerBox
+from nuiitivet.modifiers.transform import TransformBox
+from nuiitivet.modifiers.visible import _AnimatedVisibleBox, visible
 from nuiitivet.observable import runtime as observable_runtime
 from nuiitivet.observable.value import _ObservableValue
 from nuiitivet.rendering.sizing import Sizing
@@ -47,75 +49,106 @@ def _make_child() -> Box:
     return Box(width=Sizing.fixed(100), height=Sizing.fixed(50))
 
 
-def test_visible_static_true_mounts_child() -> None:
+# ---------------------------------------------------------------------------
+# Static (non-animated) composition
+# ---------------------------------------------------------------------------
+
+
+def test_visible_static_true_composes_opacity_and_ignore_pointer() -> None:
     child = _make_child()
-    box = child.modifier(visible(True))
+    wrapped = child.modifier(visible(True))
 
-    assert isinstance(box, VisibleBox)
-    assert box._physical_present is True
-    assert box._logical_visible is True
-    assert box.preferred_size() == (100, 50)
+    # Outer wrapper is IgnorePointerBox; inside is a TransformBox (opacity).
+    assert isinstance(wrapped, IgnorePointerBox)
+    assert wrapped._active is False
+    inner = wrapped.children[0]
+    assert isinstance(inner, TransformBox)
+    assert inner._opacity == 1.0
 
 
-def test_visible_static_false_does_not_mount_child() -> None:
+def test_visible_static_false_keeps_layout_and_blocks_input() -> None:
     child = _make_child()
-    box = child.modifier(visible(False))
+    wrapped = child.modifier(visible(False))
 
-    assert isinstance(box, VisibleBox)
-    assert box._physical_present is False
-    assert box._logical_visible is False
-    assert box.preferred_size() == (0, 0)
-    # Sizing collapses to 0 so parents allocate no space.
-    assert box.width_sizing.kind == "fixed"
-    assert box.width_sizing.value == 0
-    assert box.height_sizing.kind == "fixed"
-    assert box.height_sizing.value == 0
+    assert isinstance(wrapped, IgnorePointerBox)
+    assert wrapped._active is True
+    inner = wrapped.children[0]
+    assert isinstance(inner, TransformBox)
+    assert inner._opacity == 0.0
 
+    # Layout space is preserved (no zero collapse).
+    assert wrapped.preferred_size() == (100, 50)
 
-def test_visible_observable_show_then_hide_no_transition() -> None:
-    cond = _ObservableValue(False)
-    child = _make_child()
-    box = child.modifier(visible(cond))
-    assert isinstance(box, VisibleBox)
-
-    app = _DummyApp()
-    box.mount(app)
-
-    assert box._physical_present is False
-    assert box.preferred_size() == (0, 0)
-
-    cond.value = True
-    assert box._physical_present is True
-    assert box._logical_visible is True
-    assert box.preferred_size() == (100, 50)
-
-    cond.value = False
-    assert box._physical_present is False
-    assert box._logical_visible is False
-    assert box.preferred_size() == (0, 0)
+    # Hit-test is blocked while hidden.
+    wrapped.layout(100, 50)
+    assert wrapped.hit_test(50, 25) is None
 
 
-def test_visible_initial_true_observable_is_mounted() -> None:
+def test_visible_observable_toggles_input_blocking_and_opacity() -> None:
     cond = _ObservableValue(True)
     child = _make_child()
-    box = child.modifier(visible(cond))
-    assert isinstance(box, VisibleBox)
+    wrapped = child.modifier(visible(cond))
+    assert isinstance(wrapped, IgnorePointerBox)
+    inner = wrapped.children[0]
+    assert isinstance(inner, TransformBox)
 
-    assert box._physical_present is True
-    assert box.preferred_size() == (100, 50)
+    app = _DummyApp()
+    wrapped.mount(app)
+
+    assert wrapped._active is False
+    assert inner._opacity == 1.0
+
+    cond.value = False
+    assert wrapped._active is True
+    assert inner._opacity == 0.0
+
+    cond.value = True
+    assert wrapped._active is False
+    assert inner._opacity == 1.0
 
 
-def test_visible_hidden_blocks_hit_test() -> None:
+def test_visible_observable_layout_space_preserved_when_hidden() -> None:
     cond = _ObservableValue(False)
     child = _make_child()
-    box = child.modifier(visible(cond))
-    assert isinstance(box, VisibleBox)
+    wrapped = child.modifier(visible(cond))
 
-    box.layout(0, 0)
-    assert box.hit_test(0, 0) is None
+    app = _DummyApp()
+    wrapped.mount(app)
+
+    # Layout space stays at child's natural size in both states.
+    assert wrapped.preferred_size() == (100, 50)
+    cond.value = True
+    assert wrapped.preferred_size() == (100, 50)
+    cond.value = False
+    assert wrapped.preferred_size() == (100, 50)
 
 
-def test_visible_with_transition_keeps_mounted_during_exit() -> None:
+def test_visible_child_stays_mounted_across_hide_show_cycles() -> None:
+    cond = _ObservableValue(True)
+    child = _make_child()
+    wrapped = child.modifier(visible(cond))
+
+    app = _DummyApp()
+    wrapped.mount(app)
+
+    inner = wrapped.children[0]
+    assert isinstance(inner, TransformBox)
+    # The original child is the inner-most descendant.
+    assert child in inner.children
+
+    cond.value = False
+    cond.value = True
+
+    # Same child instance is still mounted (state preserved).
+    assert child in inner.children
+
+
+# ---------------------------------------------------------------------------
+# Animated path
+# ---------------------------------------------------------------------------
+
+
+def test_visible_with_transition_initial_visible_animates_exit() -> None:
     prev_clock = observable_runtime.clock
     fake_clock = _FakeClock()
     observable_runtime.set_clock(fake_clock)
@@ -126,42 +159,39 @@ def test_visible_with_transition_keeps_mounted_during_exit() -> None:
             motion=LinearMotion(1.0),
             pattern=FadePattern(start_alpha=0.0, end_alpha=1.0),
         )
-        box = child.modifier(visible(cond, transition=transition))
-        assert isinstance(box, VisibleBox)
+        wrapped = child.modifier(visible(cond, transition=transition))
+
+        # Outer wrapper is IgnorePointerBox; inside is _AnimatedVisibleBox.
+        assert isinstance(wrapped, IgnorePointerBox)
+        paint_box = wrapped.children[0]
+        assert isinstance(paint_box, _AnimatedVisibleBox)
 
         app = _DummyApp()
-        box.mount(app)
+        wrapped.mount(app)
 
-        # Initially visible: progress=1.0, child mounted.
-        assert box._physical_present is True
-        assert box._progress == 1.0
+        assert paint_box._progress == 1.0
+        assert wrapped._active is False
 
-        # Trigger hide.
+        # Trigger hide. Hit-test is blocked immediately (ignore_pointer toggles).
         cond.value = False
+        assert wrapped._active is True
+        wrapped.layout(100, 50)
+        assert wrapped.hit_test(50, 25) is None
 
-        # Logical visibility flipped immediately, but child remains mounted
-        # while exit animation runs.
-        assert box._logical_visible is False
-        assert box._physical_present is True
-
-        # Hit-testing is blocked even before animation completes.
-        box.layout(100, 50)
-        assert box.hit_test(50, 25) is None
-
-        # Halfway through: progress should be ~0.5, still mounted.
+        # Halfway through exit: progress ~0.5, child still mounted.
         fake_clock.advance(0.5)
-        assert 0.4 <= box._progress <= 0.6
-        assert box._physical_present is True
+        assert 0.4 <= paint_box._progress <= 0.6
+        assert child in paint_box.children
 
-        # Animation completes: progress hits 0.0 -> child unmounted.
+        # Animation completes: progress reaches 0.0; child remains mounted.
         fake_clock.advance(0.5)
-        assert box._progress == 0.0
-        assert box._physical_present is False
+        assert paint_box._progress == 0.0
+        assert child in paint_box.children
     finally:
         observable_runtime.set_clock(prev_clock)
 
 
-def test_visible_with_transition_enter_animates_progress() -> None:
+def test_visible_with_transition_enter_animates_progress_up() -> None:
     prev_clock = observable_runtime.clock
     fake_clock = _FakeClock()
     observable_runtime.set_clock(fake_clock)
@@ -172,52 +202,36 @@ def test_visible_with_transition_enter_animates_progress() -> None:
             motion=LinearMotion(1.0),
             pattern=FadePattern(start_alpha=0.0, end_alpha=1.0),
         )
-        box = child.modifier(visible(cond, transition=transition))
-        assert isinstance(box, VisibleBox)
+        wrapped = child.modifier(visible(cond, transition=transition))
+        assert isinstance(wrapped, IgnorePointerBox)
+        paint_box = wrapped.children[0]
+        assert isinstance(paint_box, _AnimatedVisibleBox)
 
         app = _DummyApp()
-        box.mount(app)
+        wrapped.mount(app)
 
-        # Trigger show.
+        assert paint_box._progress == 0.0
+        assert wrapped._active is True
+
         cond.value = True
-
-        # Mounted immediately; progress starts at 0 and animates up.
-        assert box._physical_present is True
-        assert box._logical_visible is True
+        assert wrapped._active is False
 
         fake_clock.advance(0.5)
-        assert 0.4 <= box._progress <= 0.6
+        assert 0.4 <= paint_box._progress <= 0.6
 
         fake_clock.advance(0.5)
-        assert box._progress == 1.0
-        assert box._physical_present is True
+        assert paint_box._progress == 1.0
     finally:
         observable_runtime.set_clock(prev_clock)
 
 
-def test_visible_show_after_hide_remounts_child() -> None:
-    cond = _ObservableValue(True)
-    child = _make_child()
-    box = child.modifier(visible(cond))
-    assert isinstance(box, VisibleBox)
-
-    app = _DummyApp()
-    box.mount(app)
-
-    cond.value = False
-    assert box._physical_present is False
-
-    cond.value = True
-    assert box._physical_present is True
-    assert box.preferred_size() == (100, 50)
-
-
-def test_visible_modifier_chains_with_other_modifiers() -> None:
+def test_visible_chains_with_other_modifiers() -> None:
     from nuiitivet.modifiers import opacity
 
     cond = _ObservableValue(True)
     child = _make_child()
-    # Apply visible after opacity. Result should be a VisibleBox at the top.
+    # Apply opacity first, then visible. visible() expands to opacity|ignore_pointer
+    # so the outer-most wrapper is IgnorePointerBox.
     wrapped = child.modifier(opacity(0.5) | visible(cond))
-    assert isinstance(wrapped, VisibleBox)
-    assert wrapped._physical_present is True
+    assert isinstance(wrapped, IgnorePointerBox)
+    assert wrapped._active is False


### PR DESCRIPTION
## Summary

Refactor `visible()` so it is a *thin composition* of two paint-time / input
primitives instead of an independent feature. Layout responsibility (forced
`Sizing.fixed(0)` and lazy mount / unmount) is removed; `visible()` no longer
breaks the project rule that "modifiers do not handle layout".

Closes #114

## Changes

* **Add `ignore_pointer()` modifier** (`src/nuiitivet/modifiers/ignore_pointer.py`)
  * Single-responsibility primitive that blocks hit-testing for the wrapped subtree.
  * Accepts a static `bool` or `Observable[bool]`; defaults to always-block.
* **Re-define `visible()` as a thin composition** (`src/nuiitivet/modifiers/visible.py`)
  * No-transition path: returns literally `opacity(...) | ignore_pointer(...)`.
  * Animated path: `_AnimatedVisibleBox` (paint-only, always-mounted) wrapped by
    `IgnorePointerBox`. Pattern visuals (`opacity` / `scale` / `translate` /
    fractional translate) are applied at paint time; input is blocked
    immediately when the condition flips to `False`.
  * The previous `VisibleBox` (~400 lines) is removed.
* **Update `docs/design/MODIFIER.md`**
  * Drop the "intentional exception" note about `visible()` influencing layout.
  * Refresh the comparison table:

    | Behavior | `opacity(0.0)` | `ignore_pointer()` | `visible(False)` |
    |---|---|---|---|
    | Visually hidden | Yes | No | Yes |
    | Receives input | Yes | No | No |
    | Layout space | Reserved | Reserved | Reserved |
* **Tests**
  * `tests/test_ignore_pointer.py`: new (default block, static false, observable toggle, layout preservation).
  * `tests/test_visible.py`: rewritten for the composition structure (preserved layout, preserved widget state across cycles, animated path still blocks input on flip).
* **Sample**: refresh `src/samples/visible_demo.py` wording.

## Behavior After Change

* Hidden widgets keep their natural layout space (no zero collapse).
* Children are always eagerly mounted; widget-local state is preserved across hide/show cycles.
* Hit-testing is blocked while `condition` is `False`; visual fade is driven by `opacity`.
* With `transition`, input blocks the moment `condition` flips to `False`, even while the exit animation is still playing.

## Breaking Changes

* Hidden widgets no longer collapse to zero size. Callers relying on the old
  "gone" semantics must migrate to a layout-aware Widget once #113 lands.
* The lazy mount behavior is removed; child subtrees are constructed eagerly.
* `VisibleBox` and `VisibleModifier` are no longer exported from
  `nuiitivet.modifiers.visible`. Use `visible(...)` (returns
  `ModifierElement`) as the public API.

## Validation

* `uv run pytest` — 1175 passed
* `uv run mypy` — Success (506 source files)
* `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` — clean

## Out of Scope

* Layout-size animation (#113, #112).
