### PR TITLE
fix(text-field): align label and input layout with MD3 spec

### DIFF
--- a/docs/md3/text_fields.md
+++ b/docs/md3/text_fields.md
@@ -1,0 +1,644 @@
+<!-- markdownlint-disable MD060 -->
+
+# Text Fields MD3 Specs
+
+**Source:** <https://m3.material.io/components/text-fields/specs>  
+**Collected:** 2026-04-27
+
+## Summary
+
+- Material Design 3 text field specifications covering filled and outlined fields plus current select and autocomplete variants exposed in the live token viewer.
+- Five interactive states are represented across the current token sets: Enabled, Disabled, Hovered, Focused, and Error.
+- Values were resolved from the Material token table using the Light + Default + Expressive context when available, with Light + Default as fallback.
+
+## Tokens & Specs
+
+### Token Sets Discovered
+
+| Token Set | Count | Type | Status |
+|---|---:|---|---|
+| Text field - Filled | 89 | Component | Active |
+| Text field - Outlined | 84 | Component | Active |
+| Text field - Select, outlined | 105 | Component | Active |
+| Text field - Select, filled | 107 | Component | Active |
+| Text field - Autocomplete, filled | 103 | Component | Active |
+| Text field - Autocomplete, outlined | 101 | Component | Active |
+
+### Text field - Filled
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Text field - Filled | Enabled | Filled text field active indicator color | md.comp.filled-text-field.active-indicator.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field active indicator height | md.comp.filled-text-field.active-indicator.height |  | 1dp |  |
+| Text field - Filled | Enabled | Filled text field caret color | md.comp.filled-text-field.caret.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Filled | Enabled | Filled text field container color | md.comp.filled-text-field.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Filled | Layout | Filled text field container height | md.comp.filled-text-field.container.height |  | 56dp |  |
+| Text field - Filled | Shape | Filled text field container shape | md.comp.filled-text-field.container.shape | md.sys.shape.corner.extra-small.top | Rounded Corners | Resolved as rounded corners. |
+| Text field - Filled | Disabled | Filled text field disabled active indicator color | md.comp.filled-text-field.disabled.active-indicator.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Disabled | Filled text field disabled active indicator height | md.comp.filled-text-field.disabled.active-indicator.height |  | 1dp |  |
+| Text field - Filled | Disabled | Filled text field disabled active indicator opacity | md.comp.filled-text-field.disabled.active-indicator.opacity |  | 0.38 |  |
+| Text field - Filled | Disabled | Filled text field disabled container color | md.comp.filled-text-field.disabled.container.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Disabled | Filled text field disabled container opacity | md.comp.filled-text-field.disabled.container.opacity |  | 0.04 |  |
+| Text field - Filled | Disabled | Filled text field disabled input text color | md.comp.filled-text-field.disabled.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Disabled | Filled text field disabled input text opacity | md.comp.filled-text-field.disabled.input-text.opacity |  | 0.38 |  |
+| Text field - Filled | Disabled | Filled text field disabled label text color | md.comp.filled-text-field.disabled.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Disabled | Filled text field disabled label text opacity | md.comp.filled-text-field.disabled.label-text.opacity |  | 0.38 |  |
+| Text field - Filled | Disabled | Filled text field disabled leading icon color | md.comp.filled-text-field.disabled.leading-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Disabled | Filled text field disabled leading icon opacity | md.comp.filled-text-field.disabled.leading-icon.opacity |  | 0.38 |  |
+| Text field - Filled | Disabled | Filled text field disabled supporting text color | md.comp.filled-text-field.disabled.supporting-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Disabled | Filled text field disabled supporting text opacity | md.comp.filled-text-field.disabled.supporting-text.opacity |  | 0.38 |  |
+| Text field - Filled | Disabled | Filled text field disabled trailing icon color | md.comp.filled-text-field.disabled.trailing-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Disabled | Filled text field disabled trailing icon opacity | md.comp.filled-text-field.disabled.trailing-icon.opacity |  | 0.38 |  |
+| Text field - Filled | Error | Filled text field error active indicator color | md.comp.filled-text-field.error.active-indicator.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error / Focused | Filled text field error focus active indicator color | md.comp.filled-text-field.error.focus.active-indicator.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error / Focused | Filled text field error focus caret color | md.comp.filled-text-field.error.focus.caret.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error / Focused | Filled text field error focus input text color | md.comp.filled-text-field.error.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Error / Focused | Filled text field error focus label text color | md.comp.filled-text-field.error.focus.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error / Focused | Filled text field error focus leading icon color | md.comp.filled-text-field.error.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Error / Focused | Filled text field error focus supporting text color | md.comp.filled-text-field.error.focus.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error / Focused | Filled text field error focus trailing icon color | md.comp.filled-text-field.error.focus.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover active indicator color | md.comp.filled-text-field.error.hover.active-indicator.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover input text color | md.comp.filled-text-field.error.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover label text color | md.comp.filled-text-field.error.hover.label-text.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover leading icon color | md.comp.filled-text-field.error.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover state layer color | md.comp.filled-text-field.error.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover state layer opacity | md.comp.filled-text-field.error.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover supporting text color | md.comp.filled-text-field.error.hover.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error / Hovered | Filled text field error hover trailing icon color | md.comp.filled-text-field.error.hover.trailing-icon.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Filled | Error | Filled text field error input text color | md.comp.filled-text-field.error.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Error | Filled text field error label text color | md.comp.filled-text-field.error.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error | Filled text field error leading icon color | md.comp.filled-text-field.error.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Error | Filled text field error supporting text color | md.comp.filled-text-field.error.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Error | Filled text field error trailing icon color | md.comp.filled-text-field.error.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Filled | Focused | Filled text field focus active indicator color | md.comp.filled-text-field.focus.active-indicator.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Filled | Focused | Filled text field focus active indicator height | md.comp.filled-text-field.focus.active-indicator.height |  | 2dp |  |
+| Text field - Filled | Focused | Filled text field focus active indicator thickness | md.comp.filled-text-field.focus.active-indicator.thickness | md.sys.state.focus-indicator.thickness | 3dp |  |
+| Text field - Filled | Focused | Filled text field focus input text color | md.comp.filled-text-field.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Focused | Filled text field focus label text color | md.comp.filled-text-field.focus.label-text.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Filled | Focused | Filled text field focus leading icon color | md.comp.filled-text-field.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Focused | Filled text field focus supporting text color | md.comp.filled-text-field.focus.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Focused | Filled text field focus trailing icon color | md.comp.filled-text-field.focus.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Hovered | Filled text field hover active indicator color | md.comp.filled-text-field.hover.active-indicator.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Hovered | Filled text field hover active indicator height | md.comp.filled-text-field.hover.active-indicator.height |  | 1dp |  |
+| Text field - Filled | Hovered | Filled text field hover input text color | md.comp.filled-text-field.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Hovered | Filled text field hover label text color | md.comp.filled-text-field.hover.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Hovered | Filled text field hover leading icon color | md.comp.filled-text-field.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Hovered | Filled text field hover state layer color | md.comp.filled-text-field.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Hovered | Filled text field hover state layer opacity | md.comp.filled-text-field.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Filled | Hovered | Filled text field hover supporting text color | md.comp.filled-text-field.hover.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Hovered | Filled text field hover trailing icon color | md.comp.filled-text-field.hover.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field input text color | md.comp.filled-text-field.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Filled | Enabled | Filled text field input text font | md.comp.filled-text-field.input-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Filled | Enabled | Filled text field input text line height | md.comp.filled-text-field.input-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Filled | Enabled | Filled text field input text placeholder color | md.comp.filled-text-field.input-text.placeholder.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field input text prefix color | md.comp.filled-text-field.input-text.prefix.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field input text size | md.comp.filled-text-field.input-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Filled | Enabled | Filled text field input text suffix color | md.comp.filled-text-field.input-text.suffix.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field input text tracking | md.comp.filled-text-field.input-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Filled | Enabled | Filled text field input text type | md.comp.filled-text-field.input-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Filled | Enabled | Filled text field input text weight | md.comp.filled-text-field.input-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Filled | Enabled | Filled text field label text color | md.comp.filled-text-field.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field label text font | md.comp.filled-text-field.label-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Filled | Enabled | Filled text field label text line height | md.comp.filled-text-field.label-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Filled | Enabled | Filled text field label text populated line height | md.comp.filled-text-field.label-text.populated.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Filled | Enabled | Filled text field label text populated size | md.comp.filled-text-field.label-text.populated.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Filled | Enabled | Filled text field label text size | md.comp.filled-text-field.label-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Filled | Enabled | Filled text field label text tracking | md.comp.filled-text-field.label-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Filled | Enabled | Filled text field label text type | md.comp.filled-text-field.label-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Filled | Enabled | Filled text field label text weight | md.comp.filled-text-field.label-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Filled | Enabled | Filled text field leading icon color | md.comp.filled-text-field.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field leading icon size | md.comp.filled-text-field.leading-icon.size |  | 24dp |  |
+| Text field - Filled | Enabled | Filled text field supporting text color | md.comp.filled-text-field.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field supporting text font | md.comp.filled-text-field.supporting-text.font | md.sys.typescale.body-small.font | Roboto |  |
+| Text field - Filled | Enabled | Filled text field supporting text line height | md.comp.filled-text-field.supporting-text.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Filled | Enabled | Filled text field supporting text size | md.comp.filled-text-field.supporting-text.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Filled | Enabled | Filled text field supporting text tracking | md.comp.filled-text-field.supporting-text.tracking | md.sys.typescale.body-small.tracking | 0.4pt |  |
+| Text field - Filled | Enabled | Filled text field supporting text type | md.comp.filled-text-field.supporting-text.type | md.sys.typescale.body-small.font | Roboto / 400 / 12pt / 0.4pt / 16pt |  |
+| Text field - Filled | Enabled | Filled text field supporting text weight | md.comp.filled-text-field.supporting-text.weight | md.sys.typescale.body-small.weight | 400 |  |
+| Text field - Filled | Enabled | Filled text field trailing icon color | md.comp.filled-text-field.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Filled | Enabled | Filled text field trailing icon size | md.comp.filled-text-field.trailing-icon.size |  | 24dp |  |
+
+### Text field - Outlined
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Text field - Outlined | Enabled | Outlined text field caret color | md.comp.outlined-text-field.caret.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Outlined | Layout | Outlined text field container height | md.comp.outlined-text-field.container.height |  | 56dp |  |
+| Text field - Outlined | Shape | Outlined text field container shape | md.comp.outlined-text-field.container.shape | md.sys.shape.corner.extra-small | 4dp | Resolved as rounded corners. |
+| Text field - Outlined | Disabled | Outlined text field disabled input text color | md.comp.outlined-text-field.disabled.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled input text opacity | md.comp.outlined-text-field.disabled.input-text.opacity |  | 0.38 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled label text color | md.comp.outlined-text-field.disabled.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled label text opacity | md.comp.outlined-text-field.disabled.label-text.opacity |  | 0.38 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled leading icon color | md.comp.outlined-text-field.disabled.leading-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled leading icon opacity | md.comp.outlined-text-field.disabled.leading-icon.opacity |  | 0.38 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled outline color | md.comp.outlined-text-field.disabled.outline.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled outline opacity | md.comp.outlined-text-field.disabled.outline.opacity |  | 0.12 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled outline width | md.comp.outlined-text-field.disabled.outline.width |  | 1dp |  |
+| Text field - Outlined | Disabled | Outlined text field disabled supporting text color | md.comp.outlined-text-field.disabled.supporting-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled supporting text opacity | md.comp.outlined-text-field.disabled.supporting-text.opacity |  | 0.38 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled trailing-icon color | md.comp.outlined-text-field.disabled.trailing-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Disabled | Outlined text field disabled trailing-icon opacity | md.comp.outlined-text-field.disabled.trailing-icon.opacity |  | 0.38 |  |
+| Text field - Outlined | Error / Focused | Outlined text field error focus caret color | md.comp.outlined-text-field.error.focus.caret.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error / Focused | Outlined text field focus indicator color - error | md.comp.outlined-text-field.error.focus.indicator.outline.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error / Focused | Outlined text field error focus input text color | md.comp.outlined-text-field.error.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Error / Focused | Outlined text field error focus label text color | md.comp.outlined-text-field.error.focus.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error / Focused | Outlined text field error focus leading icon color | md.comp.outlined-text-field.error.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Error / Focused | Outlined text field error focus outline color | md.comp.outlined-text-field.error.focus.outline.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error / Focused | Outlined text field error focus supporting text color | md.comp.outlined-text-field.error.focus.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error / Focused | Outlined text field error focus trailing icon color | md.comp.outlined-text-field.error.focus.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error / Hovered | Outlined text field error hover input text color | md.comp.outlined-text-field.error.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Error / Hovered | Outlined text field error hover label text color | md.comp.outlined-text-field.error.hover.label-text.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Outlined | Error / Hovered | Outlined text field error hover leading icon color | md.comp.outlined-text-field.error.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Error / Hovered | Outlined text field error hover outline color | md.comp.outlined-text-field.error.hover.outline.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Outlined | Error / Hovered | Outlined text field error hover supporting text color | md.comp.outlined-text-field.error.hover.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error / Hovered | Outlined text field error hover trailing icon color | md.comp.outlined-text-field.error.hover.trailing-icon.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Outlined | Error | Outlined text field error input text color | md.comp.outlined-text-field.error.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Error | Outlined text field error label text color | md.comp.outlined-text-field.error.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error | Outlined text field error leading icon color | md.comp.outlined-text-field.error.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Error | Outlined text field error outline color | md.comp.outlined-text-field.error.outline.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error | Outlined text field error supporting text color | md.comp.outlined-text-field.error.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Error | Outlined text field error trailing icon color | md.comp.outlined-text-field.error.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Outlined | Focused | Outlined text field focus indicator color | md.comp.outlined-text-field.focus.indicator.outline.color | md.sys.color.secondary | #625B71 |  |
+| Text field - Outlined | Focused | Outlined text field focus indicator thickness | md.comp.outlined-text-field.focus.indicator.outline.thickness | md.sys.state.focus-indicator.thickness | 3dp |  |
+| Text field - Outlined | Focused | Outlined text field focus input text color | md.comp.outlined-text-field.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Focused | Outlined text field focus label text color | md.comp.outlined-text-field.focus.label-text.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Outlined | Focused | Outlined text field focus leading icon color | md.comp.outlined-text-field.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Focused | Outlined text field focus outline color | md.comp.outlined-text-field.focus.outline.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Outlined | Focused | Outlined text field focus outline width | md.comp.outlined-text-field.focus.outline.width |  | 3dp |  |
+| Text field - Outlined | Focused | Outlined text field focus supporting text color | md.comp.outlined-text-field.focus.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Focused | Outlined text field focus trailing icon color | md.comp.outlined-text-field.focus.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Hovered | Outlined text field hover input text color | md.comp.outlined-text-field.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Hovered | Outlined text field hover label text color | md.comp.outlined-text-field.hover.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Hovered | Outlined text field hover leading icon color | md.comp.outlined-text-field.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Hovered | Outlined text field hover outline color | md.comp.outlined-text-field.hover.outline.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Hovered | Outlined text field hover outline width | md.comp.outlined-text-field.hover.outline.width |  | 1dp |  |
+| Text field - Outlined | Hovered | Outlined text field hover supporting text color | md.comp.outlined-text-field.hover.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Hovered | Outlined text field hover trailing icon color | md.comp.outlined-text-field.hover.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field input text color | md.comp.outlined-text-field.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Outlined | Enabled | Outlined text field input text font | md.comp.outlined-text-field.input-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Outlined | Enabled | Outlined text field input text line height | md.comp.outlined-text-field.input-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Outlined | Enabled | Outlined text field input text placeholder color | md.comp.outlined-text-field.input-text.placeholder.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field input text prefix color | md.comp.outlined-text-field.input-text.prefix.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field input text size | md.comp.outlined-text-field.input-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Outlined | Enabled | Outlined text field input text suffix color | md.comp.outlined-text-field.input-text.suffix.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field input text tracking | md.comp.outlined-text-field.input-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Outlined | Enabled | Outlined text field input text type | md.comp.outlined-text-field.input-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Outlined | Enabled | Outlined text field input text weight | md.comp.outlined-text-field.input-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Outlined | Enabled | Outlined text field label text color | md.comp.outlined-text-field.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field label text font | md.comp.outlined-text-field.label-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Outlined | Enabled | Outlined text field label text line height | md.comp.outlined-text-field.label-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Outlined | Enabled | Outlined text field label text populated line height | md.comp.outlined-text-field.label-text.populated.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Outlined | Enabled | Outlined text field label text populated size | md.comp.outlined-text-field.label-text.populated.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Outlined | Enabled | Outlined text field label text size | md.comp.outlined-text-field.label-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Outlined | Enabled | Outlined text field label text tracking | md.comp.outlined-text-field.label-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Outlined | Enabled | Outlined text field label text type | md.comp.outlined-text-field.label-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Outlined | Enabled | Outlined text field label text weight | md.comp.outlined-text-field.label-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Outlined | Enabled | Outlined text field leading icon color | md.comp.outlined-text-field.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field leading icon size | md.comp.outlined-text-field.leading-icon.size |  | 24dp |  |
+| Text field - Outlined | Enabled | Outlined text field outline color | md.comp.outlined-text-field.outline.color | md.sys.color.outline | #79747E |  |
+| Text field - Outlined | Layout | Outlined text field outline width | md.comp.outlined-text-field.outline.width |  | 1dp |  |
+| Text field - Outlined | Enabled | Outlined text field supporting text color | md.comp.outlined-text-field.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field supporting text font | md.comp.outlined-text-field.supporting-text.font | md.sys.typescale.body-small.font | Roboto |  |
+| Text field - Outlined | Enabled | Outlined text field supporting text line height | md.comp.outlined-text-field.supporting-text.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Outlined | Enabled | Outlined text field supporting text size | md.comp.outlined-text-field.supporting-text.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Outlined | Enabled | Outlined text field supporting text tracking | md.comp.outlined-text-field.supporting-text.tracking | md.sys.typescale.body-small.tracking | 0.4pt |  |
+| Text field - Outlined | Enabled | Outlined text field supporting text type | md.comp.outlined-text-field.supporting-text.type | md.sys.typescale.body-small.font | Roboto / 400 / 12pt / 0.4pt / 16pt |  |
+| Text field - Outlined | Enabled | Outlined text field supporting text weight | md.comp.outlined-text-field.supporting-text.weight | md.sys.typescale.body-small.weight | 400 |  |
+| Text field - Outlined | Enabled | Outlined text field trailing icon color | md.comp.outlined-text-field.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Outlined | Enabled | Outlined text field trailing icon size | md.comp.outlined-text-field.trailing-icon.size |  | 24dp |  |
+
+### Text field - Select, outlined
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Text field - Select, outlined | Enabled | Outlined select menu cascading menu indicator icon color | md.comp.outlined-select.menu.cascading-menu-indicator.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Layout | Outlined select menu cascading menu indicator icon size | md.comp.outlined-select.menu.cascading-menu-indicator.icon.size |  | 24dp |  |
+| Text field - Select, outlined | Enabled | Outlined select menu container color | md.comp.outlined-select.menu.container.color | md.sys.color.surface-container | #F3EDF7 |  |
+| Text field - Select, outlined | Enabled | Outlined select menu container elevation | md.comp.outlined-select.menu.container.elevation | md.sys.elevation.level2 | 3dp |  |
+| Text field - Select, outlined | Enabled | Outlined select menu container shadow color | md.comp.outlined-select.menu.container.shadow-color | md.sys.color.shadow | #000000 |  |
+| Text field - Select, outlined | Shape | Outlined select menu container shape | md.comp.outlined-select.menu.container.shape | md.sys.shape.corner.extra-small | 4dp | Resolved as rounded corners. |
+| Text field - Select, outlined | Enabled | Outlined select menu container surface tint layer color | md.comp.outlined-select.menu.container.surface-tint-layer.color | md.sys.color.surface-tint | #6750A4 |  |
+| Text field - Select, outlined | Enabled | Outlined select menu divider color | md.comp.outlined-select.menu.divider.color | md.sys.color.surface-variant | #E7E0EC |  |
+| Text field - Select, outlined | Enabled | Outlined select menu divider height | md.comp.outlined-select.menu.divider.height |  | 1dp |  |
+| Text field - Select, outlined | Layout | Outlined select menu list item container height | md.comp.outlined-select.menu.list-item.container.height |  | 48dp |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item label text color | md.comp.outlined-select.menu.list-item.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item label text font | md.comp.outlined-select.menu.list-item.label-text.font | md.sys.typescale.label-large.font | Roboto |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item label text line height | md.comp.outlined-select.menu.list-item.label-text.line-height | md.sys.typescale.label-large.line-height | 20pt |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item label text size | md.comp.outlined-select.menu.list-item.label-text.size | md.sys.typescale.label-large.size | 14pt |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item label text tracking | md.comp.outlined-select.menu.list-item.label-text.tracking | md.sys.typescale.label-large.tracking | 0.1pt |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item label text type style | md.comp.outlined-select.menu.list-item.label-text.type | md.sys.typescale.label-large.font | Roboto / 500 / 14pt / 0.1pt / 20pt |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item label text weight | md.comp.outlined-select.menu.list-item.label-text.weight | md.sys.typescale.label-large.weight | 700 |  |
+| Text field - Select, outlined | Enabled / Toggle selected | Outlined select menu list item selected container color | md.comp.outlined-select.menu.list-item.selected.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item with leading icon leading icon color | md.comp.outlined-select.menu.list-item.with-leading-icon.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item with leading icon leading icon size | md.comp.outlined-select.menu.list-item.with-leading-icon.leading-icon.size |  | 24dp |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item with trailing icon trailing icon color | md.comp.outlined-select.menu.list-item.with-trailing-icon.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Enabled | Outlined select menu list item with trailing icon trailing icon size | md.comp.outlined-select.menu.list-item.with-trailing-icon.trailing-icon.size |  | 24dp |  |
+| Text field - Select, outlined | Enabled | Outlined select text field caret color | md.comp.outlined-select.text-field.caret.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, outlined | Enabled | Outlined select text field container color | md.comp.outlined-select.text-field.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Select, outlined | Layout | Outlined select text field container height | md.comp.outlined-select.text-field.container.height |  | 56dp |  |
+| Text field - Select, outlined | Shape | Outlined select text field container shape | md.comp.outlined-select.text-field.container.shape | md.sys.shape.corner.extra-small | 4dp | Resolved as rounded corners. |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled input text color | md.comp.outlined-select.text-field.disabled.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled input text opacity | md.comp.outlined-select.text-field.disabled.input-text.opacity |  | 0.38 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled label text color | md.comp.outlined-select.text-field.disabled.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled label text opacity | md.comp.outlined-select.text-field.disabled.label-text.opacity |  | 0.38 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled leading icon color | md.comp.outlined-select.text-field.disabled.leading-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled leading icon opacity | md.comp.outlined-select.text-field.disabled.leading-icon.opacity |  | 0.38 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled outline color | md.comp.outlined-select.text-field.disabled.outline.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled outline opacity | md.comp.outlined-select.text-field.disabled.outline.opacity |  | 0.12 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled outline width | md.comp.outlined-select.text-field.disabled.outline.width |  | 1dp |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled supporting text color | md.comp.outlined-select.text-field.disabled.supporting-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled supporting text opacity | md.comp.outlined-select.text-field.disabled.supporting-text.opacity |  | 0.38 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled trailing icon color | md.comp.outlined-select.text-field.disabled.trailing-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Disabled | Outlined select text field disabled trailing icon opacity | md.comp.outlined-select.text-field.disabled.trailing-icon.opacity |  | 0.38 |  |
+| Text field - Select, outlined | Error / Focused | Outlined select text field error focus caret color | md.comp.outlined-select.text-field.error.focus.caret.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error / Focused | Outlined select text field error focus input text color | md.comp.outlined-select.text-field.error.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Error / Focused | Outlined select text field error focus label text color | md.comp.outlined-select.text-field.error.focus.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error / Focused | Outlined select text field error focus leading icon color | md.comp.outlined-select.text-field.error.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Error / Focused | Outlined select text field error focus outline color | md.comp.outlined-select.text-field.error.focus.outline.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error / Focused | Outlined select text field error focus supporting text color | md.comp.outlined-select.text-field.error.focus.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error / Focused | Outlined select text field error focus trailing icon color | md.comp.outlined-select.text-field.error.focus.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover input text color | md.comp.outlined-select.text-field.error.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover label text color | md.comp.outlined-select.text-field.error.hover.label-text.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover leading icon color | md.comp.outlined-select.text-field.error.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover outline color | md.comp.outlined-select.text-field.error.hover.outline.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover state layer color | md.comp.outlined-select.text-field.error.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover state layer opacity | md.comp.outlined-select.text-field.error.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover supporting text color | md.comp.outlined-select.text-field.error.hover.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error / Hovered | Outlined select text field error hover trailing icon color | md.comp.outlined-select.text-field.error.hover.trailing-icon.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Select, outlined | Error | Outlined select text field error input text color | md.comp.outlined-select.text-field.error.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Error | Outlined select text field error label text color | md.comp.outlined-select.text-field.error.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error | Outlined select text field error leading icon color | md.comp.outlined-select.text-field.error.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Error | Outlined select text field error outline color | md.comp.outlined-select.text-field.error.outline.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error | Outlined select text field error supporting text color | md.comp.outlined-select.text-field.error.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Error | Outlined select text field error trailing icon color | md.comp.outlined-select.text-field.error.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, outlined | Focused | Outlined select text field focus input text color | md.comp.outlined-select.text-field.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Focused | Outlined select text field focus label text color | md.comp.outlined-select.text-field.focus.label-text.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, outlined | Focused | Outlined select text field focus leading icon color | md.comp.outlined-select.text-field.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Focused | Outlined select text field focus outline color | md.comp.outlined-select.text-field.focus.outline.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, outlined | Focused | Outlined select text field focus outline width | md.comp.outlined-select.text-field.focus.outline.width | md.sys.state.focus-indicator.thickness | 3dp |  |
+| Text field - Select, outlined | Focused | Outlined select text field focus supporting text color | md.comp.outlined-select.text-field.focus.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Focused | Outlined select text field focus trailing icon color | md.comp.outlined-select.text-field.focus.trailing-icon.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover input text color | md.comp.outlined-select.text-field.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover label text color | md.comp.outlined-select.text-field.hover.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover leading icon color | md.comp.outlined-select.text-field.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover outline color | md.comp.outlined-select.text-field.hover.outline.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover outline width | md.comp.outlined-select.text-field.hover.outline.width |  | 1dp |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover state layer color | md.comp.outlined-select.text-field.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover state layer opacity | md.comp.outlined-select.text-field.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover supporting text color | md.comp.outlined-select.text-field.hover.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Hovered | Outlined select text field hover trailing icon color | md.comp.outlined-select.text-field.hover.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Enabled | Outlined select text field input text color | md.comp.outlined-select.text-field.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, outlined | Enabled | Outlined select text field input text font | md.comp.outlined-select.text-field.input-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Select, outlined | Enabled | Outlined select text field input text line height | md.comp.outlined-select.text-field.input-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field input text size | md.comp.outlined-select.text-field.input-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field input text tracking | md.comp.outlined-select.text-field.input-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field input text type style | md.comp.outlined-select.text-field.input-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field input text weight | md.comp.outlined-select.text-field.input-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text color | md.comp.outlined-select.text-field.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text font | md.comp.outlined-select.text-field.label-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text line height | md.comp.outlined-select.text-field.label-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text populated line height | md.comp.outlined-select.text-field.label-text.populated.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text populated size | md.comp.outlined-select.text-field.label-text.populated.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text size | md.comp.outlined-select.text-field.label-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text tracking | md.comp.outlined-select.text-field.label-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text type style | md.comp.outlined-select.text-field.label-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field label text weight | md.comp.outlined-select.text-field.label-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Select, outlined | Enabled | Outlined select text field leading icon color | md.comp.outlined-select.text-field.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Enabled | Outlined select text field leading icon size | md.comp.outlined-select.text-field.leading-icon.size |  | 24dp |  |
+| Text field - Select, outlined | Enabled | Outlined select text field outline color | md.comp.outlined-select.text-field.outline.color | md.sys.color.outline | #79747E |  |
+| Text field - Select, outlined | Layout | Outlined select text field outline width | md.comp.outlined-select.text-field.outline.width |  | 1dp |  |
+| Text field - Select, outlined | Enabled | Outlined select text field supporting text color | md.comp.outlined-select.text-field.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Enabled | Outlined select text field supporting text font | md.comp.outlined-select.text-field.supporting-text.font | md.sys.typescale.body-small.font | Roboto |  |
+| Text field - Select, outlined | Enabled | Outlined select text field supporting text line height | md.comp.outlined-select.text-field.supporting-text.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field supporting text size | md.comp.outlined-select.text-field.supporting-text.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field supporting text tracking | md.comp.outlined-select.text-field.supporting-text.tracking | md.sys.typescale.body-small.tracking | 0.4pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field supporting text type style | md.comp.outlined-select.text-field.supporting-text.type | md.sys.typescale.body-small.font | Roboto / 400 / 12pt / 0.4pt / 16pt |  |
+| Text field - Select, outlined | Enabled | Outlined select text field supporting text weight | md.comp.outlined-select.text-field.supporting-text.weight | md.sys.typescale.body-small.weight | 400 |  |
+| Text field - Select, outlined | Enabled | Outlined select text field trailing icon color | md.comp.outlined-select.text-field.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, outlined | Enabled | Outlined select text field trailing icon size | md.comp.outlined-select.text-field.trailing-icon.size |  | 24dp |  |
+
+### Text field - Select, filled
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Text field - Select, filled | Enabled | Filled select menu cascading menu indicator icon color | md.comp.filled-select.menu.cascading-menu-indicator.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Layout | Filled select menu cascading menu indicator icon size | md.comp.filled-select.menu.cascading-menu-indicator.icon.size |  | 24dp |  |
+| Text field - Select, filled | Enabled | Filled select menu container color | md.comp.filled-select.menu.container.color | md.sys.color.surface-container | #F3EDF7 |  |
+| Text field - Select, filled | Enabled | Filled select menu container elevation | md.comp.filled-select.menu.container.elevation | md.sys.elevation.level2 | 3dp |  |
+| Text field - Select, filled | Enabled | Filled select menu container shadow color | md.comp.filled-select.menu.container.shadow-color | md.sys.color.shadow | #000000 |  |
+| Text field - Select, filled | Shape | Filled select menu container shape | md.comp.filled-select.menu.container.shape | md.sys.shape.corner.extra-small | 4dp | Resolved as rounded corners. |
+| Text field - Select, filled | Enabled | Filled select menu container surface tint layer color | md.comp.filled-select.menu.container.surface-tint-layer.color | md.sys.color.surface-tint | #6750A4 |  |
+| Text field - Select, filled | Enabled | Filled select menu divider color | md.comp.filled-select.menu.divider.color | md.sys.color.surface-variant | #E7E0EC |  |
+| Text field - Select, filled | Enabled | Filled select menu divider height | md.comp.filled-select.menu.divider.height |  | 1dp |  |
+| Text field - Select, filled | Layout | Filled select menu list item container height | md.comp.filled-select.menu.list-item.container.height |  | 48dp |  |
+| Text field - Select, filled | Enabled | Filled select menu list item label text color | md.comp.filled-select.menu.list-item.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Enabled | Filled select menu list item label text font | md.comp.filled-select.menu.list-item.label-text.font | md.sys.typescale.label-large.font | Roboto |  |
+| Text field - Select, filled | Enabled | Filled select menu list item label text line height | md.comp.filled-select.menu.list-item.label-text.line-height | md.sys.typescale.label-large.line-height | 20pt |  |
+| Text field - Select, filled | Enabled | Filled select menu list item label text size | md.comp.filled-select.menu.list-item.label-text.size | md.sys.typescale.label-large.size | 14pt |  |
+| Text field - Select, filled | Enabled | Filled select menu list item label text tracking | md.comp.filled-select.menu.list-item.label-text.tracking | md.sys.typescale.label-large.tracking | 0.1pt |  |
+| Text field - Select, filled | Enabled | Filled select menu list item label text type style | md.comp.filled-select.menu.list-item.label-text.type | md.sys.typescale.label-large.font | Roboto / 500 / 14pt / 0.1pt / 20pt |  |
+| Text field - Select, filled | Enabled | Filled select menu list item label text weight | md.comp.filled-select.menu.list-item.label-text.weight | md.sys.typescale.label-large.weight | 700 |  |
+| Text field - Select, filled | Enabled / Toggle selected | Filled select menu list item selected container color | md.comp.filled-select.menu.list-item.selected.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Select, filled | Enabled | Filled select menu list item with leading icon leading icon color | md.comp.filled-select.menu.list-item.with-leading-icon.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select menu list item with leading icon leading icon size | md.comp.filled-select.menu.list-item.with-leading-icon.leading-icon.size |  | 24dp |  |
+| Text field - Select, filled | Enabled | Filled select menu list item with trailing icon trailing icon color | md.comp.filled-select.menu.list-item.with-trailing-icon.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select menu list item with trailing icon trailing icon size | md.comp.filled-select.menu.list-item.with-trailing-icon.trailing-icon.size |  | 24dp |  |
+| Text field - Select, filled | Enabled | Filled select text field active indicator color | md.comp.filled-select.text-field.active-indicator.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select text field active indicator height | md.comp.filled-select.text-field.active-indicator.height |  | 1dp |  |
+| Text field - Select, filled | Enabled | Filled select text field caret color | md.comp.filled-select.text-field.caret.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, filled | Enabled | Filled select text field container color | md.comp.filled-select.text-field.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Select, filled | Layout | Filled select text field container height | md.comp.filled-select.text-field.container.height |  | 56dp |  |
+| Text field - Select, filled | Shape | Filled select text field container shape | md.comp.filled-select.text-field.container.shape | md.sys.shape.corner.extra-small.top | Rounded Corners | Resolved as rounded corners. |
+| Text field - Select, filled | Disabled | Filled select text field disabled active indicator color | md.comp.filled-select.text-field.disabled.active-indicator.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled active indicator height | md.comp.filled-select.text-field.disabled.active-indicator.height |  | 1dp |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled active indicator opacity | md.comp.filled-select.text-field.disabled.active-indicator.opacity |  | 0.38 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled container color | md.comp.filled-select.text-field.disabled.container.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled container opacity | md.comp.filled-select.text-field.disabled.container.opacity |  | 0.04 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled input text color | md.comp.filled-select.text-field.disabled.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled input text opacity | md.comp.filled-select.text-field.disabled.input-text.opacity |  | 0.38 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled label text color | md.comp.filled-select.text-field.disabled.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled label text opacity | md.comp.filled-select.text-field.disabled.label-text.opacity |  | 0.38 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled leading icon color | md.comp.filled-select.text-field.disabled.leading-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled leading icon opacity | md.comp.filled-select.text-field.disabled.leading-icon.opacity |  | 0.38 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled supporting text color | md.comp.filled-select.text-field.disabled.supporting-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled supporting text opacity | md.comp.filled-select.text-field.disabled.supporting-text.opacity |  | 0.38 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled trailing icon color | md.comp.filled-select.text-field.disabled.trailing-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Disabled | Filled select text field disabled trailing icon opacity | md.comp.filled-select.text-field.disabled.trailing-icon.opacity |  | 0.38 |  |
+| Text field - Select, filled | Error | Filled select text field error active indicator color | md.comp.filled-select.text-field.error.active-indicator.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error / Focused | Filled select text field error focus active indicator color | md.comp.filled-select.text-field.error.focus.active-indicator.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error / Focused | Filled select text field error focus caret color | md.comp.filled-select.text-field.error.focus.caret.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error / Focused | Filled select text field error focus input text color | md.comp.filled-select.text-field.error.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Error / Focused | Filled select text field error focus label text color | md.comp.filled-select.text-field.error.focus.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error / Focused | Filled select text field error focus leading icon color | md.comp.filled-select.text-field.error.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Error / Focused | Filled select text field error focus supporting text color | md.comp.filled-select.text-field.error.focus.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error / Focused | Filled select text field error focus trailing icon color | md.comp.filled-select.text-field.error.focus.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover active indicator color | md.comp.filled-select.text-field.error.hover.active-indicator.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover input text color | md.comp.filled-select.text-field.error.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover label text color | md.comp.filled-select.text-field.error.hover.label-text.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover leading icon color | md.comp.filled-select.text-field.error.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover state layer color | md.comp.filled-select.text-field.error.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover state layer opacity | md.comp.filled-select.text-field.error.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover supporting text color | md.comp.filled-select.text-field.error.hover.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error / Hovered | Filled select text field error hover trailing icon color | md.comp.filled-select.text-field.error.hover.trailing-icon.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Select, filled | Error | Filled select text field error input text color | md.comp.filled-select.text-field.error.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Error | Filled select text field error label text color | md.comp.filled-select.text-field.error.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error | Filled select text field error leading icon color | md.comp.filled-select.text-field.error.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Error | Filled select text field error supporting text color | md.comp.filled-select.text-field.error.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Error | Filled select text field error trailing icon color | md.comp.filled-select.text-field.error.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Select, filled | Focused | Filled select text field focus active indicator color | md.comp.filled-select.text-field.focus.active-indicator.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, filled | Focused | Filled select text field focus active indicator height | md.comp.filled-select.text-field.focus.active-indicator.height |  | 2dp |  |
+| Text field - Select, filled | Focused | Filled select text field focus input text color | md.comp.filled-select.text-field.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Focused | Filled select text field focus label text color | md.comp.filled-select.text-field.focus.label-text.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, filled | Focused | Filled select text field focus leading icon color | md.comp.filled-select.text-field.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Focused | Filled select text field focus supporting text color | md.comp.filled-select.text-field.focus.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Focused | Filled select text field focus trailing icon color | md.comp.filled-select.text-field.focus.trailing-icon.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Select, filled | Hovered | Filled select text field hover active indicator color | md.comp.filled-select.text-field.hover.active-indicator.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Hovered | Filled select text field hover active indicator height | md.comp.filled-select.text-field.hover.active-indicator.height |  | 1dp |  |
+| Text field - Select, filled | Hovered | Filled select text field hover input text color | md.comp.filled-select.text-field.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Hovered | Filled select text field hover label text color | md.comp.filled-select.text-field.hover.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Hovered | Filled select text field hover leading icon color | md.comp.filled-select.text-field.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Hovered | Filled select text field hover state layer color | md.comp.filled-select.text-field.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Hovered | Filled select text field hover state layer opacity | md.comp.filled-select.text-field.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Select, filled | Hovered | Filled select text field hover supporting text color | md.comp.filled-select.text-field.hover.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Hovered | Filled select text field hover trailing icon color | md.comp.filled-select.text-field.hover.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select text field input text color | md.comp.filled-select.text-field.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Select, filled | Enabled | Filled select text field input text font | md.comp.filled-select.text-field.input-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Select, filled | Enabled | Filled select text field input text line height | md.comp.filled-select.text-field.input-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Select, filled | Enabled | Filled select text field input text size | md.comp.filled-select.text-field.input-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Select, filled | Enabled | Filled select text field input text tracking | md.comp.filled-select.text-field.input-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Select, filled | Enabled | Filled select text field input text type style | md.comp.filled-select.text-field.input-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Select, filled | Enabled | Filled select text field input text weight | md.comp.filled-select.text-field.input-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Select, filled | Enabled | Filled select text field label text color | md.comp.filled-select.text-field.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select text field label text font | md.comp.filled-select.text-field.label-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Select, filled | Enabled | Filled select text field label text line height | md.comp.filled-select.text-field.label-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Select, filled | Enabled | Filled select text field label text populated line height | md.comp.filled-select.text-field.label-text.populated.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Select, filled | Enabled | Filled select text field label text populated size | md.comp.filled-select.text-field.label-text.populated.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Select, filled | Enabled | Filled select text field label text size | md.comp.filled-select.text-field.label-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Select, filled | Enabled | Filled select text field label text tracking | md.comp.filled-select.text-field.label-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Select, filled | Enabled | Filled select text field label text type style | md.comp.filled-select.text-field.label-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Select, filled | Enabled | Filled select text field label text weight | md.comp.filled-select.text-field.label-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Select, filled | Enabled | Filled select text field leading icon color | md.comp.filled-select.text-field.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select text field leading icon size | md.comp.filled-select.text-field.leading-icon.size |  | 24dp |  |
+| Text field - Select, filled | Enabled | Filled select text field supporting text color | md.comp.filled-select.text-field.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select text field supporting text font | md.comp.filled-select.text-field.supporting-text.font | md.sys.typescale.body-small.font | Roboto |  |
+| Text field - Select, filled | Enabled | Filled select text field supporting text line height | md.comp.filled-select.text-field.supporting-text.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Select, filled | Enabled | Filled select text field supporting text size | md.comp.filled-select.text-field.supporting-text.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Select, filled | Enabled | Filled select text field supporting text tracking | md.comp.filled-select.text-field.supporting-text.tracking | md.sys.typescale.body-small.tracking | 0.4pt |  |
+| Text field - Select, filled | Enabled | Filled select text field supporting text type style | md.comp.filled-select.text-field.supporting-text.type | md.sys.typescale.body-small.font | Roboto / 400 / 12pt / 0.4pt / 16pt |  |
+| Text field - Select, filled | Enabled | Filled select text field supporting text weight | md.comp.filled-select.text-field.supporting-text.weight | md.sys.typescale.body-small.weight | 400 |  |
+| Text field - Select, filled | Enabled | Filled select text field trailing icon color | md.comp.filled-select.text-field.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Select, filled | Enabled | Filled select text field trailing icon size | md.comp.filled-select.text-field.trailing-icon.size |  | 24dp |  |
+
+### Text field - Autocomplete, filled
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu cascading menu indicator icon color | md.comp.filled-autocomplete.menu.cascading-menu-indicator.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Layout | Filled autocomplete menu cascading menu indicator icon size | md.comp.filled-autocomplete.menu.cascading-menu-indicator.icon.size |  | 24dp |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu container color | md.comp.filled-autocomplete.menu.container.color | md.sys.color.surface-container | #F3EDF7 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu container elevation | md.comp.filled-autocomplete.menu.container.elevation | md.sys.elevation.level2 | 3dp |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu container shadow color | md.comp.filled-autocomplete.menu.container.shadow-color | md.sys.color.shadow | #000000 |  |
+| Text field - Autocomplete, filled | Shape | Filled autocomplete menu container shape | md.comp.filled-autocomplete.menu.container.shape | md.sys.shape.corner.extra-small | 4dp | Resolved as rounded corners. |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu container surface tint layer color | md.comp.filled-autocomplete.menu.container.surface-tint-layer.color | md.sys.color.surface-tint | #6750A4 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu divider color | md.comp.filled-autocomplete.menu.divider.color | md.sys.color.surface-variant | #E7E0EC |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu divider height | md.comp.filled-autocomplete.menu.divider.height |  | 1dp |  |
+| Text field - Autocomplete, filled | Layout | Filled autocomplete menu list item container height | md.comp.filled-autocomplete.menu.list-item.container.height |  | 48dp |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu list item label text color | md.comp.filled-autocomplete.menu.list-item.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu list item label text font | md.comp.filled-autocomplete.menu.list-item.label-text.font | md.sys.typescale.label-large.font | Roboto |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu list item label text line height | md.comp.filled-autocomplete.menu.list-item.label-text.line-height | md.sys.typescale.label-large.line-height | 20pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu list item label text size | md.comp.filled-autocomplete.menu.list-item.label-text.size | md.sys.typescale.label-large.size | 14pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu list item label text tracking | md.comp.filled-autocomplete.menu.list-item.label-text.tracking | md.sys.typescale.label-large.tracking | 0.1pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu list item label text type style | md.comp.filled-autocomplete.menu.list-item.label-text.type | md.sys.typescale.label-large.font | Roboto / 500 / 14pt / 0.1pt / 20pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete menu list item label text weight | md.comp.filled-autocomplete.menu.list-item.label-text.weight | md.sys.typescale.label-large.weight | 700 |  |
+| Text field - Autocomplete, filled | Enabled / Toggle selected | Filled autocomplete menu list item selected container color | md.comp.filled-autocomplete.menu.list-item.selected.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field active indicator color | md.comp.filled-autocomplete.text-field.active-indicator.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field active indicator height | md.comp.filled-autocomplete.text-field.active-indicator.height |  | 1dp |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field caret color | md.comp.filled-autocomplete.text-field.caret.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field container color | md.comp.filled-autocomplete.text-field.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Autocomplete, filled | Layout | Filled autocomplete text field container height | md.comp.filled-autocomplete.text-field.container.height |  | 56dp |  |
+| Text field - Autocomplete, filled | Shape | Filled autocomplete text field container shape | md.comp.filled-autocomplete.text-field.container.shape | md.sys.shape.corner.extra-small.top | Rounded Corners | Resolved as rounded corners. |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled active indicator color | md.comp.filled-autocomplete.text-field.disabled.active-indicator.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled active indicator height | md.comp.filled-autocomplete.text-field.disabled.active-indicator.height |  | 1dp |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled active indicator opacity | md.comp.filled-autocomplete.text-field.disabled.active-indicator.opacity |  | 0.38 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled container color | md.comp.filled-autocomplete.text-field.disabled.container.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled container opacity | md.comp.filled-autocomplete.text-field.disabled.container.opacity |  | 0.04 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled input text color | md.comp.filled-autocomplete.text-field.disabled.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled input text opacity | md.comp.filled-autocomplete.text-field.disabled.input-text.opacity |  | 0.38 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled label text color | md.comp.filled-autocomplete.text-field.disabled.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled label text opacity | md.comp.filled-autocomplete.text-field.disabled.label-text.opacity |  | 0.38 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled leading icon color | md.comp.filled-autocomplete.text-field.disabled.leading-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled leading icon opacity | md.comp.filled-autocomplete.text-field.disabled.leading-icon.opacity |  | 0.38 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled supporting text color | md.comp.filled-autocomplete.text-field.disabled.supporting-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled supporting text opacity | md.comp.filled-autocomplete.text-field.disabled.supporting-text.opacity |  | 0.38 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled trailing icon color | md.comp.filled-autocomplete.text-field.disabled.trailing-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Disabled | Filled autocomplete text field disabled trailing icon opacity | md.comp.filled-autocomplete.text-field.disabled.trailing-icon.opacity |  | 0.38 |  |
+| Text field - Autocomplete, filled | Error | Filled autocomplete text field error active indicator color | md.comp.filled-autocomplete.text-field.error.active-indicator.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error / Focused | Filled autocomplete text field error focus active indicator color | md.comp.filled-autocomplete.text-field.error.focus.active-indicator.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error / Focused | error.Filled focus caret color | md.comp.filled-autocomplete.text-field.error.focus.caret.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error / Focused | Filled autocomplete text field error focus input text color | md.comp.filled-autocomplete.text-field.error.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Error / Focused | Filled autocomplete text field error focus label text color | md.comp.filled-autocomplete.text-field.error.focus.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error / Focused | Filled autocomplete text field error focus leading icon color | md.comp.filled-autocomplete.text-field.error.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Error / Focused | Filled autocomplete text field error focus supporting text color | md.comp.filled-autocomplete.text-field.error.focus.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error / Focused | Filled autocomplete text field error focus trailing icon color | md.comp.filled-autocomplete.text-field.error.focus.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover active indicator color | md.comp.filled-autocomplete.text-field.error.hover.active-indicator.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover input text color | md.comp.filled-autocomplete.text-field.error.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover label text color | md.comp.filled-autocomplete.text-field.error.hover.label-text.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover leading icon color | md.comp.filled-autocomplete.text-field.error.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover state layer color | md.comp.filled-autocomplete.text-field.error.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover state layer opacity | md.comp.filled-autocomplete.text-field.error.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover supporting text color | md.comp.filled-autocomplete.text-field.error.hover.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error / Hovered | Filled autocomplete text field error hover trailing icon color | md.comp.filled-autocomplete.text-field.error.hover.trailing-icon.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Autocomplete, filled | Error | Filled autocomplete text field error input text color | md.comp.filled-autocomplete.text-field.error.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Error | Filled autocomplete text field error label text color | md.comp.filled-autocomplete.text-field.error.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error | Filled autocomplete text field error leading icon color | md.comp.filled-autocomplete.text-field.error.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Error | Filled autocomplete text field error supporting text color | md.comp.filled-autocomplete.text-field.error.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Error | Filled autocomplete text field error trailing icon color | md.comp.filled-autocomplete.text-field.error.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, filled | Focused | Filled autocomplete text field focus active indicator color | md.comp.filled-autocomplete.text-field.focus.active-indicator.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Autocomplete, filled | Focused | Filled autocomplete text field focus active indicator height | md.comp.filled-autocomplete.text-field.focus.active-indicator.height |  | 2dp |  |
+| Text field - Autocomplete, filled | Focused | Filled autocomplete text field focus input text color | md.comp.filled-autocomplete.text-field.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Focused | Filled autocomplete text field focus label text color | md.comp.filled-autocomplete.text-field.focus.label-text.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Autocomplete, filled | Focused | Filled autocomplete text field focus leading icon color | md.comp.filled-autocomplete.text-field.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Focused | Filled autocomplete text field focus supporting text color | md.comp.filled-autocomplete.text-field.focus.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Focused | Filled autocomplete text field focus trailing icon color | md.comp.filled-autocomplete.text-field.focus.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover active indicator color | md.comp.filled-autocomplete.text-field.hover.active-indicator.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover active indicator height | md.comp.filled-autocomplete.text-field.hover.active-indicator.height |  | 1dp |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover input text color | md.comp.filled-autocomplete.text-field.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover label text color | md.comp.filled-autocomplete.text-field.hover.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover leading icon color | md.comp.filled-autocomplete.text-field.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover state layer color | md.comp.filled-autocomplete.text-field.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover state layer opacity | md.comp.filled-autocomplete.text-field.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover supporting text color | md.comp.filled-autocomplete.text-field.hover.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Hovered | Filled autocomplete text field hover trailing icon color | md.comp.filled-autocomplete.text-field.hover.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field input text color | md.comp.filled-autocomplete.text-field.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field input text font | md.comp.filled-autocomplete.text-field.input-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field input text line height | md.comp.filled-autocomplete.text-field.input-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field input text size | md.comp.filled-autocomplete.text-field.input-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field input text tracking | md.comp.filled-autocomplete.text-field.input-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field input text type styl | md.comp.filled-autocomplete.text-field.input-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field input text weight | md.comp.filled-autocomplete.text-field.input-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text color | md.comp.filled-autocomplete.text-field.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text font | md.comp.filled-autocomplete.text-field.label-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text line height | md.comp.filled-autocomplete.text-field.label-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text populated line height | md.comp.filled-autocomplete.text-field.label-text.populated.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text populated size | md.comp.filled-autocomplete.text-field.label-text.populated.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text size | md.comp.filled-autocomplete.text-field.label-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text tracking | md.comp.filled-autocomplete.text-field.label-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text type style | md.comp.filled-autocomplete.text-field.label-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field label text weight | md.comp.filled-autocomplete.text-field.label-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field leading icon color | md.comp.filled-autocomplete.text-field.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field leading icon size | md.comp.filled-autocomplete.text-field.leading-icon.size |  | 20dp |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field supporting text color | md.comp.filled-autocomplete.text-field.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field supporting text font | md.comp.filled-autocomplete.text-field.supporting-text.font | md.sys.typescale.body-small.font | Roboto |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field supporting text line height | md.comp.filled-autocomplete.text-field.supporting-text.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field supporting text size | md.comp.filled-autocomplete.text-field.supporting-text.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field supporting text tracking | md.comp.filled-autocomplete.text-field.supporting-text.tracking | md.sys.typescale.body-small.tracking | 0.4pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field supporting text type style | md.comp.filled-autocomplete.text-field.supporting-text.type | md.sys.typescale.body-small.font | Roboto / 400 / 12pt / 0.4pt / 16pt |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field supporting text weight | md.comp.filled-autocomplete.text-field.supporting-text.weight | md.sys.typescale.body-small.weight | 400 |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field trailing icon color | md.comp.filled-autocomplete.text-field.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, filled | Enabled | Filled autocomplete text field trailing icon size | md.comp.filled-autocomplete.text-field.trailing-icon.size |  | 24dp |  |
+
+### Text field - Autocomplete, outlined
+
+| Token Set | Group | Label | Token | Source token | Value | Notes |
+|---|---|---|---|---|---|---|
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu cascading menu indicator icon color | md.comp.outlined-autocomplete.menu.cascading-menu-indicator.icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Layout | Outlined autocomplete menu cascading menu indicator icon size | md.comp.outlined-autocomplete.menu.cascading-menu-indicator.icon.size |  | 24dp |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu container color | md.comp.outlined-autocomplete.menu.container.color | md.sys.color.surface-container | #F3EDF7 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu container elevation | md.comp.outlined-autocomplete.menu.container.elevation | md.sys.elevation.level2 | 3dp |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu container shadow color | md.comp.outlined-autocomplete.menu.container.shadow-color | md.sys.color.shadow | #000000 |  |
+| Text field - Autocomplete, outlined | Shape | Outlined autocomplete menu container shape | md.comp.outlined-autocomplete.menu.container.shape | md.sys.shape.corner.extra-small | 4dp | Resolved as rounded corners. |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu container surface tint layer color | md.comp.outlined-autocomplete.menu.container.surface-tint-layer.color | md.sys.color.surface-tint | #6750A4 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu divider color | md.comp.outlined-autocomplete.menu.divider.color | md.sys.color.surface-variant | #E7E0EC |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu divider height | md.comp.outlined-autocomplete.menu.divider.height |  | 1dp |  |
+| Text field - Autocomplete, outlined | Layout | Outlined autocomplete menu list item container height | md.comp.outlined-autocomplete.menu.list-item.container.height |  | 48dp |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu list item label text color | md.comp.outlined-autocomplete.menu.list-item.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu list item label text font | md.comp.outlined-autocomplete.menu.list-item.label-text.font | md.sys.typescale.label-large.font | Roboto |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu list item label text line height | md.comp.outlined-autocomplete.menu.list-item.label-text.line-height | md.sys.typescale.label-large.line-height | 20pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu list item label text size | md.comp.outlined-autocomplete.menu.list-item.label-text.size | md.sys.typescale.label-large.size | 14pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu list item label text tracking | md.comp.outlined-autocomplete.menu.list-item.label-text.tracking | md.sys.typescale.label-large.tracking | 0.1pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu list item label text type style | md.comp.outlined-autocomplete.menu.list-item.label-text.type | md.sys.typescale.label-large.font | Roboto / 500 / 14pt / 0.1pt / 20pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete menu list item label text weight | md.comp.outlined-autocomplete.menu.list-item.label-text.weight | md.sys.typescale.label-large.weight | 700 |  |
+| Text field - Autocomplete, outlined | Enabled / Toggle selected | Outlined autocomplete menu list item selected container color | md.comp.outlined-autocomplete.menu.list-item.selected.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field caret color | md.comp.outlined-autocomplete.text-field.caret.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field container color | md.comp.outlined-autocomplete.text-field.container.color | md.sys.color.surface-container-highest | #E6E0E9 |  |
+| Text field - Autocomplete, outlined | Layout | Outlined autocomplete text field container height | md.comp.outlined-autocomplete.text-field.container.height |  | 56dp |  |
+| Text field - Autocomplete, outlined | Shape | Outlined autocomplete text field container shape | md.comp.outlined-autocomplete.text-field.container.shape | md.sys.shape.corner.extra-small | 4dp | Resolved as rounded corners. |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled input text color | md.comp.outlined-autocomplete.text-field.disabled.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled input text opacity | md.comp.outlined-autocomplete.text-field.disabled.input-text.opacity |  | 0.38 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled label text color | md.comp.outlined-autocomplete.text-field.disabled.label-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled label text opacity | md.comp.outlined-autocomplete.text-field.disabled.label-text.opacity |  | 0.38 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled leading icon color | md.comp.outlined-autocomplete.text-field.disabled.leading-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled leading icon opacity | md.comp.outlined-autocomplete.text-field.disabled.leading-icon.opacity |  | 0.38 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled outline color | md.comp.outlined-autocomplete.text-field.disabled.outline.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled outline opacity | md.comp.outlined-autocomplete.text-field.disabled.outline.opacity |  | 0.12 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled outline width | md.comp.outlined-autocomplete.text-field.disabled.outline.width |  | 1dp |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled supporting text color | md.comp.outlined-autocomplete.text-field.disabled.supporting-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled supporting text opacity | md.comp.outlined-autocomplete.text-field.disabled.supporting-text.opacity |  | 0.38 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled trailing icon color | md.comp.outlined-autocomplete.text-field.disabled.trailing-icon.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Disabled | Outlined autocomplete text field disabled trailing icon opacity | md.comp.outlined-autocomplete.text-field.disabled.trailing-icon.opacity |  | 0.38 |  |
+| Text field - Autocomplete, outlined | Error / Focused | Outlined autocomplete text field error focus caret color | md.comp.outlined-autocomplete.text-field.error.focus.caret.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error / Focused | Outlined autocomplete text field error focus input text color | md.comp.outlined-autocomplete.text-field.error.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Error / Focused | Outlined autocomplete text field error focus label text color | md.comp.outlined-autocomplete.text-field.error.focus.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error / Focused | Outlined autocomplete text field error focus leading icon color | md.comp.outlined-autocomplete.text-field.error.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Error / Focused | Outlined autocomplete text field error focus outline color | md.comp.outlined-autocomplete.text-field.error.focus.outline.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error / Focused | Outlined autocomplete text field error focus supporting text color | md.comp.outlined-autocomplete.text-field.error.focus.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error / Focused | Outlinedfield error focus trailing icon color | md.comp.outlined-autocomplete.text-field.error.focus.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover input text color | md.comp.outlined-autocomplete.text-field.error.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover label text color | md.comp.outlined-autocomplete.text-field.error.hover.label-text.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover leading icon color | md.comp.outlined-autocomplete.text-field.error.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover outline color | md.comp.outlined-autocomplete.text-field.error.hover.outline.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover state layer color | md.comp.outlined-autocomplete.text-field.error.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover state layer opacity | md.comp.outlined-autocomplete.text-field.error.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover supporting text color | md.comp.outlined-autocomplete.text-field.error.hover.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error / Hovered | Outlined autocomplete text field error hover trailing icon color | md.comp.outlined-autocomplete.text-field.error.hover.trailing-icon.color | md.sys.color.on-error-container | #8C1D18 |  |
+| Text field - Autocomplete, outlined | Error | Outlined autocomplete text field error input text color | md.comp.outlined-autocomplete.text-field.error.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Error | Outlined autocomplete text field error label text color | md.comp.outlined-autocomplete.text-field.error.label-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error | Outlined autocomplete text field error leading icon color | md.comp.outlined-autocomplete.text-field.error.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Error | text field error outline color | md.comp.outlined-autocomplete.text-field.error.outline.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error | Outlined autocomplete text field error supporting text color | md.comp.outlined-autocomplete.text-field.error.supporting-text.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Error | Outlined autocomplete text field error trailing icon color | md.comp.outlined-autocomplete.text-field.error.trailing-icon.color | md.sys.color.error | #B3261E |  |
+| Text field - Autocomplete, outlined | Focused | Outlined autocomplete text field focus input text color | md.comp.outlined-autocomplete.text-field.focus.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Focused | Outlined autocomplete text field focus label text color | md.comp.outlined-autocomplete.text-field.focus.label-text.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Autocomplete, outlined | Focused | Outlined autocomplete text field focus leading icon color | md.comp.outlined-autocomplete.text-field.focus.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Focused | Outlined autocomplete text field focus outline color | md.comp.outlined-autocomplete.text-field.focus.outline.color | md.sys.color.primary | #6750A4 |  |
+| Text field - Autocomplete, outlined | Focused | Outlined autocomplete text field focus outline width | md.comp.outlined-autocomplete.text-field.focus.outline.width |  | 2dp |  |
+| Text field - Autocomplete, outlined | Focused | Outlined autocomplete text field focus supporting text color | md.comp.outlined-autocomplete.text-field.focus.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Focused | Outlined autocomplete text field focus trailing icon color | md.comp.outlined-autocomplete.text-field.focus.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover input text color | md.comp.outlined-autocomplete.text-field.hover.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover label text color | md.comp.outlined-autocomplete.text-field.hover.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover leading icon color | md.comp.outlined-autocomplete.text-field.hover.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover outline color | md.comp.outlined-autocomplete.text-field.hover.outline.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover outline width | md.comp.outlined-autocomplete.text-field.hover.outline.width |  | 1dp |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover state layer color | md.comp.outlined-autocomplete.text-field.hover.state-layer.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover state layer opacity | md.comp.outlined-autocomplete.text-field.hover.state-layer.opacity | md.sys.state.hover.state-layer-opacity | 0.08 |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover supporting text color | md.comp.outlined-autocomplete.text-field.hover.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Hovered | Outlined autocomplete text field hover trailing icon color | md.comp.outlined-autocomplete.text-field.hover.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field input text color | md.comp.outlined-autocomplete.text-field.input-text.color | md.sys.color.on-surface | #1D1B20 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field input text font | md.comp.outlined-autocomplete.text-field.input-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field input text line height | md.comp.outlined-autocomplete.text-field.input-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field input text size | md.comp.outlined-autocomplete.text-field.input-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field input text tracking | md.comp.outlined-autocomplete.text-field.input-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field input text type style | md.comp.outlined-autocomplete.text-field.input-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field input text weight | md.comp.outlined-autocomplete.text-field.input-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text color | md.comp.outlined-autocomplete.text-field.label-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text font | md.comp.outlined-autocomplete.text-field.label-text.font | md.sys.typescale.body-large.font | Roboto |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text line height | md.comp.outlined-autocomplete.text-field.label-text.line-height | md.sys.typescale.body-large.line-height | 24pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text populated line height | md.comp.outlined-autocomplete.text-field.label-text.populated.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text populated size | md.comp.outlined-autocomplete.text-field.label-text.populated.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text size | md.comp.outlined-autocomplete.text-field.label-text.size | md.sys.typescale.body-large.size | 16pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text tracking | md.comp.outlined-autocomplete.text-field.label-text.tracking | md.sys.typescale.body-large.tracking | 0.5pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text type style | md.comp.outlined-autocomplete.text-field.label-text.type | md.sys.typescale.body-large.font | Roboto / 400 / 16pt / 0.5pt / 24pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field label text weight | md.comp.outlined-autocomplete.text-field.label-text.weight | md.sys.typescale.body-large.weight | 400 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field leading icon color | md.comp.outlined-autocomplete.text-field.leading-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field leading icon size | md.comp.outlined-autocomplete.text-field.leading-icon.size |  | 24dp |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field outline color | md.comp.outlined-autocomplete.text-field.outline.color | md.sys.color.outline | #79747E |  |
+| Text field - Autocomplete, outlined | Layout | Outlined autocomplete text field outline width | md.comp.outlined-autocomplete.text-field.outline.width |  | 1dp |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field supporting text color | md.comp.outlined-autocomplete.text-field.supporting-text.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field supporting text font | md.comp.outlined-autocomplete.text-field.supporting-text.font | md.sys.typescale.body-small.font | Roboto |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field supporting text line height | md.comp.outlined-autocomplete.text-field.supporting-text.line-height | md.sys.typescale.body-small.line-height | 16pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field supporting text size | md.comp.outlined-autocomplete.text-field.supporting-text.size | md.sys.typescale.body-small.size | 12pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field supporting text tracking | md.comp.outlined-autocomplete.text-field.supporting-text.tracking | md.sys.typescale.body-small.tracking | 0.4pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field supporting text type style | md.comp.outlined-autocomplete.text-field.supporting-text.type | md.sys.typescale.body-small.font | Roboto / 400 / 12pt / 0.4pt / 16pt |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field supporting text weight | md.comp.outlined-autocomplete.text-field.supporting-text.weight | md.sys.typescale.body-small.weight | 400 |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field trailing icon color | md.comp.outlined-autocomplete.text-field.trailing-icon.color | md.sys.color.on-surface-variant | #49454F |  |
+| Text field - Autocomplete, outlined | Enabled | Outlined autocomplete text field trailing icon size | md.comp.outlined-autocomplete.text-field.trailing-icon.size |  | 24dp |  |

--- a/src/nuiitivet/material/styles/text_field_style.py
+++ b/src/nuiitivet/material/styles/text_field_style.py
@@ -77,6 +77,7 @@ class TextFieldStyle:
             mode="outlined",
             container_color=(0, 0, 0, 0),  # Transparent
             indicator_color=ColorRole.OUTLINE,
+            focused_indicator_width=3.0,  # MD3: focused outline width = 3dp
             border_radius=4.0,
             content_padding=(16, 16, 16, 16),
         )

--- a/src/nuiitivet/material/text_fields.py
+++ b/src/nuiitivet/material/text_fields.py
@@ -17,7 +17,15 @@ from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.widgets.interaction import FocusNode
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
-from nuiitivet.rendering.skia import draw_round_rect, make_font, make_paint, make_rect, make_text_blob, get_typeface
+from nuiitivet.rendering.skia import (
+    draw_round_rect,
+    get_skia,
+    make_font,
+    make_paint,
+    make_rect,
+    make_text_blob,
+    get_typeface,
+)
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.theme.manager import manager as theme_manager
 from nuiitivet.widgets.editable_text import EditableText
@@ -542,6 +550,17 @@ class TextField(InteractiveWidget):
 
         pl, pt, pr, pb = style.content_padding
 
+        # When the floating label is shown inside the container (filled mode),
+        # reserve a 16dp band at the top for the populated label text. This
+        # matches MD3 spec: container 56dp = 8 (top) + 16 (floating label) + 24
+        # (input text) + 8 (bottom). The rest-state (large) label still uses
+        # the full content area; this offset only affects the input text and
+        # populated label position.
+        self._label_band = 0
+        if self.label and style.mode == "filled":
+            self._label_band = 16
+            pt = pt + self._label_band
+
         # Leading Icon
         leading_w = 0
         if self.leading_icon:
@@ -694,7 +713,7 @@ class TextField(InteractiveWidget):
             text_x, text_y, _, text_h = cx, cy, cw, ch
             error_h = 0
 
-        self._draw_container(canvas, cx, cy, cw, ch)
+        self._draw_container(canvas, cx, cy, cw, ch, text_x_abs=text_x)
 
         if not self.disabled:
             self.draw_state_layer(canvas, cx, cy, cw, ch)
@@ -718,7 +737,7 @@ class TextField(InteractiveWidget):
         self._editable.set_last_rect(cx, cy, w, h)
         self._editable.paint(canvas, cx, cy, w, h)
 
-    def _draw_container(self, canvas, cx, cy, cw, ch):
+    def _draw_container(self, canvas, cx, cy, cw, ch, *, text_x_abs: int | None = None):
         style = self.style
 
         container_color = resolve_color_to_rgba(style.container_color, theme=theme_manager.current)
@@ -739,8 +758,84 @@ class TextField(InteractiveWidget):
         if rect is not None and paint_container is not None:
             draw_round_rect(canvas, rect, style.border_radius, paint_container)
         paint_border = make_paint(color=indicator_color, style="stroke", stroke_width=indicator_width)
-        if rect is not None and paint_border is not None:
-            draw_round_rect(canvas, rect, style.border_radius, paint_border)
+        if paint_border is None:
+            return
+
+        notch = self._compute_outline_notch(cx, cw, text_x_abs) if text_x_abs is not None else None
+        if notch is None:
+            if rect is not None:
+                draw_round_rect(canvas, rect, style.border_radius, paint_border)
+            return
+
+        path = self._build_outlined_notched_path(cx, cy, cw, ch, style.border_radius, notch)
+        if path is None:
+            if rect is not None:
+                draw_round_rect(canvas, rect, style.border_radius, paint_border)
+            return
+        canvas.drawPath(path, paint_border)
+
+    def _compute_outline_notch(self, cx: int, cw: int, text_x_abs: int) -> Optional[Tuple[float, float]]:
+        """Compute the outline notch range (absolute x) for the floating label.
+
+        Returns None when no notch should be drawn (no label, rest state, or
+        the resulting gap would be smaller than the corner radii).
+        """
+        if not self.label:
+            return None
+        progress = self._label_progress.value
+        if progress <= 0.0:
+            return None
+        font = self._get_font()
+        if font is None:
+            return None
+        font.setSize(12)
+        label_w = font.measureText(self.label)
+        if label_w <= 0:
+            return None
+        gap_pad = 4.0
+        full_w = label_w + gap_pad * 2
+        animated_w = full_w * progress
+        center_x = text_x_abs + label_w / 2
+        notch_left = center_x - animated_w / 2
+        notch_right = center_x + animated_w / 2
+        # Clamp inside corner radii so we don't cut into the rounded corners.
+        r = self.style.border_radius
+        min_x = cx + r + 1
+        max_x = cx + cw - r - 1
+        notch_left = max(min_x, notch_left)
+        notch_right = min(max_x, notch_right)
+        if notch_right - notch_left < 2:
+            return None
+        return (notch_left, notch_right)
+
+    def _build_outlined_notched_path(
+        self, cx: int, cy: int, cw: int, ch: int, r: float, notch: Tuple[float, float]
+    ) -> Optional[Any]:
+        """Build a Skia Path of the outlined border with a top-edge notch."""
+        skia = get_skia()
+        if skia is None:
+            return None
+        notch_left, notch_right = notch
+        d = 2 * r
+        path = skia.Path()
+        # Top edge starts after the top-left corner arc.
+        path.moveTo(cx + r, cy)
+        path.lineTo(notch_left, cy)
+        # Skip the notch.
+        path.moveTo(notch_right, cy)
+        path.lineTo(cx + cw - r, cy)
+        # Top-right corner.
+        path.arcTo(skia.Rect.MakeXYWH(cx + cw - d, cy, d, d), 270, 90, False)
+        path.lineTo(cx + cw, cy + ch - r)
+        # Bottom-right corner.
+        path.arcTo(skia.Rect.MakeXYWH(cx + cw - d, cy + ch - d, d, d), 0, 90, False)
+        path.lineTo(cx + r, cy + ch)
+        # Bottom-left corner.
+        path.arcTo(skia.Rect.MakeXYWH(cx, cy + ch - d, d, d), 90, 90, False)
+        path.lineTo(cx, cy + r)
+        # Top-left corner.
+        path.arcTo(skia.Rect.MakeXYWH(cx, cy, d, d), 180, 90, False)
+        return path
 
     def _draw_label(self, canvas, text_x, text_y, text_h, cy):
         if not self.label:
@@ -758,8 +853,20 @@ class TextField(InteractiveWidget):
             label_metrics = label_font.getMetrics()
             label_h = -label_metrics.fAscent + label_metrics.fDescent
 
-            start_y = text_y + (text_h + label_h) / 2 - label_metrics.fDescent
-            end_y = cy + 8 + label_h
+            # Rest-state label is vertically centered in the full inner area
+            # (i.e. as if the floating-label band were not reserved).
+            band = getattr(self, "_label_band", 0)
+            rest_text_y = text_y - band
+            rest_text_h = text_h + band
+            start_y = rest_text_y + (rest_text_h + label_h) / 2 - label_metrics.fDescent
+            style = self.style
+            if style.mode == "outlined":
+                # MD3 outlined: floating label is centered on the top outline,
+                # i.e. visually overlaps the border line.
+                end_y = cy - (label_metrics.fAscent + label_metrics.fDescent) / 2
+            else:
+                # MD3 filled: floating label sits in the cy+8..cy+24 band.
+                end_y = cy + 8 + (-label_metrics.fAscent)
 
             current_label_y = start_y - (start_y - end_y) * label_progress
 


### PR DESCRIPTION
## Summary

Aligns the `TextField` (filled / outlined) layout with the MD3 spec collected in [docs/md3/text_fields.md](docs/md3/text_fields.md). The floating label no longer overlaps the input text in filled mode, the populated label of outlined mode now sits on the top outline, and the outlined border is notched around the label.

Closes #117

## Changes

### Filled
- Reserve a **16dp floating-label band** when `label` is set so input text no longer overlaps the label (`pt = pt + 16` in `layout()`).
- Keep the **rest-state label centered** in the full inner area; animate to the floating band via `_label_progress` (`_draw_label` uses `_label_band` to compute rest geometry).
- Position the populated label baseline using `-fAscent` so the glyph top aligns with `cy + 8` (band: `cy+8..cy+24`).

### Outlined
- Place the populated label so it is **vertically centered on the top outline** (`end_y = cy - (fAscent + fDescent) / 2`).
- Set focused outline width to **3dp** per `md.comp.outlined-text-field.focus.outline.width`.
- Draw a **notched outline** by building a Skia `Path` that skips the label region on the top edge. Notch width is animated via `_label_progress` and clamped within the corner radii.

## Verification

- [docs/md3/text_fields.md](docs/md3/text_fields.md) (collected MD3 spec / tokens) used as reference.
- `uv run pytest` → 1175 passed
- `uv run mypy` / `uv run flake8` → clean
- Manual visual check via [src/samples/text_field_demo.py](src/samples/text_field_demo.py)

## Out of scope

- Disabled-state token-level opacity (label / container / outline) verification.
- Select / Autocomplete variants.
