### PR TITLE
feat(sheet): auto-wire close button via OverlayAware

### DIFF
--- a/src/nuiitivet/material/sheet.py
+++ b/src/nuiitivet/material/sheet.py
@@ -13,13 +13,14 @@ from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.overlay import OverlayAware
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.widgets.box import Box
 
 _logger = logging.getLogger(__name__)
 
 
-class SideSheet(ComposableWidget):
+class SideSheet(ComposableWidget, OverlayAware[None]):
     """Modal side sheet container widget.
 
     Renders an M3-compliant header (optional Back button, Headline, Close button) above
@@ -46,6 +47,9 @@ class SideSheet(ComposableWidget):
             (e.g. driven by in-sheet navigation state). Defaults to ``False``.
             The button is only rendered when this is truthy **and** *on_back* is
             not ``None``.
+        on_close: Callback invoked when the Close icon button is pressed.
+            If ``None`` and the sheet is shown via an ``Overlay`` API, the
+            button automatically calls ``self.overlay_handle.close(None)``.
         style: Container style. Defaults to :class:`SideSheetStyle`.
     """
 
@@ -70,7 +74,10 @@ class SideSheet(ComposableWidget):
             show_back_button: Back button visibility (bool or Observable[bool]).
                 Defaults to ``False``. Rendered only when truthy **and** *on_back*
                 is not ``None``.
-            on_close: Callback for the Close icon button press.
+            on_close: Callback for the Close icon button press. When ``None``
+                and the sheet is shown via an ``Overlay`` API, the button
+                automatically closes the sheet through the injected
+                :class:`OverlayHandle`.
             style: Container style. Defaults to :class:`SideSheetStyle`.
         """
         _style = style if style is not None else SideSheetStyle()
@@ -92,6 +99,14 @@ class SideSheet(ComposableWidget):
         if isinstance(self._show_back_button, ReadOnlyObservableProtocol):
             return bool(self._show_back_button.value)
         return bool(self._show_back_button)
+
+    def _resolve_on_close(self) -> Optional[Callable[[], None]]:
+        """Pick the close handler: explicit ``on_close`` > injected overlay handle."""
+        if self._on_close is not None:
+            return self._on_close
+        if self._overlay_handle is not None:
+            return lambda: self.overlay_handle.close(None)
+        return None
 
     def on_mount(self) -> None:
         """Mount and subscribe to show_back_button observable if provided."""
@@ -126,8 +141,7 @@ class SideSheet(ComposableWidget):
                     width="100%",
                     padding=(8, 0, 8, 0),
                 ),
-                # TODO(#38): when IOverlayAware is available, wire None → handle.close()
-                IconButton("close", on_click=self._on_close),
+                IconButton("close", on_click=self._resolve_on_close()),
             ],
             width="100%",
             height=72,
@@ -155,7 +169,7 @@ class SideSheet(ComposableWidget):
         )
 
 
-class BottomSheet(ComposableWidget):
+class BottomSheet(ComposableWidget, OverlayAware[None]):
     """Modal bottom sheet container widget.
 
     Renders an M3-compliant header (Headline, Close button) above *content*.
@@ -169,8 +183,8 @@ class BottomSheet(ComposableWidget):
         content: Widget to display below the header.
         headline: Header title text (str or Observable[str]). Required by M3.
         on_close: Callback invoked when the Close icon button is pressed.
-            If ``None``, the button will trigger ``IOverlayAware.close()``
-            automatically once Issue #38 is resolved.
+            If ``None`` and the sheet is shown via an ``Overlay`` API, the
+            button automatically calls ``self.overlay_handle.close(None)``.
         style: Container size, background, and shape options.
             Defaults to :class:`BottomSheetStyle`.
     """
@@ -188,7 +202,10 @@ class BottomSheet(ComposableWidget):
         Args:
             content: Widget to display below the header.
             headline: Header title text (str or Observable[str]).
-            on_close: Callback for the Close icon button press.
+            on_close: Callback for the Close icon button press. When ``None``
+                and the sheet is shown via an ``Overlay`` API, the button
+                automatically closes the sheet through the injected
+                :class:`OverlayHandle`.
             style: Container style. Defaults to :class:`BottomSheetStyle`.
         """
         _style = style if style is not None else BottomSheetStyle()
@@ -202,6 +219,14 @@ class BottomSheet(ComposableWidget):
     def style(self) -> BottomSheetStyle:
         """Return resolved sheet style."""
         return self._user_style if self._user_style is not None else BottomSheetStyle()
+
+    def _resolve_on_close(self) -> Optional[Callable[[], None]]:
+        """Pick the close handler: explicit ``on_close`` > injected overlay handle."""
+        if self._on_close is not None:
+            return self._on_close
+        if self._overlay_handle is not None:
+            return lambda: self.overlay_handle.close(None)
+        return None
 
     def build(self) -> Widget:
         """Build the sheet: outer Box with header Row and content Column."""
@@ -217,8 +242,7 @@ class BottomSheet(ComposableWidget):
                     width="100%",
                     padding=(8, 0, 8, 0),
                 ),
-                # TODO(#38): when IOverlayAware is available, wire None → handle.close()
-                IconButton("close", on_click=self._on_close),
+                IconButton("close", on_click=self._resolve_on_close()),
             ],
             width="100%",
             height=72,

--- a/src/samples/sheet_demo.py
+++ b/src/samples/sheet_demo.py
@@ -89,12 +89,11 @@ def main() -> None:
         )
 
     def open_non_dismissible_sheet() -> None:
-        """Right-side sheet — dismiss_on_outside_tap=False, close via on_close callback."""
-        handle = Overlay.root().side_sheet(
+        """Right-side sheet — dismiss_on_outside_tap=False; close button auto-closes via OverlayAware."""
+        Overlay.root().side_sheet(
             SideSheet(
                 _sheet_content("Non-Dismissible Sheet"),
                 headline="Edit",
-                on_close=lambda: handle.close(None),
             ),
             dismiss_on_outside_tap=False,
         )

--- a/src/samples/sheet_demo.py
+++ b/src/samples/sheet_demo.py
@@ -14,14 +14,13 @@ from __future__ import annotations
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
-from nuiitivet.material import (Divider, App, Overlay, Text, Button)
+from nuiitivet.material import Divider, App, Overlay, Text, Button
 from nuiitivet.material.sheet import BottomSheet, SideSheet
 from nuiitivet.material.styles.sheet_style import BottomSheetStyle, SideSheetStyle
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.observable import Observable
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle
-
 
 # ---------------------------------------------------------------------------
 # Sheet content builders

--- a/tests/test_bottom_sheet.py
+++ b/tests/test_bottom_sheet.py
@@ -152,3 +152,47 @@ def test_bottom_sheet_transition_fallback_for_string_height():
     spec = MaterialTransitions.bottom_sheet()
     visuals_mid = spec.enter.pattern.resolve(0.5)
     assert visuals_mid.translate_y_fraction == pytest.approx(0.5)
+
+
+def test_bottom_sheet_resolve_on_close_uses_explicit_callback():
+    """Explicit on_close takes precedence over the injected overlay handle."""
+    calls = []
+    sheet = BottomSheet(Box(), headline="Filters", on_close=lambda: calls.append("explicit"))
+
+    class _FakeHandle:
+        def close(self, value=None) -> None:
+            calls.append("handle")
+
+        def done(self) -> bool:
+            return False
+
+    sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
+    handler = sheet._resolve_on_close()
+    assert handler is not None
+    handler()
+    assert calls == ["explicit"]
+
+
+def test_bottom_sheet_resolve_on_close_uses_overlay_handle():
+    """Without explicit on_close, falls back to overlay_handle.close(None)."""
+    closed = []
+
+    class _FakeHandle:
+        def close(self, value=None) -> None:
+            closed.append(value)
+
+        def done(self) -> bool:
+            return False
+
+    sheet = BottomSheet(Box(), headline="Filters")
+    sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
+    handler = sheet._resolve_on_close()
+    assert handler is not None
+    handler()
+    assert closed == [None]
+
+
+def test_bottom_sheet_resolve_on_close_returns_none_when_standalone():
+    """No on_close, no overlay handle → close button stays inert."""
+    sheet = BottomSheet(Box(), headline="Filters")
+    assert sheet._resolve_on_close() is None

--- a/tests/test_side_sheet.py
+++ b/tests/test_side_sheet.py
@@ -203,6 +203,50 @@ def test_side_sheet_transition_fallback_for_non_int_width():
     assert visuals_end.translate_x_fraction == pytest.approx(1.0)
 
 
+def test_side_sheet_resolve_on_close_uses_explicit_callback():
+    """Explicit on_close takes precedence over the injected overlay handle."""
+    calls = []
+    sheet = SideSheet(Box(), headline="Settings", on_close=lambda: calls.append("explicit"))
+
+    class _FakeHandle:
+        def close(self, value=None) -> None:
+            calls.append("handle")
+
+        def done(self) -> bool:
+            return False
+
+    sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
+    handler = sheet._resolve_on_close()
+    assert handler is not None
+    handler()
+    assert calls == ["explicit"]
+
+
+def test_side_sheet_resolve_on_close_uses_overlay_handle():
+    """Without explicit on_close, falls back to overlay_handle.close(None)."""
+    closed = []
+
+    class _FakeHandle:
+        def close(self, value=None) -> None:
+            closed.append(value)
+
+        def done(self) -> bool:
+            return False
+
+    sheet = SideSheet(Box(), headline="Settings")
+    sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
+    handler = sheet._resolve_on_close()
+    assert handler is not None
+    handler()
+    assert closed == [None]
+
+
+def test_side_sheet_resolve_on_close_returns_none_when_standalone():
+    """No on_close, no overlay handle → close button stays inert."""
+    sheet = SideSheet(Box(), headline="Settings")
+    assert sheet._resolve_on_close() is None
+
+
 def test_side_sheet_back_button_suppressed_without_on_back():
     """Back button is silently suppressed when show_back_button=True but on_back is None.
 


### PR DESCRIPTION
## Summary
Resolve the long-standing `TODO(#38)` in `SideSheet` / `BottomSheet`: when `on_close` is not provided and the sheet is shown via an `Overlay` API, the header close (×) button now automatically dismisses the sheet through the injected `OverlayHandle`. Callers no longer need to wire `handle.close()` manually.

Closes #119.

## Changes
- `SideSheet` and `BottomSheet` inherit `OverlayAware[None]`.
- New `_resolve_on_close()` resolves the close handler with priority:
  1. Explicit `on_close` argument
  2. Injected `overlay_handle.close(None)`
  3. `None` (standalone usage stays inert)
- Drop `TODO(#38)` comments and update docstrings.
- `sheet_demo.py`: simplify the non-dismissible sample (no manual handle wiring required) and minor import cleanup.
- Tests cover all three resolution paths for both sheet types.

## Before / After (caller code)
**Before**
```python
handle = Overlay.root().side_sheet(
    SideSheet(content, headline="Edit",
              on_close=lambda: handle.close(None)),
    dismiss_on_outside_tap=False,
)
```
**After**
```python
Overlay.root().side_sheet(
    SideSheet(content, headline="Edit"),
    dismiss_on_outside_tap=False,
)
```

## Verification
- `uv run pytest` — 1181 passed
- `uv run mypy src/nuiitivet/material/sheet.py` — clean
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` — clean

## Related
- Closes #119
- Follows up on #38 (OverlayAware mixin)