### PR TITLE
fix(text-field): resolve Japanese rendering, focus lifecycle and overflow issues (#121)

### DIFF
--- a/src/nuiitivet/material/text_fields.py
+++ b/src/nuiitivet/material/text_fields.py
@@ -19,6 +19,7 @@ from nuiitivet.widgets.interaction import FocusNode
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.rendering.skia import (
     draw_round_rect,
+    get_default_font_fallbacks,
     get_skia,
     make_font,
     make_paint,
@@ -186,9 +187,19 @@ class TextField(InteractiveWidget):
             width=width,
             height=height,
             padding=padding,
-            on_click=lambda: self.focus(),
             state_layer_color=ColorRole.ON_SURFACE,
             disabled=False,  # Set initial disabled state below
+            # The TextField itself does not host a FocusNode. The focus
+            # subject is the inner EditableText; mirroring it here would
+            # cause focus ping-pong between two FocusNodes during pointer
+            # press handling and produce stale ``_focus_from_pointer``
+            # state. The visual focus indicator (ring / state layer) reads
+            # the editable's focus state directly via
+            # ``should_show_focus_ring``. Pointer presses are routed to the
+            # editable in ``_handle_press`` below; keyboard Tab traversal
+            # collects the editable's FocusNode directly because the
+            # TextField has none.
+            focusable=False,
         )
 
         self._label_source: ReadOnlyObservableProtocol[str] | None = None
@@ -324,8 +335,14 @@ class TextField(InteractiveWidget):
 
     @property
     def should_show_focus_ring(self) -> bool:
-        """Override to check internal editable focus interaction."""
-        return self._editable.state.focused and not self._focus_from_pointer
+        """Show the focus ring only when focus arrived via keyboard navigation.
+
+        The actual focus subject is ``self._editable``; the host TextField
+        does not own a FocusNode (see ``focusable=False`` in __init__).
+        ``EditableText`` exposes ``is_focus_from_pointer`` so that, per
+        MD3 spec, the ring is suppressed for clicks.
+        """
+        return self._editable.state.focused and not self._editable.is_focus_from_pointer
 
     def corner_radii_pixels(self, width: float, height: float) -> Tuple[float, float, float, float]:
         style = self.style
@@ -431,11 +448,6 @@ class TextField(InteractiveWidget):
                 self._apply_disabled(bool(self._disabled_source.value))
             except Exception:
                 exception_once(_logger, "text_field_bind_disabled_exc", "TextField failed to bind disabled")
-
-    def _handle_focus_change(self, focused: bool) -> None:
-        super()._handle_focus_change(focused)
-        if focused and hasattr(self, "_editable"):
-            self._editable.focus()
 
     @property
     def style(self) -> TextFieldStyle:
@@ -594,23 +606,37 @@ class TextField(InteractiveWidget):
         self._text_rect = (text_x, text_y, text_w, text_h)
 
     def focus(self) -> None:
+        """Programmatically focus the TextField (keyboard-style focus).
+
+        Delegates to the inner EditableText. This path does NOT mark the
+        focus as pointer-driven, so the focus ring will be shown — use
+        this for keyboard / API-initiated focus only. Pointer presses go
+        through ``_handle_press`` which calls
+        ``EditableText.request_focus_from_pointer`` to suppress the ring
+        per MD3 spec.
+        """
         self._editable.focus()
 
     def _handle_press(self, event: PointerEvent) -> None:
         if self.disabled:
             return
 
+        # All press paths route focus through the editable's pointer-focus
+        # entry point so that ``EditableText._focus_from_pointer`` is set
+        # consistently regardless of where the press lands (icons, padding,
+        # or the editable area itself). This avoids the focus ring showing
+        # for clicks per MD3 spec.
         if self._is_point_in_icon_rect(event, self.leading_icon):
             self._invoke_icon_tap_callback(self._on_tap_leading_icon, key="leading")
-            self.focus()
+            self._editable.request_focus_from_pointer()
             return
 
         if self._is_point_in_icon_rect(event, self.trailing_icon):
             self._invoke_icon_tap_callback(self._on_tap_trailing_icon, key="trailing")
-            self.focus()
+            self._editable.request_focus_from_pointer()
             return
 
-        self.focus()
+        self._editable.request_focus_from_pointer()
 
     def _is_point_in_icon_rect(self, event: PointerEvent, icon: Optional[Widget]) -> bool:
         if icon is None:
@@ -636,9 +662,12 @@ class TextField(InteractiveWidget):
             )
 
     def _get_font(self):
+        # Use locale-aware fallbacks so that label / supporting text written
+        # in non-Latin scripts (e.g. Japanese) renders without mojibake or
+        # missing glyphs.
         tf = get_typeface(
             candidate_files=None,
-            family_candidates=("DejaVu Sans", "Arial", "Helvetica", "Liberation Sans"),
+            family_candidates=get_default_font_fallbacks(),
             pkg_font_dir=None,
             fallback_to_default=True,
         )

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -724,8 +724,8 @@ class App:
         _dispatch_mouse_motion_fn(self, x, y)
 
     # --- Keyboard / focus helpers ---------------------------------
-    def request_focus(self, node: FocusNode) -> None:
-        """Set focus to the given FocusNode."""
+    def request_focus(self, node: Optional[FocusNode]) -> None:
+        """Set focus to the given FocusNode. Pass ``None`` to clear focus."""
         if self._focused_node is node:
             return
 
@@ -740,6 +740,8 @@ class App:
             # Also update legacy target if the node belongs to a widget
             if node.region:
                 self._focused_target = node.region
+        else:
+            self._focused_target = None
 
     def _collect_focus_nodes(self) -> list[FocusNode]:
         """Return a list of FocusNodes in tree order."""

--- a/src/nuiitivet/runtime/app_events.py
+++ b/src/nuiitivet/runtime/app_events.py
@@ -9,7 +9,6 @@ from .pointer import PointerCaptureManager
 from nuiitivet.input.pointer import PointerEvent, PointerEventType
 from nuiitivet.common.logging_once import exception_once
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -116,6 +115,61 @@ def dispatch_mouse_motion(app: Any, x: int, y: int):
             exception_once(logger, "app_events_set_last_hover_target_exc", "Failed to set app._last_hover_target")
 
 
+def _press_target_contains_focused_node(target: Any, focused_node: Any) -> bool:
+    """Return True if ``target`` is the focused widget itself or one of its
+    descendants.
+
+    Used for the "click landed on the focused widget" case. The reverse
+    direction (focused widget being a descendant of ``target``) is
+    intentionally NOT covered here — see ``_handler_hosts_focused_node``
+    which restricts that direction to actual press handlers so arbitrary
+    layout ancestors do not spuriously keep focus.
+    """
+    if focused_node is None or target is None:
+        return False
+    focused_owner = getattr(focused_node, "owner", None)
+    if focused_owner is None:
+        return False
+
+    current = target
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        if current is focused_owner:
+            return True
+        current = getattr(current, "_parent", None)
+    return False
+
+
+def _handler_hosts_focused_node(handler: Any, focused_node: Any) -> bool:
+    """Return True if ``handler`` is the focused widget's host.
+
+    The press ``handler`` is the widget that actually consumed the event
+    (typically a Clickable). When the focused widget is a descendant of
+    that handler, the click belongs to the same "focus group" — for
+    example, clicking a leading/trailing icon inside a TextField whose
+    inner EditableText is focused must not blur the editable.
+
+    This is restricted to the actual handler (rather than the deepest
+    hit-test target or any ancestor) so that clicks on unrelated layout
+    ancestors (Column, Container, etc.) still blur correctly.
+    """
+    if handler is None or focused_node is None:
+        return False
+    focused_owner = getattr(focused_node, "owner", None)
+    if focused_owner is None:
+        return False
+
+    current = focused_owner
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        if current is handler:
+            return True
+        current = getattr(current, "_parent", None)
+    return False
+
+
 def dispatch_mouse_press(app: Any, x: int, y: int):
     if app.root is None:
         return
@@ -127,7 +181,20 @@ def dispatch_mouse_press(app: Any, x: int, y: int):
         exception_once(logger, "app_events_hit_test_exc", "hit_test raised")
         target = None
 
+    # Capture focus state before dispatch so we can decide whether to blur.
+    focused_before = getattr(app, "_focused_node", None)
+
     if target is None:
+        # Click on empty area: blur any currently-focused node.
+        if focused_before is not None:
+            try:
+                app.request_focus(None)
+            except Exception:
+                exception_once(
+                    logger,
+                    "app_events_blur_focus_no_target_exc",
+                    "app.request_focus(None) raised (no hit target)",
+                )
         return
 
     pointer_id = _primary_pointer_id(app)
@@ -141,6 +208,30 @@ def dispatch_mouse_press(app: Any, x: int, y: int):
             app._pressed_target = handler
         except Exception:
             exception_once(logger, "app_events_set_pressed_target_exc", "Failed to set app._pressed_target")
+
+    # If the press did not transfer focus to a node within the press target
+    # (e.g. click landed on a non-interactive area), blur the previously
+    # focused node so that text fields lose focus when clicking outside.
+    focused_after = getattr(app, "_focused_node", None)
+    # Two complementary in-group checks:
+    # - target check: the press hit the focused widget itself or a descendant.
+    # - handler check: the consuming press handler is the focused widget's
+    #   host (e.g. TextField containing a focused EditableText). Restricted
+    #   to ``handler`` so unrelated layout ancestors do not preserve focus.
+    if (
+        focused_before is not None
+        and focused_after is focused_before
+        and not _press_target_contains_focused_node(target, focused_before)
+        and not _handler_hosts_focused_node(handler, focused_before)
+    ):
+        try:
+            app.request_focus(None)
+        except Exception:
+            exception_once(
+                logger,
+                "app_events_blur_focus_outside_exc",
+                "app.request_focus(None) raised (click outside focus group)",
+            )
 
 
 def dispatch_mouse_release(app: Any, x: int, y: int):

--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -18,9 +18,16 @@ from nuiitivet.input.codes import (
 from nuiitivet.observable import Disposable, Observable, ObservableProtocol
 from nuiitivet.platform import IMEManager, get_system_clipboard
 from nuiitivet.rendering.sizing import SizingLike
-from nuiitivet.widgets.interaction import InteractionHostMixin, FocusNode
+from nuiitivet.widgets.interaction import InteractionHostMixin, FocusNode, DraggableNode
 from nuiitivet.widgets.text_editing import TextEditingValue, TextRange
-from nuiitivet.rendering.skia import make_font, make_paint, make_text_blob, get_typeface, get_default_font_fallbacks
+from nuiitivet.rendering.skia import (
+    make_font,
+    make_paint,
+    make_rect,
+    make_text_blob,
+    get_typeface,
+    get_default_font_fallbacks,
+)
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.common.logging_once import exception_once
@@ -65,6 +72,17 @@ class EditableText(InteractionHostMixin, Widget):
         self._external_str_obs: ObservableProtocol[str] | None = None
         self._external_sub: Optional[Disposable] = None
 
+        # Horizontal scroll offset (pixels) used to keep the cursor visible
+        # when the text exceeds the available width.
+        self._scroll_x: float = 0.0
+        # Track whether the current pointer interaction is in drag mode so
+        # that pointer MOVE events extend the selection from the press anchor.
+        self._drag_anchor: Optional[int] = None
+        # Whether the current focus arrived from a pointer interaction. Used
+        # by the host (e.g. TextField) to suppress the keyboard-only focus
+        # ring per MD3 spec.
+        self._focus_from_pointer: bool = False
+
         # Initialize state
         initial_text = ""
         if hasattr(value, "subscribe") and hasattr(value, "value"):
@@ -84,6 +102,15 @@ class EditableText(InteractionHostMixin, Widget):
                 on_text=self._handle_text,
                 on_text_motion=self._handle_text_motion,
                 on_ime_composition=self._handle_ime_composition,
+            )
+        )
+
+        # Drag handling for pointer-based range selection.
+        self.add_node(
+            DraggableNode(
+                on_drag_start=self._handle_drag_start,
+                on_drag_update=self._handle_drag_update,
+                on_drag_end=self._handle_drag_end,
             )
         )
 
@@ -164,6 +191,21 @@ class EditableText(InteractionHostMixin, Widget):
                 new_val = TextEditingValue(text=new_text, selection=TextRange(len(new_text), len(new_text)))
                 self._state_internal.value = new_val
                 self.invalidate()
+                # Notify listeners so that decorators (e.g. floating label
+                # state in TextField) can synchronize with externally-driven
+                # value changes. The ``current.text == new_text`` early-return
+                # above guards against write-back loops in two-way bound
+                # scenarios: an Observable -> on_change -> observable.value
+                # cycle terminates because the second delivery is a no-op.
+                if self._on_change:
+                    try:
+                        self._on_change(new_text)
+                    except Exception:
+                        exception_once(
+                            _logger,
+                            "editable_text_external_on_change_exc",
+                            "EditableText external on_change raised",
+                        )
 
             self._external_sub = self._external_str_obs.subscribe(_on_external_change)
 
@@ -228,19 +270,59 @@ class EditableText(InteractionHostMixin, Widget):
         except Exception:
             exception_once(_logger, "editable_text_focus_exc", "EditableText.focus failed")
 
+    def request_focus_from_pointer(self) -> None:
+        # Mark this focus acquisition as pointer-driven so the host can
+        # suppress the keyboard-only focus ring (MD3 spec). Reset is handled
+        # in ``_handle_focus_change`` when focus is released.
+        self._focus_from_pointer = True
+        super().request_focus_from_pointer()
+
+    @property
+    def is_focus_from_pointer(self) -> bool:
+        """Whether the current focus was acquired from a pointer interaction.
+
+        Hosts (e.g. ``TextField``) read this to suppress the keyboard-only
+        focus ring per MD3 spec. The flag is set by
+        ``request_focus_from_pointer`` and cleared on blur.
+        """
+        return self._focus_from_pointer
+
     def _handle_press(self, event: PointerEvent) -> None:
         self.focus()
 
-        # Simple hit testing for cursor position
-        local_x = event.x
-        if self.global_layout_rect:
-            local_x -= self.global_layout_rect[0]
-
-        index = self._get_index_at(local_x)
+        index = self._index_at_event(event)
+        self._drag_anchor = index
 
         current = self._state_internal.value
         if current.selection.start != index or current.selection.end != index:
             self._update_value(current.copy_with(selection=TextRange(index, index), composing=TextRange(-1, -1)))
+
+    def _handle_drag_start(self, event: PointerEvent) -> None:
+        # Selection anchor is set on press; the fallback below covers the
+        # rare case where a drag is observed without a preceding press
+        # (e.g. capture transferred mid-gesture). Without it the first
+        # drag-update would have nothing to extend the selection from.
+        if self._drag_anchor is None:
+            self._drag_anchor = self._index_at_event(event)
+
+    def _handle_drag_update(self, event: PointerEvent, dx: float, dy: float) -> None:
+        if self._drag_anchor is None:
+            return
+        index = self._index_at_event(event)
+        anchor = self._drag_anchor
+        current = self._state_internal.value
+        new_selection = TextRange(anchor, index)
+        if new_selection != current.selection:
+            self._update_value(current.copy_with(selection=new_selection, composing=TextRange(-1, -1)))
+
+    def _handle_drag_end(self, event: PointerEvent) -> None:
+        self._drag_anchor = None
+
+    def _index_at_event(self, event: PointerEvent) -> int:
+        local_x = event.x
+        if self.global_layout_rect:
+            local_x -= self.global_layout_rect[0]
+        return self._get_index_at(local_x)
 
     def _get_font(self):
         fallbacks = get_default_font_fallbacks()
@@ -265,21 +347,28 @@ class EditableText(InteractionHostMixin, Widget):
 
         display_text = self._get_display_text(text)
 
-        if x < 0:
+        # Translate viewport-local x into text-coordinate space.
+        text_x = x + self._scroll_x
+
+        if text_x < 0:
             return 0
 
         for i in range(len(text) + 1):
             sub = display_text[:i]
             w = font.measureText(sub)
-            if w > x:
+            if w > text_x:
                 prev_w = font.measureText(display_text[: i - 1]) if i > 0 else 0
-                if x - prev_w < w - x:
+                if text_x - prev_w < w - text_x:
                     return i - 1
                 return i
 
         return len(text)
 
     def _handle_focus_change(self, focused: bool):
+        if not focused:
+            # Clear the pointer-origin marker so the next keyboard focus
+            # acquisition correctly shows the focus ring.
+            self._focus_from_pointer = False
         self.invalidate()
         if self._on_focus_change_callback:
             self._on_focus_change_callback(focused)
@@ -469,26 +558,88 @@ class EditableText(InteractionHostMixin, Widget):
         selection = current_value.selection
 
         font = self._get_font()
-        if font:
-            font_metrics = font.getMetrics()
-            # Align text vertically centered in the available height
-            text_height = -font_metrics.fAscent + font_metrics.fDescent
-            ty = y + (height + text_height) / 2 - font_metrics.fDescent
+        if not font:
+            return
+
+        font_metrics = font.getMetrics()
+        # Align text vertically centered in the available height
+        text_height = -font_metrics.fAscent + font_metrics.fDescent
+        ty = y + (height + text_height) / 2 - font_metrics.fDescent
+
+        # Compute scroll offset so that the cursor remains within the visible
+        # viewport, mirroring the behavior of single-line text inputs in the
+        # platform: long values are not truncated mid-glyph but are scrolled
+        # horizontally as the cursor moves.
+        cursor_x_in_text = font.measureText(display_text[: selection.end])
+        total_text_width = font.measureText(display_text) if display_text else 0.0
+        margin = 2.0  # Padding so the caret is not flush against the edge.
+        scroll = self._scroll_x
+        if total_text_width <= max(0.0, width - margin):
+            scroll = 0.0
+        else:
+            # Keep the caret visible.
+            if cursor_x_in_text - scroll < 0:
+                scroll = cursor_x_in_text
+            elif cursor_x_in_text - scroll > width - margin:
+                scroll = cursor_x_in_text - (width - margin)
+            # Avoid leaving empty space at the right edge.
+            max_scroll = max(0.0, total_text_width - (width - margin))
+            scroll = max(0.0, min(scroll, max_scroll))
+        self._scroll_x = scroll
+
+        # Clip drawing to the layout viewport so long text never bleeds
+        # outside the field. Use a save/restore scope to avoid disturbing
+        # parent clip state.
+        clip_rect = make_rect(x, y, width, height)
+        save_count = None
+        if clip_rect is not None:
+            try:
+                save_count = canvas.save()
+                canvas.clipRect(clip_rect)
+            except Exception:
+                exception_once(
+                    _logger,
+                    "editable_text_clip_rect_exc",
+                    "EditableText canvas clipRect raised",
+                )
+                save_count = None
+
+        try:
+            from nuiitivet.theme.manager import manager as theme_manager
+
+            # Draw selection highlight (behind the text).
+            if display_text and not selection.is_collapsed:
+                sel_start = max(0, min(selection.min, len(display_text)))
+                sel_end = max(0, min(selection.max, len(display_text)))
+                if sel_end > sel_start:
+                    sx0 = font.measureText(display_text[:sel_start]) - scroll
+                    sx1 = font.measureText(display_text[:sel_end]) - scroll
+                    sel_top = ty + font_metrics.fAscent
+                    sel_bottom = ty + font_metrics.fDescent
+                    sel_color = resolve_color_to_rgba(self.selection_color, theme=theme_manager.current)
+                    paint_sel = make_paint(color=sel_color)
+                    sel_rect = make_rect(int(x + sx0), int(sel_top), int(sx1 - sx0), int(sel_bottom - sel_top))
+                    if sel_rect is not None and paint_sel is not None:
+                        try:
+                            canvas.drawRect(sel_rect, paint_sel)
+                        except Exception:
+                            exception_once(
+                                _logger,
+                                "editable_text_draw_selection_exc",
+                                "EditableText selection draw raised",
+                            )
 
             # Draw Text
             if display_text:
-                from nuiitivet.theme.manager import manager as theme_manager
-
                 text_color = resolve_color_to_rgba(self.text_color, theme=theme_manager.current)
                 paint_text = make_paint(color=text_color)
                 blob = make_text_blob(display_text, font)
                 if blob:
-                    canvas.drawTextBlob(blob, x, ty, paint_text)
+                    canvas.drawTextBlob(blob, x - scroll, ty, paint_text)
 
             # Draw Cursor
             if is_focused and selection.is_collapsed:
-                cursor_text = display_text[: selection.end]
-                cursor_x = font.measureText(cursor_text)
+                cursor_x = cursor_x_in_text - scroll
 
                 cursor_top = ty + font_metrics.fAscent
                 cursor_bottom = ty + font_metrics.fDescent
@@ -500,8 +651,6 @@ class EditableText(InteractionHostMixin, Widget):
                     cursor_bottom - cursor_top,
                 )
 
-                from nuiitivet.theme.manager import manager as theme_manager
-
                 cursor_color = resolve_color_to_rgba(self.cursor_color, theme=theme_manager.current)
                 paint_cursor = make_paint(color=cursor_color, style="stroke", stroke_width=2)
                 if paint_cursor is not None:
@@ -512,6 +661,19 @@ class EditableText(InteractionHostMixin, Widget):
                         cursor_bottom,
                         paint_cursor,
                     )
+        finally:
+            if save_count is not None:
+                try:
+                    canvas.restoreToCount(save_count)
+                except Exception:
+                    try:
+                        canvas.restore()
+                    except Exception:
+                        exception_once(
+                            _logger,
+                            "editable_text_canvas_restore_exc",
+                            "EditableText canvas restore raised",
+                        )
 
     def _get_display_text(self, text: str) -> str:
         if not self._obscure_text:

--- a/src/samples/japanese_text_demo.py
+++ b/src/samples/japanese_text_demo.py
@@ -4,6 +4,7 @@ from nuiitivet.material.text import Text
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.layout.column import Column
 import nuiitivet as nv
+from nuiitivet.material.text_fields import TextField
 
 
 def main():
@@ -17,7 +18,14 @@ def main():
     text2 = Text("日本語フォント指定 (Hiragino Sans)", style=TextStyle(font_size=24, font_family="Hiragino Sans"))
 
     column = Column(
-        children=[text1, text2],
+        children=[
+            text1,
+            text2,
+            TextField(
+                label="入力してください",
+                supporting_text="日本語のテキストフィールドです",
+            ),
+        ],
         gap=20,
         padding=20,
         cross_alignment="center",

--- a/tests/test_text_field_issue121.py
+++ b/tests/test_text_field_issue121.py
@@ -1,0 +1,435 @@
+"""Regression tests for Issue #121.
+
+Covers:
+- Japanese label / supporting text rendering uses CJK-aware font fallback.
+- Click-outside the TextField clears focus state.
+- External Observable updates synchronize the floating label state.
+- Pointer drag selects a text range.
+- Long text is clipped (canvas clip is applied) and the cursor stays in view.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from nuiitivet.input.pointer import PointerEvent, PointerEventType
+from nuiitivet.material.text_fields import TextField
+from nuiitivet.observable import Observable
+from nuiitivet.runtime.app_events import dispatch_mouse_press
+from nuiitivet.widgets.editable_text import EditableText
+from nuiitivet.widgets.interaction import FocusNode
+from nuiitivet.widgets.text_editing import TextRange
+
+# ---------------------------------------------------------------------------
+# 1. Japanese rendering uses locale-aware font fallback for label/supporting.
+# ---------------------------------------------------------------------------
+
+
+def test_text_field_label_font_uses_locale_fallbacks() -> None:
+    tf = TextField(label="入力してください", supporting_text="日本語のテキストフィールドです")
+
+    captured: dict = {}
+
+    def _fake_get_typeface(**kwargs):
+        captured["family_candidates"] = kwargs.get("family_candidates")
+        return MagicMock()
+
+    with patch("nuiitivet.material.text_fields.get_typeface", side_effect=_fake_get_typeface):
+        with patch("nuiitivet.material.text_fields.make_font", return_value=MagicMock()):
+            tf._get_font()
+
+    candidates = captured.get("family_candidates")
+    assert candidates is not None
+    # The fallback chain must include CJK fonts so Japanese glyphs render.
+    cjk_markers = ("Hiragino", "Noto Sans CJK", "Noto Sans JP", "Yu Gothic", "Meiryo")
+    assert any(any(marker in fam for marker in cjk_markers) for fam in candidates), candidates
+
+
+# ---------------------------------------------------------------------------
+# 2. Click-outside the TextField clears focus.
+# ---------------------------------------------------------------------------
+
+
+class _FakeApp:
+    """Minimal app stub for dispatch_mouse_press focus testing."""
+
+    def __init__(self, hit_target):
+        self._hit_target = hit_target
+        self._focused_node = None
+        self._focused_target = None
+        self._pressed_target = None
+        self._pointer_capture_manager = None
+        self._primary_pointer_id = 1
+        self.root = MagicMock()
+        self.root.hit_test = MagicMock(return_value=hit_target)
+        self.invalidate = MagicMock()
+
+    def request_focus(self, node):
+        if self._focused_node is node:
+            return
+        if self._focused_node is not None:
+            self._focused_node._set_focused(False)
+        self._focused_node = node
+        if node is not None:
+            node._set_focused(True)
+
+
+def test_click_outside_text_field_blurs_focus() -> None:
+    # Build a focused EditableText and simulate a press elsewhere.
+    editable = EditableText(value="hi")
+    focus_node = editable.get_node(FocusNode)
+    assert isinstance(focus_node, FocusNode)
+    focus_node.attach(editable)
+
+    # Some unrelated widget receives the click.
+    other_target = MagicMock()
+    other_target._parent = None
+
+    app = _FakeApp(hit_target=other_target)
+    app.request_focus(focus_node)
+    assert editable.state.focused is True
+
+    dispatch_mouse_press(app, x=999, y=999)
+
+    assert editable.state.focused is False
+    assert app._focused_node is None
+
+
+def test_click_with_no_hit_target_blurs_focus() -> None:
+    editable = EditableText(value="hi")
+    focus_node = editable.get_node(FocusNode)
+    assert isinstance(focus_node, FocusNode)
+    focus_node.attach(editable)
+
+    app = _FakeApp(hit_target=None)
+    app.request_focus(focus_node)
+    assert editable.state.focused is True
+
+    dispatch_mouse_press(app, x=10, y=10)
+    assert editable.state.focused is False
+
+
+def test_click_inside_focused_widget_keeps_focus() -> None:
+    editable = EditableText(value="hi")
+    focus_node = editable.get_node(FocusNode)
+    assert isinstance(focus_node, FocusNode)
+    focus_node.attach(editable)
+
+    app = _FakeApp(hit_target=editable)
+    app.request_focus(focus_node)
+
+    # Avoid triggering the real pointer dispatch chain in this stubbed test;
+    # we only care about the focus-blur behavior.
+    with patch(
+        "nuiitivet.runtime.app_events._deliver_pointer_event",
+        return_value=editable,
+    ):
+        dispatch_mouse_press(app, x=10, y=10)
+
+    # Focus should not be cleared because the press landed on the focused widget.
+    assert app._focused_node is focus_node
+    assert editable.state.focused is True
+
+
+def test_click_on_host_keeps_focus_on_inner_focused_descendant() -> None:
+    """Edge-clicking a TextField host while its inner EditableText is
+    focused must NOT blur the editable. Otherwise focus ping-pongs and the
+    pointer-origin flag flips back to keyboard, falsely showing the focus
+    ring (and restarting label animation).
+    """
+    tf = TextField(value="hi")
+    editable = tf._editable
+    focus_node = editable.get_node(FocusNode)
+    assert isinstance(focus_node, FocusNode)
+    focus_node.attach(editable)
+    # Wire parent linkage so the press helper can walk up from editable.
+    editable._parent = tf
+
+    # The press lands on the host TextField (e.g. the padding area), not on
+    # the inner editable. The press handler will internally route focus to
+    # the editable, but since editable is already focused that re-request
+    # is a no-op — the post-press blur logic must not treat this as
+    # "click outside focused".
+    app = _FakeApp(hit_target=tf)
+    app.request_focus(focus_node)
+    assert editable.state.focused is True
+
+    with patch(
+        "nuiitivet.runtime.app_events._deliver_pointer_event",
+        return_value=tf,
+    ):
+        dispatch_mouse_press(app, x=5, y=5)
+
+    assert app._focused_node is focus_node
+    assert editable.state.focused is True
+
+
+def test_click_on_sibling_inside_host_keeps_focus_on_focused_descendant() -> None:
+    """Clicking a sibling widget (e.g. a leading/trailing icon) inside the
+    same TextField host as the focused EditableText must NOT blur focus.
+
+    The deepest hit target (icon) is neither an ancestor nor a descendant
+    of the focused editable — they are siblings sharing the TextField as a
+    common ancestor. The blur-on-press logic must consult the actual press
+    handler (the TextField) so this case is recognised as in-group.
+    """
+    tf = TextField(value="hi")
+    editable = tf._editable
+    focus_node = editable.get_node(FocusNode)
+    assert isinstance(focus_node, FocusNode)
+    focus_node.attach(editable)
+    editable._parent = tf
+
+    # Simulate an icon child that is a sibling of the editable.
+    sibling_icon = MagicMock()
+    sibling_icon._parent = tf
+
+    app = _FakeApp(hit_target=sibling_icon)
+    app.request_focus(focus_node)
+    assert editable.state.focused is True
+
+    # The press is delivered to the icon but consumed (handled) by the
+    # parent TextField — that is what _pressed_target reflects in real
+    # dispatch.
+    with patch(
+        "nuiitivet.runtime.app_events._deliver_pointer_event",
+        return_value=tf,
+    ):
+        dispatch_mouse_press(app, x=5, y=5)
+
+    assert app._focused_node is focus_node
+    assert editable.state.focused is True
+
+
+def test_click_on_layout_ancestor_blurs_focus() -> None:
+    """Clicking on a non-handler layout ancestor of the focused widget
+    (e.g. the surrounding Container/Column) MUST blur focus.
+
+    The focused editable's owner has many ancestors going up to the app
+    root. Treating any ancestor as "in-group" would make outside-clicks
+    fail to blur. Only the actual press handler (Clickable) should keep
+    focus, and an unrelated layout container does not consume presses.
+    """
+    tf = TextField(value="")
+    editable = tf._editable
+    focus_node = editable.get_node(FocusNode)
+    assert isinstance(focus_node, FocusNode)
+    focus_node.attach(editable)
+
+    # Layout ancestor (e.g. Column wrapping multiple TextFields).
+    layout_ancestor = MagicMock()
+    layout_ancestor._parent = None
+    tf._parent = layout_ancestor
+
+    app = _FakeApp(hit_target=layout_ancestor)
+    app.request_focus(focus_node)
+    assert editable.state.focused is True
+
+    # Layout ancestor is not Clickable: no handler consumes the press.
+    with patch(
+        "nuiitivet.runtime.app_events._deliver_pointer_event",
+        return_value=None,
+    ):
+        dispatch_mouse_press(app, x=10, y=10)
+
+    assert app._focused_node is None
+    assert editable.state.focused is False
+
+
+# ---------------------------------------------------------------------------
+# 3. External Observable update synchronizes floating label state.
+# ---------------------------------------------------------------------------
+
+
+def test_external_observable_value_updates_label_state() -> None:
+    obs = Observable("")
+    tf = TextField(value=obs, label="Name")
+
+    # Mount to wire up the external subscription.
+    tf.mount(MagicMock())
+
+    # Initially empty -> label is in rest state.
+    assert tf._label_progress.target == 0.0
+
+    obs.value = "Alice"
+    assert tf.value == "Alice"
+    # Floating label should follow the externally-driven value.
+    assert tf._label_progress.target == 1.0
+
+    obs.value = ""
+    assert tf._label_progress.target == 0.0
+
+    tf.on_unmount()
+
+
+# ---------------------------------------------------------------------------
+# 4. Pointer drag selects a text range.
+# ---------------------------------------------------------------------------
+
+
+def test_pointer_drag_selects_range() -> None:
+    tf = TextField(value="abcdefgh")
+    tf.layout(200, 56)
+    tf.set_layout_rect(0, 0, 200, 56)
+    # Trigger a paint so editable.last_rect / global_layout_rect are populated.
+    tf.paint(None, 0, 0, 200, 56)
+
+    editable = tf._editable
+
+    # Stub character measurement so the test does not depend on a real font.
+    fake_font = MagicMock()
+    fake_font.measureText = MagicMock(side_effect=lambda s: float(len(s) * 10))
+    metrics = MagicMock()
+    metrics.fAscent = -10
+    metrics.fDescent = 3
+    fake_font.getMetrics = MagicMock(return_value=metrics)
+
+    with patch.object(EditableText, "_get_font", return_value=fake_font):
+        # Place the editable so we can compute local x easily.
+        editable.set_last_rect(0, 0, 200, 40)
+        editable.set_layout_rect(0, 0, 200, 40)
+
+        # Press at index 1 (x=10).
+        editable._handle_press(PointerEvent(id=1, type=PointerEventType.PRESS, x=10, y=10))
+        assert editable._drag_anchor == 1
+        assert editable._state_internal.value.selection == TextRange(1, 1)
+
+        # Drag to index 5 (x=50).
+        editable._handle_drag_update(
+            PointerEvent(id=1, type=PointerEventType.MOVE, x=50, y=10),
+            dx=40.0,
+            dy=0.0,
+        )
+        sel = editable._state_internal.value.selection
+        assert sel == TextRange(1, 5)
+        assert sel.is_collapsed is False
+
+        # Release ends the drag.
+        editable._handle_drag_end(PointerEvent(id=1, type=PointerEventType.RELEASE, x=50, y=10))
+        assert editable._drag_anchor is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Long text overflow handling: clip rect applied + cursor scrolled into view.
+# ---------------------------------------------------------------------------
+
+
+def test_long_text_paint_applies_clip_rect() -> None:
+    tf = TextField(value="x" * 200)
+    tf.layout(200, 56)
+
+    fake_font = MagicMock()
+    fake_font.measureText = MagicMock(side_effect=lambda s: float(len(s) * 10))
+    metrics = MagicMock()
+    metrics.fAscent = -10
+    metrics.fDescent = 3
+    fake_font.getMetrics = MagicMock(return_value=metrics)
+
+    canvas = MagicMock()
+    canvas.save = MagicMock(return_value=42)
+
+    with patch.object(EditableText, "_get_font", return_value=fake_font):
+        with patch("nuiitivet.widgets.editable_text.make_paint", return_value=MagicMock()):
+            with patch("nuiitivet.widgets.editable_text.resolve_color_to_rgba", return_value=(0, 0, 0, 255)):
+                with patch("nuiitivet.widgets.editable_text.make_text_blob", return_value=MagicMock()):
+                    with patch("nuiitivet.widgets.editable_text.make_rect", return_value="<rect>"):
+                        tf._editable.paint(canvas, 0, 0, 100, 40)
+
+    # The viewport must be clipped so long text cannot bleed outside the field.
+    assert canvas.clipRect.called is True
+    assert canvas.save.called is True
+
+
+def test_long_text_scrolls_cursor_into_view() -> None:
+    tf = TextField(value="abcdefghijklmno")
+    tf.layout(60, 40)
+
+    fake_font = MagicMock()
+    fake_font.measureText = MagicMock(side_effect=lambda s: float(len(s) * 10))
+    metrics = MagicMock()
+    metrics.fAscent = -10
+    metrics.fDescent = 3
+    fake_font.getMetrics = MagicMock(return_value=metrics)
+
+    canvas = MagicMock()
+    canvas.save = MagicMock(return_value=1)
+
+    editable = tf._editable
+    # Cursor at the end so total width (150) > viewport (60).
+    editable._state_internal.value = editable._state_internal.value.copy_with(
+        selection=TextRange(len("abcdefghijklmno"), len("abcdefghijklmno"))
+    )
+
+    with patch.object(EditableText, "_get_font", return_value=fake_font):
+        with patch("nuiitivet.widgets.editable_text.make_paint", return_value=MagicMock()):
+            with patch("nuiitivet.widgets.editable_text.resolve_color_to_rgba", return_value=(0, 0, 0, 255)):
+                with patch("nuiitivet.widgets.editable_text.make_text_blob", return_value=MagicMock()):
+                    with patch("nuiitivet.widgets.editable_text.make_rect", return_value="<rect>"):
+                        editable.paint(canvas, 0, 0, 60, 40)
+
+    # Scroll offset must be > 0 so that the caret position (150px) is inside
+    # the 60px viewport rather than rendered outside.
+    assert editable._scroll_x > 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Pointer-driven focus must NOT show the focus ring (MD3 spec).
+# ---------------------------------------------------------------------------
+
+
+def test_pointer_focus_hides_focus_ring() -> None:
+    tf = TextField(value="")
+
+    # Pointer-driven focus path: the press handler routes through the
+    # editable's pointer-focus entry point, marking it as pointer-origin.
+    tf._editable.request_focus_from_pointer()
+    tf._editable.state.focused = True
+    tf._on_editable_focus_change(True)
+
+    # Even though the editable is focused, the ring must stay hidden
+    # because focus originated from a pointer interaction.
+    assert tf._editable.is_focus_from_pointer is True
+    assert tf.should_show_focus_ring is False
+
+
+def test_keyboard_focus_shows_focus_ring() -> None:
+    tf = TextField(value="")
+
+    # Keyboard navigation focuses the editable directly (Tab traversal
+    # collects EditableText's FocusNode since TextField has none).
+    tf._editable.focus()
+    tf._editable.state.focused = True
+    tf._on_editable_focus_change(True)
+
+    assert tf._editable.is_focus_from_pointer is False
+    assert tf.should_show_focus_ring is True
+
+
+def test_blur_resets_pointer_focus_flag() -> None:
+    tf = TextField(value="")
+
+    tf._editable.request_focus_from_pointer()
+    tf._editable.state.focused = True
+    tf._on_editable_focus_change(True)
+    assert tf._editable.is_focus_from_pointer is True
+
+    # Releasing focus should clear the pointer-origin flag so that the next
+    # keyboard focus correctly shows the ring.
+    tf._editable._handle_focus_change(False)
+    tf._editable.state.focused = False
+    tf._on_editable_focus_change(False)
+    assert tf._editable.is_focus_from_pointer is False
+
+
+def test_pointer_press_on_editable_propagates_to_text_field() -> None:
+    """Clicking the center (which hits the inner EditableText directly) must
+    still suppress the focus ring on the parent TextField."""
+    tf = TextField(value="abc")
+
+    # Simulate the path taken when EditableText handles the press itself.
+    tf._editable.request_focus_from_pointer()
+    tf._editable.state.focused = True
+    tf._on_editable_focus_change(True)
+
+    assert tf._editable.is_focus_from_pointer is True
+    assert tf.should_show_focus_ring is False


### PR DESCRIPTION
## Summary

Closes #121.

Resolves the five acceptance criteria of Issue #121 plus an MD3 focus-ring regression discovered during validation.

## Changes

### TextField (`src/nuiitivet/material/text_fields.py`)
- Use locale-aware font fallbacks (`get_default_font_fallbacks`) for label and supporting text so Japanese / CJK glyphs render without mojibake.
- Synchronize floating label state when an externally-bound value Observable changes.
- Drop the TextField's own `FocusNode` (`focusable=False`) and route all pointer presses through `EditableText.request_focus_from_pointer`. This eliminates focus ping-pong between two `FocusNode`s and stale `_focus_from_pointer` state.
- `should_show_focus_ring` now reads `EditableText.is_focus_from_pointer` via the new public property.
- Add docstring to `focus()` clarifying it is for keyboard / API focus (the focus ring will be shown).

### EditableText (`src/nuiitivet/widgets/editable_text.py`)
- Apply `clipRect` and a horizontal scroll offset so long values stay within the field bounds and the caret remains visible.
- Support pointer drag range selection via a new `DraggableNode`.
- Notify `on_change` on external Observable updates so decorators (e.g. the floating label) sync with two-way bindings; loop-guarded by the existing equality early-return.
- New `is_focus_from_pointer` public property; flag is cleared on blur.
- Replace silent `except: pass` in paint-time clip / restore with `exception_once` so render issues surface in logs.

### Runtime focus dispatch (`src/nuiitivet/runtime/app_events.py`, `app.py`)
- `App.request_focus(node: Optional[FocusNode])` now accepts `None` to clear focus.
- `dispatch_mouse_press` blurs the focused node when the press lands outside its focus group. Two complementary in-group checks:
  - `_press_target_contains_focused_node`: target is the focused widget or one of its descendants.
  - `_handler_hosts_focused_node`: the actual press handler hosts the focused widget (e.g. TextField hosting a focused EditableText). The handler-only check prevents arbitrary layout ancestors (Column / Container) from spuriously preserving focus.
- Distinct `logging_once` keys for the two blur paths.

## Tests

`tests/test_text_field_issue121.py` (14 cases) covers:
- Japanese fallback in label/supporting font candidates.
- Click-outside / no-target / inside-focused / host edge / sibling-icon / layout-ancestor click scenarios.
- External Observable value sync of the floating label.
- Pointer drag range selection.
- Long-text clip rect & horizontal scroll-to-cursor.
- Pointer-origin focus suppresses ring; keyboard focus shows it; blur resets the flag; press on inner editable propagates correctly.

## Verification

- `uv run pytest`: **1196 passed**
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203`: clean
- `uv run mypy`: clean
- Visual: text_field_demo / japanese_text_demo verified — Japanese characters render, focus ring suppressed for clicks, label animation no longer restarts on edge / icon clicks, click-outside blurs and returns label to center.

## Demo

Updated `src/samples/japanese_text_demo.py` to include a Japanese TextField for visual reproduction of the rendering fix.