### PR TITLE
fix(fab): align FAB state-layer and elevation tokens with MD3 spec

### DIFF
--- a/src/nuiitivet/material/buttons.py
+++ b/src/nuiitivet/material/buttons.py
@@ -27,6 +27,7 @@ from nuiitivet.material.styles.toggle_button_style import ToggleButtonStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.theme.types import ColorSpec
+from nuiitivet.rendering.elevation import resolve_shadow_params
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.rendering.skia.color import make_opacity_paint
 from nuiitivet.widgeting.widget import Widget
@@ -97,6 +98,22 @@ def _resolve_color_rgba(value: ColorSpec) -> Tuple[int, int, int, int]:
     from nuiitivet.theme.resolver import resolve_color_to_rgba
 
     return resolve_color_to_rgba(value, theme=manager.current)
+
+
+def _shadow_from_elevation(elevation_val: Optional[float]) -> tuple[ColorSpec, float, tuple[float, float]]:
+    shadow_color = None
+    shadow_blur = 0.0
+    shadow_offset: tuple[float, float] = (0.0, 0.0)
+
+    if elevation_val is None or elevation_val <= 0.0:
+        return shadow_color, shadow_blur, shadow_offset
+
+    shadow = resolve_shadow_params(float(elevation_val))
+    shadow_color = (ColorRole.SHADOW, shadow.alpha)
+    shadow_offset = shadow.offset
+    shadow_blur = shadow.blur
+
+    return shadow_color, shadow_blur, shadow_offset
 
 
 _RGBA_CONVERTER = RgbaTupleConverter()
@@ -229,7 +246,7 @@ def resolve_button_style_params(
     # Elevation -> Shadow
     shadow_color = None
     shadow_blur = 0.0
-    shadow_offset = (0, 0)
+    shadow_offset: tuple[float, float] = (0.0, 0.0)
 
     elevation_val = None
     if style and getattr(style, "elevation", None) is not None:
@@ -243,19 +260,7 @@ def resolve_button_style_params(
             )
 
     if elevation_val is not None and elevation_val > 0.0:
-        try:
-            from nuiitivet.rendering.elevation import Elevation
-
-            elev = Elevation.from_level(elevation_val)
-            shadow_color = (ColorRole.SHADOW, elev.alpha)
-            shadow_offset = elev.offset
-            shadow_blur = elev.blur
-        except Exception as exc:
-            exception_once(
-                logger,
-                f"button_resolve_elevation_shadow_exc_{type(exc).__name__}",
-                "Failed to resolve button shadow",
-            )
+        shadow_color, shadow_blur, shadow_offset = _shadow_from_elevation(elevation_val)
 
     # Overlay
     overlay_color = None
@@ -1095,6 +1100,7 @@ class Fab(MaterialButtonBase):
             disabled=disabled,
             **params,
         )
+        self._sync_state_tokens()
 
         self._press_scale_x_anim: Animatable[float] = Animatable(1.0, motion=EXPRESSIVE_FAST_SPATIAL)
         self._press_scale_y_anim: Animatable[float] = Animatable(1.0, motion=EXPRESSIVE_FAST_SPATIAL)
@@ -1122,6 +1128,48 @@ class Fab(MaterialButtonBase):
             self.disabled,
         )
         self._apply_style_params(params)
+        self._sync_state_tokens()
+
+    def _container_elevation(self) -> float:
+        style = self.style
+        if self.state.dragging or self.state.pressed:
+            return float(getattr(style, "pressed_elevation", style.elevation) or 0.0)
+        if self.state.hovered:
+            return float(getattr(style, "hovered_elevation", style.elevation) or 0.0)
+        if self.state.focused:
+            return float(getattr(style, "focused_elevation", style.elevation) or 0.0)
+        return float(getattr(style, "elevation", 0.0) or 0.0)
+
+    def _sync_state_tokens(self) -> None:
+        style = self.style
+
+        focus_opacity = float(getattr(style, "focus_opacity", 0.1) or 0.0)
+        hover_opacity = float(getattr(style, "hover_opacity", self._HOVER_OPACITY) or 0.0)
+        pressed_opacity = float(getattr(style, "pressed_opacity", self._PRESS_OPACITY) or 0.0)
+
+        self._FOCUS_OPACITY = focus_opacity
+        self._HOVER_OPACITY = hover_opacity
+        self._PRESS_OPACITY = pressed_opacity
+
+        shadow_color, shadow_blur, shadow_offset = _shadow_from_elevation(self._container_elevation())
+        if self.shadow_color != shadow_color:
+            self.shadow_color = shadow_color
+        if abs(float(self.shadow_blur) - float(shadow_blur)) > 1e-6:
+            self.shadow_blur = shadow_blur
+        if self.shadow_offset != shadow_offset:
+            self.shadow_offset = shadow_offset
+
+    def _get_state_layer_target_opacity(self) -> float:
+        state = self.state
+        if state.dragging:
+            return float(self._DRAG_OPACITY)
+        if state.pressed:
+            return float(self._PRESS_OPACITY)
+        if state.hovered:
+            return float(self._HOVER_OPACITY)
+        if state.focused:
+            return float(self._FOCUS_OPACITY)
+        return 0.0
 
     def _expressive_press_scale(self) -> tuple[float, float]:
         target = (0.94, 0.9) if self.state.pressed and not self.disabled else (1.0, 1.0)
@@ -1132,6 +1180,7 @@ class Fab(MaterialButtonBase):
         return float(self._press_scale_x_anim.value), float(self._press_scale_y_anim.value)
 
     def paint(self, canvas, x: int, y: int, width: int, height: int):
+        self._sync_state_tokens()
         sx, sy = self._expressive_press_scale()
         if abs(sx - 1.0) < 1e-6 and abs(sy - 1.0) < 1e-6:
             super().paint(canvas, x, y, width, height)

--- a/src/nuiitivet/material/card.py
+++ b/src/nuiitivet/material/card.py
@@ -14,6 +14,7 @@ from typing import Callable, Optional, Tuple, Union
 
 from nuiitivet.common.logging_once import exception_once
 from ..widgeting.widget import ComposableWidget, Widget
+from ..rendering.elevation import resolve_shadow_params
 from ..rendering.sizing import SizingLike
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.material.theme.color_role import ColorRole
@@ -114,18 +115,16 @@ class Card(ComposableWidget, Box):
             return None, (0.0, 0.0), 0.0
 
         try:
-            from ..rendering.elevation import Elevation
-
-            e = Elevation.from_level(elevation)
+            shadow = resolve_shadow_params(elevation)
 
             # Use provided shadow color or default to SHADOW role with alpha from Elevation
             if shadow_color_spec:
                 shadow_color = shadow_color_spec
             else:
-                shadow_color = (ColorRole.SHADOW, e.alpha)
+                shadow_color = (ColorRole.SHADOW, shadow.alpha)
 
-            shadow_offset = e.offset
-            shadow_blur = e.blur
+            shadow_offset = shadow.offset
+            shadow_blur = shadow.blur
         except Exception:
             exception_once(_logger, "card_resolve_shadow_exc", "Failed to resolve elevation shadow")
             shadow_color = None

--- a/src/nuiitivet/material/menu.py
+++ b/src/nuiitivet/material/menu.py
@@ -20,7 +20,7 @@ from nuiitivet.material.symbols import Symbols
 from nuiitivet.material.text import Text
 from nuiitivet.observable import runtime
 from nuiitivet.overlay.overlay_position import AnchoredOverlayPosition
-from nuiitivet.rendering.elevation import Elevation
+from nuiitivet.rendering.elevation import resolve_shadow_params
 from nuiitivet.rendering.sizing import Sizing, SizingLike
 from nuiitivet.theme.types import ColorBase, ColorSpec
 from nuiitivet.widgets.interaction import FocusNode
@@ -456,10 +456,10 @@ class Menu(InteractiveWidget):
         except Exception:
             elevation_value = 0.0
         if elevation_value > 0.0:
-            elev = Elevation.from_level(elevation_value)
-            shadow_color = _with_opacity(self.style.elevation_color, elev.alpha)
-            shadow_blur = elev.blur
-            shadow_offset = elev.offset
+            shadow = resolve_shadow_params(elevation_value)
+            shadow_color = _with_opacity(self.style.elevation_color, shadow.alpha)
+            shadow_blur = shadow.blur
+            shadow_offset = shadow.offset
 
         children = self._materialize_children()
         self._column = Column(children=children, width=Sizing.flex(), gap=0, cross_alignment="start")

--- a/src/nuiitivet/material/styles/fab_style.py
+++ b/src/nuiitivet/material/styles/fab_style.py
@@ -27,6 +27,13 @@ class FabStyle(ButtonStyle):
     the shared ``resolve_button_style_params`` machinery without changes.
     """
 
+    focus_opacity: float = 0.1
+    hover_opacity: float = 0.08
+    pressed_opacity: float = 0.1
+    focused_elevation: float = 6.0
+    hovered_elevation: float = 8.0
+    pressed_elevation: float = 6.0
+
     @staticmethod
     def _base(size: FabSize) -> dict:
         t = FAB_SIZE_TOKENS[size]
@@ -41,6 +48,12 @@ class FabStyle(ButtonStyle):
             icon_size=t["icon_size"],
             elevation=6.0,
             overlay_alpha=0.08,
+            focus_opacity=0.1,
+            hover_opacity=0.08,
+            pressed_opacity=0.1,
+            focused_elevation=6.0,
+            hovered_elevation=8.0,
+            pressed_elevation=6.0,
         )
 
     @classmethod

--- a/src/nuiitivet/material/tooltip.py
+++ b/src/nuiitivet/material/tooltip.py
@@ -12,7 +12,7 @@ from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.styles.tooltip_style import RichTooltipStyle, TooltipStyle
 from nuiitivet.material.text import Text
-from nuiitivet.rendering.elevation import Elevation
+from nuiitivet.rendering.elevation import resolve_shadow_params
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.theme.manager import manager
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -22,7 +22,7 @@ from nuiitivet.widgets.box import Box
 def _resolve_shadow(elevation: float, color_spec):
     if elevation <= 0.0:
         return None, (0.0, 0.0), 0.0
-    resolved = Elevation.from_level(float(elevation))
+    resolved = resolve_shadow_params(float(elevation))
     return color_spec, resolved.offset, resolved.blur
 
 

--- a/src/nuiitivet/rendering/elevation.py
+++ b/src/nuiitivet/rendering/elevation.py
@@ -6,7 +6,6 @@ from typing import Tuple
 
 from nuiitivet.common.logging_once import exception_once
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -74,6 +73,20 @@ class Elevation:
         return cls(level=lv, offset=(0, int(round(dy))), blur=float(blur), alpha=float(alpha))
 
 
-def compute_shadow_params(elevation: float):
-    e = Elevation.from_level(elevation)
-    return e.offset, e.blur, e.alpha
+@dataclass(frozen=True)
+class ShadowParams:
+    """Shadow paint parameters derived from an elevation level."""
+
+    offset: Tuple[int, int]
+    blur: float
+    alpha: float
+
+
+def resolve_shadow_params(elevation: float) -> ShadowParams:
+    """Resolve shadow paint parameters for the given elevation."""
+    elevation_spec = Elevation.from_level(elevation)
+    return ShadowParams(
+        offset=elevation_spec.offset,
+        blur=elevation_spec.blur,
+        alpha=elevation_spec.alpha,
+    )

--- a/src/samples/my_widget.py
+++ b/src/samples/my_widget.py
@@ -13,6 +13,8 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.material import App
 from nuiitivet.material import Checkbox, Icon, Text
 from nuiitivet.material.styles import IconStyle
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.modifiers import shadow
 from nuiitivet.observable import Observable
 from nuiitivet.scrolling import ScrollDirection
 from nuiitivet.layout.column import Column
@@ -280,9 +282,11 @@ class MyWidget(ComposableWidget):
                     cross_alignment="start",
                 ),
                 padding=8,
-                style=CardStyle.filled().copy_with(border_radius=6),
+                style=CardStyle.outlined().copy_with(border_radius=6),
                 alignment="start",
-            ),
+            ).modifier(
+                shadow((ColorRole.SHADOW, 0.12), blur=12.0, offset=(0, 6))
+            ),  # Test that modifiers work on Cards
             Card(
                 Column(
                     [

--- a/tests/test_overlay_logic.py
+++ b/tests/test_overlay_logic.py
@@ -1,7 +1,9 @@
 import pytest
 
 from nuiitivet.material import Fab, Button
+from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.styles.button_style import ButtonStyle
+from nuiitivet.rendering.elevation import Elevation
 
 
 def test_resolve_overlay_defaults():
@@ -22,7 +24,7 @@ def test_resolve_overlay_defaults():
         (lambda: Button(label="lbl", style=ButtonStyle.filled()), 0.08, 0.04),
         (lambda: Button(label="lbl", style=ButtonStyle.outlined()), 0.08, 0.04),
         (lambda: Button(label="lbl", style=ButtonStyle.tonal()), 0.08, 0.04),
-        (lambda: Fab(icon="add"), 0.08, 0.04),
+        (lambda: Fab(icon="add"), 0.1, 0.08),
         (lambda: Button(label="lbl", style=ButtonStyle.text()), 0.08, 0.04),
         (lambda: Button(label="lbl", style=ButtonStyle.elevated()), 0.08, 0.04),
     ],
@@ -31,6 +33,39 @@ def test_resolve_overlay_defaults_for_variants(factory, expected_pressed: float,
     b = factory()
     assert abs(b._PRESS_OPACITY - expected_pressed) < 1e-6
     assert abs(b._HOVER_OPACITY - expected_hover) < 1e-6
+
+
+def test_fab_focus_opacity_matches_md3_spec() -> None:
+    fab = Fab(icon="add")
+
+    fab.state.focused = True
+
+    assert abs(fab._get_state_layer_target_opacity() - 0.1) < 1e-6
+
+
+def test_fab_hover_elevation_matches_md3_spec() -> None:
+    fab = Fab(icon="add")
+    enabled = Elevation.from_level(6.0)
+    hovered = Elevation.from_level(8.0)
+
+    assert fab.shadow_color == (ColorRole.SHADOW, enabled.alpha)
+    assert fab.shadow_offset == enabled.offset
+    assert fab.shadow_blur == enabled.blur
+
+    fab.state.hovered = True
+    fab._sync_state_tokens()
+
+    assert fab.shadow_color == (ColorRole.SHADOW, hovered.alpha)
+    assert fab.shadow_offset == hovered.offset
+    assert fab.shadow_blur == hovered.blur
+
+    fab.state.hovered = False
+    fab.state.focused = True
+    fab._sync_state_tokens()
+
+    assert fab.shadow_color == (ColorRole.SHADOW, enabled.alpha)
+    assert fab.shadow_offset == enabled.offset
+    assert fab.shadow_blur == enabled.blur
 
 
 def test_resolve_overlay_with_style_alpha_scaled():


### PR DESCRIPTION
## Summary
Align `Fab` widget with the MD3 FAB tokens documented in `docs/md3/floating_action_buttons.md` and Issue #125.

Closes #125

## Changes
- `FabStyle`: add per-state opacity (`focus_opacity=0.1`, `hover_opacity=0.08`, `pressed_opacity=0.1`) and elevation (`focused=6`, `hovered=8`, `pressed=6` dp) tokens, propagated through `_base()` so all tonal factories pick them up.
- `Fab`: introduce `_sync_state_tokens()` and `_container_elevation()` to drive state-layer opacity and shadow blur/offset/alpha from the active interaction state. Override `_get_state_layer_target_opacity()` so `focused` resolves to `_FOCUS_OPACITY`. Re-sync on init, theme change and on every paint.
- `rendering.elevation`: replace the legacy `compute_shadow_params()` tuple API with a public `resolve_shadow_params()` returning a frozen `ShadowParams` dataclass.
- Migrate `Card`, `Menu`, `Tooltip` and the new shared `_shadow_from_elevation()` helper in `buttons.py` to the new API.
- Tests: update existing FAB overlay opacity expectations and add `test_fab_focus_opacity_matches_md3_spec` / `test_fab_hover_elevation_matches_md3_spec` to lock the spec values in.
- Sample: demonstrate `Card.modifier(shadow(...))` in `my_widget.py`.

## Acceptance Criteria
- [x] FAB focused state-layer opacity is `0.1`
- [x] FAB hovered state-layer opacity is `0.08`
- [x] FAB pressed state-layer opacity is `0.1`
- [x] FAB hovered container elevation resolves to `8 dp`
- [x] FAB enabled / focused / pressed container elevation resolve to `6 dp`
- [x] Tonal variants (`primary`, `secondary`, `tertiary`) and size variants (`s`, `m`, `l`) unchanged
- [x] Tests cover focused / hovered / pressed FAB token behavior

## Verification
- `uv run pytest` — 1203 passed
- `uv run mypy` — 0 errors
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` — clean
