### PR TITLE
docs: improve documentation readability via mkdocs-material configuration

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,29 @@
+/* Sidebar: emphasize section labels so they are clearly distinguishable
+   from leaf page links. Applies to "navigation.sections" layout. */
+
+/* Top-level section labels (e.g. "Layout", "Navigation", "Window") */
+.md-nav--primary .md-nav__item--section>.md-nav__link,
+.md-nav--primary .md-nav__item--section>label.md-nav__link {
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 0.68rem;
+    letter-spacing: 0.06em;
+    color: var(--md-default-fg-color);
+    opacity: 0.75;
+    margin-top: 0.9em;
+    margin-bottom: 0.2em;
+}
+
+/* Nested section labels (one level deeper) get a softer emphasis
+   so the visual hierarchy remains readable. */
+.md-nav--primary .md-nav .md-nav .md-nav__item--nested>.md-nav__link,
+.md-nav--primary .md-nav .md-nav .md-nav__item--nested>label.md-nav__link {
+    font-weight: 600;
+    color: var(--md-primary-fg-color);
+}
+
+/* Slightly tighten leaf links so the contrast with section labels
+   feels intentional rather than accidental. */
+.md-nav--primary .md-nav__item:not(.md-nav__item--section):not(.md-nav__item--nested)>.md-nav__link {
+    font-weight: 400;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,30 +3,109 @@
 
 site_name: Nuiitivet Documentation
 site_url: https://yuksblog.github.io/nuiitivet/
+site_description: A declarative, reactive Python UI framework.
+site_author: Yukinobu Imai
 repo_url: https://github.com/yuksblog/nuiitivet
+repo_name: yuksblog/nuiitivet
+edit_uri: edit/main/docs/
+copyright: Copyright &copy; 2026 Yukinobu Imai
 
 theme:
   name: material
+  language: en
   features:
+    # Navigation
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
+    - navigation.indexes
     - navigation.top
+    - navigation.tracking
+    - navigation.path
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.footer
+    # Table of contents
+    - toc.follow
+    # Search
     - search.suggest
     - search.highlight
+    - search.share
+    # Content
     - content.code.copy
-  palette: 
-    - scheme: default
+    - content.code.annotate
+    - content.tabs.link
+    - content.tooltips
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Roboto
+    code: Roboto Mono
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       primary: teal
       accent: purple
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       primary: teal
       accent: lime
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+
+extra:
+  version:
+    provider: mike
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/yuksblog/nuiitivet
+
+extra_css:
+  - assets/extra.css
+
+markdown_extensions:
+  # Python Markdown
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      toc_depth: 3
+  # PyMdown Extensions
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.mark
+  - pymdownx.tilde
+  - pymdownx.keys
+  - pymdownx.smartsymbols
+  - pymdownx.details
+  - pymdownx.snippets
+  - pymdownx.inlinehilite
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 plugins:
   - search
@@ -36,11 +115,24 @@ plugins:
           paths: [src]
           options:
             docstring_style: google
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            show_source: true
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            merge_init_into_class: true
+            docstring_section_style: table
+            heading_level: 2
+            filters: ["!^_"]
 
 nav:
   - Home: index.md
   - Guide:
-      - Introduction: guide/index.md
+      - guide/index.md
       - Layout:
           - Overview: guide/layout.md
           - Basics: guide/layout_basics.md
@@ -50,7 +142,8 @@ nav:
           - Grid: guide/layout_grid.md
           - Overflow: guide/layout_overflow.md
           - Extras: guide/layout_extras.md
-      - Dialogs: guide/dialogs.md
+      - Dialogs:
+          - guide/dialogs.md
       - Navigation:
           - Overview: guide/navigation.md
           - PageRoute & Animations: guide/navigation_route.md
@@ -75,9 +168,12 @@ nav:
           - Practical Controls: guide/observable/practical-controls.md
           - Thread Safety: guide/observable/thread-safety.md
           - Patterns and Recipes: guide/observable/patterns-and-recipes.md
-      - Async & Threading: guide/threading.md
-      - Interaction: guide/interaction_region.md
-      - Packaging: guide/packaging.md
+      - Async & Threading:
+          - guide/threading.md
+      - Interaction:
+          - guide/interaction_region.md
+      - Packaging:
+          - guide/packaging.md
   - API Reference:
       - Core: api/nuiitivet.md
       - Material Components: api/material.md


### PR DESCRIPTION
## Summary
Enhance the readability and navigability of the published documentation site by enabling additional `mkdocs-material` features, PyMdown extensions, richer `mkdocstrings` rendering options, and a small custom stylesheet that visually distinguishes navigation section labels from leaf links.

Closes #131

## Changes
- **`mkdocs.yml`**
  - Theme features: `navigation.tabs.sticky`, `navigation.indexes`, `navigation.tracking`, `navigation.path`, `navigation.instant(.progress)`, `navigation.footer`, `toc.follow`, `search.share`, `content.code.annotate`, `content.tabs.link`, `content.tooltips`, `content.action.edit`.
  - Site metadata: `site_description`, `site_author`, `repo_name`, `edit_uri`, `copyright`, `extra.social`, `extra.version` (mike).
  - Light/dark palettes via `prefers-color-scheme`; Roboto / Roboto Mono fonts; GitHub repo icon.
  - Markdown extensions: `abbr`, `admonition`, `attr_list`, `def_list`, `footnotes`, `md_in_html`, `tables`, `toc` (with permalinks); PyMdown `betterem`, `caret`, `mark`, `tilde`, `keys`, `smartsymbols`, `details`, `snippets`, `inlinehilite`, `highlight`, `superfences` (mermaid), `tabbed`, `tasklist`, `emoji` (twemoji).
  - mkdocstrings options: symbol-type headings/TOC, separated signatures with annotations, cross-refs, source links, table-style docstring sections, `members_order: source`, `merge_init_into_class`, private-symbol filter.
  - Nav restructured to use section-index pages for `Guide`, `Dialogs`, `Async & Threading`, `Interaction`, and `Packaging`.
- **`docs/assets/extra.css`** (new)
  - Emphasizes top-level navigation section labels and softens nested labels and leaf links for clearer information hierarchy.

## Validation
- [ ] `uv run --group docs mkdocs build` succeeds without new warnings.
- [ ] Sidebar hierarchy is visually distinguishable in light and dark schemes.
- [ ] API reference pages show symbol-type headings and source links.
- [ ] "Edit this page" link points to `edit/main/docs/...`.
- [ ] Mermaid fenced blocks render as diagrams.

## Scope
Documentation tooling and assets only. No source code or public API changes.
