### PR TITLE
refactor(material): consolidate transition specs into MaterialTransitionSpec

### DIFF
--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -58,10 +58,7 @@ if TYPE_CHECKING:
         StandardButtonGroupStyle,
         ConnectedButtonGroupStyle,
     )
-    from .transition_spec import (
-        MaterialSideSheetTransitionSpec,
-        MaterialBottomSheetTransitionSpec,
-    )
+    from .transition_spec import MaterialTransitionSpec
 
 __all__ = [
     "MaterialApp",
@@ -124,8 +121,7 @@ __all__ = [
     "Tooltip",
     "RichTooltip",
     "MaterialTransitions",
-    "MaterialSideSheetTransitionSpec",
-    "MaterialBottomSheetTransitionSpec",
+    "MaterialTransitionSpec",
     "SideSheetStyle",
     "BottomSheetStyle",
     "SideSheet",
@@ -207,8 +203,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "RichTooltip": ("tooltip", "RichTooltip"),
     "MaterialLoadingIndicatorIntent": ("overlay_intents", "MaterialLoadingIndicatorIntent"),
     "MaterialTransitions": ("transition_spec", "MaterialTransitions"),
-    "MaterialSideSheetTransitionSpec": ("transition_spec", "MaterialSideSheetTransitionSpec"),
-    "MaterialBottomSheetTransitionSpec": ("transition_spec", "MaterialBottomSheetTransitionSpec"),
+    "MaterialTransitionSpec": ("transition_spec", "MaterialTransitionSpec"),
     "SideSheetStyle": ("styles.sheet_style", "SideSheetStyle"),
     "BottomSheetStyle": ("styles.sheet_style", "BottomSheetStyle"),
     "SideSheet": ("sheet", "SideSheet"),

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -21,10 +21,7 @@ from .overlay_visual_state import MaterialOverlayLayerComposer
 from .sheet import BottomSheet, SideSheet
 from .transition_spec import (
     MaterialTransitions,
-    MaterialBottomSheetTransitionSpec,
-    MaterialDialogTransitionSpec,
-    MaterialSideSheetTransitionSpec,
-    MaterialSnackbarTransitionSpec,
+    MaterialTransitionSpec,
 )
 
 from .intents import AlertDialogIntent, LoadingIntent
@@ -112,7 +109,7 @@ class MaterialOverlay(Overlay):
         dismiss_on_outside_tap: bool | None = None,
         timeout: float | None = None,
         position: OverlayPosition | None = None,
-        transition: MaterialDialogTransitionSpec | None = None,
+        transition: MaterialTransitionSpec | None = None,
     ) -> OverlayHandle[Any]:
         if dismiss_on_outside_tap is None:
             dismiss_on_outside_tap = True
@@ -135,7 +132,7 @@ class MaterialOverlay(Overlay):
         dialog: Widget | Route | Any,
         *,
         dismiss_on_outside_tap: bool,
-        transition: MaterialDialogTransitionSpec | None = None,
+        transition: MaterialTransitionSpec | None = None,
     ) -> Route:
         """Normalize dialog input to a Route.
 
@@ -165,7 +162,7 @@ class MaterialOverlay(Overlay):
         message: str,
         *,
         duration: float = 3.0,
-        transition: MaterialSnackbarTransitionSpec | None = None,
+        transition: MaterialTransitionSpec | None = None,
     ) -> OverlayHandle[None]:
         return self.show_modeless(
             Snackbar(str(message)),
@@ -219,7 +216,7 @@ class MaterialOverlay(Overlay):
         sheet: SideSheet,
         *,
         dismiss_on_outside_tap: bool = True,
-        transition: MaterialSideSheetTransitionSpec | None = None,
+        transition: MaterialTransitionSpec | None = None,
     ) -> OverlayHandle[Any]:
         """Display a modal side sheet.
 
@@ -256,7 +253,7 @@ class MaterialOverlay(Overlay):
         sheet: BottomSheet,
         *,
         dismiss_on_outside_tap: bool = True,
-        transition: MaterialBottomSheetTransitionSpec | None = None,
+        transition: MaterialTransitionSpec | None = None,
     ) -> OverlayHandle[Any]:
         """Display a modal bottom sheet sliding up from the bottom edge.
 

--- a/src/nuiitivet/material/transition_spec.py
+++ b/src/nuiitivet/material/transition_spec.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from typing import Literal
 
@@ -58,18 +58,21 @@ def _default_snackbar_exit() -> TransitionDefinition:
     )
 
 
-def _default_side_sheet_enter() -> TransitionDefinition:
-    # Default: right-side sheet slides in from right edge (1.0 = full width)
+def _default_side_sheet_enter(side: Literal["right", "left"] = "right") -> TransitionDefinition:
+    # Default: right-side sheet slides in from right edge (1.0 = full width).
+    # `side="left"` slides in from the left edge instead.
+    sign = 1.0 if side == "right" else -1.0
     return TransitionDefinition(
         motion=EXPRESSIVE_DEFAULT_EFFECTS,
-        pattern=FractionalSlidePattern(start_x=1.0, end_x=0.0),
+        pattern=FractionalSlidePattern(start_x=sign, end_x=0.0),
     )
 
 
-def _default_side_sheet_exit() -> TransitionDefinition:
+def _default_side_sheet_exit(side: Literal["right", "left"] = "right") -> TransitionDefinition:
+    sign = 1.0 if side == "right" else -1.0
     return TransitionDefinition(
         motion=EXPRESSIVE_DEFAULT_EFFECTS,
-        pattern=FractionalSlidePattern(start_x=0.0, end_x=1.0),
+        pattern=FractionalSlidePattern(start_x=0.0, end_x=sign),
     )
 
 
@@ -88,43 +91,19 @@ def _default_bottom_sheet_exit() -> TransitionDefinition:
 
 
 @dataclass(frozen=True, slots=True)
-class MaterialPageTransitionSpec:
-    """Material default transition token for page navigation."""
+class MaterialTransitionSpec:
+    """Material transition token for overlay/page lifecycle.
 
-    enter: TransitionDefinition = field(default_factory=_default_page_enter)
-    exit: TransitionDefinition = field(default_factory=_default_page_exit)
+    Carries `enter` / `exit_` `TransitionDefinition`s plus a `barrier_mode`
+    that controls scrim opacity behavior:
 
+    - ``"none"``  : no scrim (page, snackbar)
+    - ``"fade"``  : scrim fades in/out following progress (dialog, sheets)
+    """
 
-@dataclass(frozen=True, slots=True)
-class MaterialDialogTransitionSpec:
-    """Material default transition token for dialog overlays."""
-
-    enter: TransitionDefinition = field(default_factory=_default_dialog_enter)
-    exit: TransitionDefinition = field(default_factory=_default_dialog_exit)
-
-
-@dataclass(frozen=True, slots=True)
-class MaterialSnackbarTransitionSpec:
-    """Material default transition token for snackbars."""
-
-    enter: TransitionDefinition = field(default_factory=_default_snackbar_enter)
-    exit: TransitionDefinition = field(default_factory=_default_snackbar_exit)
-
-
-@dataclass(frozen=True, slots=True)
-class MaterialSideSheetTransitionSpec:
-    """Material transition token for modal side sheets."""
-
-    enter: TransitionDefinition = field(default_factory=_default_side_sheet_enter)
-    exit: TransitionDefinition = field(default_factory=_default_side_sheet_exit)
-
-
-@dataclass(frozen=True, slots=True)
-class MaterialBottomSheetTransitionSpec:
-    """Material transition token for modal bottom sheets."""
-
-    enter: TransitionDefinition = field(default_factory=_default_bottom_sheet_enter)
-    exit: TransitionDefinition = field(default_factory=_default_bottom_sheet_exit)
+    enter: TransitionDefinition
+    exit_: TransitionDefinition
+    barrier_mode: Literal["none", "fade"] = "none"
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,85 +111,73 @@ class _MaterialTransitionPresets:
     def page(
         self,
         enter: TransitionDefinition | None = None,
-        exit: TransitionDefinition | None = None,
-    ) -> MaterialPageTransitionSpec:
+        exit_: TransitionDefinition | None = None,
+    ) -> MaterialTransitionSpec:
         """Create a Material page transition token."""
-        return MaterialPageTransitionSpec(
-            enter=enter or _default_page_enter(),
-            exit=exit or _default_page_exit(),
+        return MaterialTransitionSpec(
+            enter=enter if enter is not None else _default_page_enter(),
+            exit_=exit_ if exit_ is not None else _default_page_exit(),
+            barrier_mode="none",
         )
 
     def dialog(
         self,
         enter: TransitionDefinition | None = None,
-        exit: TransitionDefinition | None = None,
-    ) -> MaterialDialogTransitionSpec:
+        exit_: TransitionDefinition | None = None,
+    ) -> MaterialTransitionSpec:
         """Create a Material dialog transition token."""
-        return MaterialDialogTransitionSpec(
-            enter=enter or _default_dialog_enter(),
-            exit=exit or _default_dialog_exit(),
+        return MaterialTransitionSpec(
+            enter=enter if enter is not None else _default_dialog_enter(),
+            exit_=exit_ if exit_ is not None else _default_dialog_exit(),
+            barrier_mode="fade",
         )
 
     def snackbar(
         self,
         enter: TransitionDefinition | None = None,
-        exit: TransitionDefinition | None = None,
-    ) -> MaterialSnackbarTransitionSpec:
+        exit_: TransitionDefinition | None = None,
+    ) -> MaterialTransitionSpec:
         """Create a Material snackbar transition token."""
-        return MaterialSnackbarTransitionSpec(
-            enter=enter or _default_snackbar_enter(),
-            exit=exit or _default_snackbar_exit(),
+        return MaterialTransitionSpec(
+            enter=enter if enter is not None else _default_snackbar_enter(),
+            exit_=exit_ if exit_ is not None else _default_snackbar_exit(),
+            barrier_mode="none",
         )
 
     def side_sheet(
         self,
         side: Literal["right", "left"] = "right",
         enter: TransitionDefinition | None = None,
-        exit: TransitionDefinition | None = None,
-    ) -> MaterialSideSheetTransitionSpec:
+        exit_: TransitionDefinition | None = None,
+    ) -> MaterialTransitionSpec:
         """Create a Material side sheet transition token.
 
         Args:
             side: Which edge the sheet slides in from.
             enter: Custom enter transition definition.
-            exit: Custom exit transition definition.
+            exit_: Custom exit transition definition.
         """
-        sign = 1.0 if side == "right" else -1.0
-        return MaterialSideSheetTransitionSpec(
-            enter=enter
-            or TransitionDefinition(
-                motion=EXPRESSIVE_DEFAULT_EFFECTS,
-                pattern=FractionalSlidePattern(start_x=sign, end_x=0.0),
-            ),
-            exit=exit
-            or TransitionDefinition(
-                motion=EXPRESSIVE_DEFAULT_EFFECTS,
-                pattern=FractionalSlidePattern(start_x=0.0, end_x=sign),
-            ),
+        return MaterialTransitionSpec(
+            enter=enter if enter is not None else _default_side_sheet_enter(side),
+            exit_=exit_ if exit_ is not None else _default_side_sheet_exit(side),
+            barrier_mode="fade",
         )
 
     def bottom_sheet(
         self,
         enter: TransitionDefinition | None = None,
-        exit: TransitionDefinition | None = None,
-    ) -> MaterialBottomSheetTransitionSpec:
+        exit_: TransitionDefinition | None = None,
+    ) -> MaterialTransitionSpec:
         """Create a Material bottom sheet transition token.
 
         Args:
             enter: Custom enter transition definition.
-            exit: Custom exit transition definition.
+            exit_: Custom exit transition definition.
         """
-        return MaterialBottomSheetTransitionSpec(
-            enter=enter
-            or TransitionDefinition(
-                motion=EXPRESSIVE_DEFAULT_EFFECTS,
-                pattern=FractionalSlidePattern(start_y=1.0, end_y=0.0),
-            ),
-            exit=exit
-            or TransitionDefinition(
-                motion=EXPRESSIVE_DEFAULT_EFFECTS,
-                pattern=FractionalSlidePattern(start_y=0.0, end_y=1.0),
-            ),
+        return MaterialTransitionSpec(
+            enter=enter if enter is not None else _default_bottom_sheet_enter(),
+            exit_=exit_ if exit_ is not None else _default_bottom_sheet_exit(),
+            barrier_mode="fade",
         )
 
 
@@ -218,10 +185,6 @@ MaterialTransitions = _MaterialTransitionPresets()
 
 
 __all__ = [
-    "MaterialBottomSheetTransitionSpec",
-    "MaterialDialogTransitionSpec",
-    "MaterialPageTransitionSpec",
-    "MaterialSideSheetTransitionSpec",
-    "MaterialSnackbarTransitionSpec",
+    "MaterialTransitionSpec",
     "MaterialTransitions",
 ]

--- a/src/nuiitivet/material/transition_visual_spec.py
+++ b/src/nuiitivet/material/transition_visual_spec.py
@@ -10,13 +10,7 @@ from nuiitivet.navigation.transition_spec import (
     TransitionSpec,
 )
 
-from .transition_spec import (
-    MaterialDialogTransitionSpec,
-    MaterialPageTransitionSpec,
-    MaterialSnackbarTransitionSpec,
-    MaterialSideSheetTransitionSpec,
-    MaterialBottomSheetTransitionSpec,
-)
+from .transition_spec import MaterialTransitionSpec
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,45 +42,35 @@ def resolve_material_transition_visual_spec(
             barrier_opacity=None,
         )
 
-    # Common logic for Material specs that use TransitionDefinition
-    definition = None
-    barrier: float | None = None
+    if not isinstance(transition_spec, MaterialTransitionSpec):
+        # Unknown spec kind: pass-through active state.
+        return MaterialTransitionVisualSpec(
+            content_opacity=1.0,
+            content_scale=(1.0, 1.0),
+            content_translation=(0.0, 0.0),
+            content_translation_fraction=(0.0, 0.0),
+            barrier_opacity=None,
+        )
 
-    if isinstance(transition_spec, MaterialPageTransitionSpec):
-        if phase is TransitionPhase.ENTER:
-            definition = transition_spec.enter
-        elif phase is TransitionPhase.EXIT:
-            definition = transition_spec.exit
-        # Page transitions don't have a barrier
-        barrier = None
+    # Resolve enter/exit definition
+    if phase is TransitionPhase.ENTER:
+        definition = transition_spec.enter
+    elif phase is TransitionPhase.EXIT:
+        definition = transition_spec.exit_
+    else:
+        definition = None
 
-    elif isinstance(transition_spec, MaterialDialogTransitionSpec):
+    # Resolve barrier opacity from barrier_mode
+    barrier: float | None
+    if transition_spec.barrier_mode == "fade":
         if phase is TransitionPhase.ENTER:
-            definition = transition_spec.enter
-            barrier = p  # Default linear fade for barrier
-        elif phase is TransitionPhase.EXIT:
-            definition = transition_spec.exit
-            barrier = 1.0 - p
-        else:
-            barrier = 1.0
-
-    elif isinstance(transition_spec, MaterialSnackbarTransitionSpec):
-        if phase is TransitionPhase.ENTER:
-            definition = transition_spec.enter
-        elif phase is TransitionPhase.EXIT:
-            definition = transition_spec.exit
-        # Snakebars don't have a barrier (or pass-through)
-        barrier = None
-
-    elif isinstance(transition_spec, (MaterialSideSheetTransitionSpec, MaterialBottomSheetTransitionSpec)):
-        if phase is TransitionPhase.ENTER:
-            definition = transition_spec.enter
             barrier = p
         elif phase is TransitionPhase.EXIT:
-            definition = transition_spec.exit
             barrier = 1.0 - p
         else:
             barrier = 1.0
+    else:  # "none"
+        barrier = None
 
     if definition is not None:
         visuals = definition.pattern.resolve(p)

--- a/src/nuiitivet/material/transitions.py
+++ b/src/nuiitivet/material/transitions.py
@@ -6,7 +6,7 @@ Users should prefer this module over constructing raw definitions.
 Example:
     MaterialTransitions.dialog(
         enter=FadeIn() | ScaleIn(),
-        exit=FadeOut(duration=0.2),
+        exit_=FadeOut(duration=0.2),
     )
 """
 

--- a/src/samples/navigation/route.py
+++ b/src/samples/navigation/route.py
@@ -1,7 +1,15 @@
 import nuiitivet as nv
 
-from nuiitivet.material import (FadeIn, FadeOut, App, MaterialTransitions,
-                                SlideInVertically, SlideOutVertically, Text, Button)
+from nuiitivet.material import (
+    FadeIn,
+    FadeOut,
+    App,
+    MaterialTransitions,
+    SlideInVertically,
+    SlideOutVertically,
+    Text,
+    Button,
+)
 from nuiitivet.layout.column import Column
 from nuiitivet.navigation import Navigator, PageRoute, Transitions
 from nuiitivet.widgeting.widget import ComposableWidget
@@ -34,7 +42,7 @@ class HomeScreen(ComposableWidget):
         def navigate_with_custom_animation() -> None:
             custom_transition = MaterialTransitions.page(
                 enter=FadeIn() | SlideInVertically(initial_offset_y=50.0),
-                exit=FadeOut() | SlideOutVertically(target_offset_y=50.0),
+                exit_=FadeOut() | SlideOutVertically(target_offset_y=50.0),
             )
             route = PageRoute(
                 builder=lambda: DetailsScreen(),
@@ -54,8 +62,11 @@ class HomeScreen(ComposableWidget):
             gap=12,
             children=[
                 Text("Home Screen"),
-                Button("Go to Details (Custom Animation)",
-                       on_click=navigate_with_custom_animation, style=ButtonStyle.filled()),
+                Button(
+                    "Go to Details (Custom Animation)",
+                    on_click=navigate_with_custom_animation,
+                    style=ButtonStyle.filled(),
+                ),
                 Button("Go to Details (Instant)", on_click=navigate_instantly, style=ButtonStyle.filled()),
             ],
         )

--- a/src/samples/overlay_navigator_demo.py
+++ b/src/samples/overlay_navigator_demo.py
@@ -64,7 +64,7 @@ class HomePage(ComposableWidget):
             # Demonstrate custom transition: ScaleIn + FadeIn -> FadeOut + SlideDown
             transition = MaterialTransitions.dialog(
                 enter=FadeIn() | ScaleIn(initial_scale=0.5),
-                exit=SlideOutVertically(target_offset_y=50, duration=0.4),
+                exit_=SlideOutVertically(target_offset_y=50, duration=0.4),
             )
             result = await Overlay.root().dialog(HelloDialogIntent(), transition=transition)
             if result.value == "OK":

--- a/tests/test_bottom_sheet.py
+++ b/tests/test_bottom_sheet.py
@@ -5,7 +5,7 @@ import pytest
 from nuiitivet.material.sheet import BottomSheet
 from nuiitivet.material.styles.sheet_style import BottomSheetStyle
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.transition_spec import MaterialBottomSheetTransitionSpec, MaterialTransitions
+from nuiitivet.material.transition_spec import MaterialTransitionSpec, MaterialTransitions
 from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgets.box import Box
@@ -43,19 +43,20 @@ def test_bottom_sheet_style_is_immutable():
 
 
 # ---------------------------------------------------------------------------
-# MaterialBottomSheetTransitionSpec tests
+# MaterialTransitionSpec (bottom sheet) tests
 # ---------------------------------------------------------------------------
 
 
 def test_bottom_sheet_transition_spec_defaults():
-    spec = MaterialBottomSheetTransitionSpec()
+    spec = MaterialTransitions.bottom_sheet()
     assert spec.enter is not None
-    assert spec.exit is not None
+    assert spec.exit_ is not None
+    assert spec.barrier_mode == "fade"
 
 
 def test_material_transitions_bottom_sheet():
     spec = MaterialTransitions.bottom_sheet()
-    assert isinstance(spec, MaterialBottomSheetTransitionSpec)
+    assert isinstance(spec, MaterialTransitionSpec)
     # Enter pattern should slide from positive y fraction (bottom)
     visuals = spec.enter.pattern.resolve(0.0)
     assert visuals.translate_y_fraction is not None
@@ -65,8 +66,8 @@ def test_material_transitions_bottom_sheet():
 def test_material_transitions_bottom_sheet_exit_direction():
     spec = MaterialTransitions.bottom_sheet()
     # Exit pattern should slide to positive y fraction (back down)
-    visuals_start = spec.exit.pattern.resolve(0.0)
-    visuals_end = spec.exit.pattern.resolve(1.0)
+    visuals_start = spec.exit_.pattern.resolve(0.0)
+    visuals_end = spec.exit_.pattern.resolve(1.0)
     assert visuals_start.translate_y_fraction == pytest.approx(0.0)
     assert visuals_end.translate_y_fraction == pytest.approx(1.0)
 
@@ -80,8 +81,8 @@ def test_material_transitions_bottom_sheet_custom_exit():
         motion=EXPRESSIVE_DEFAULT_EFFECTS,
         pattern=FadePattern(start_alpha=1.0, end_alpha=0.0),
     )
-    spec = MaterialTransitions.bottom_sheet(exit=custom_exit)
-    assert spec.exit is custom_exit
+    spec = MaterialTransitions.bottom_sheet(exit_=custom_exit)
+    assert spec.exit_ is custom_exit
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +144,7 @@ def test_bottom_sheet_transition_auto_uses_height():
 def test_bottom_sheet_transition_fallback_for_none_height():
     """Fractional slide is dimension-independent: works regardless of height value."""
     spec = MaterialTransitions.bottom_sheet()
-    visuals_end = spec.exit.pattern.resolve(1.0)
+    visuals_end = spec.exit_.pattern.resolve(1.0)
     assert visuals_end.translate_y_fraction == pytest.approx(1.0)
 
 

--- a/tests/test_material_transition_spec_structure.py
+++ b/tests/test_material_transition_spec_structure.py
@@ -1,8 +1,7 @@
 """Test structure and defaults of Material transition specs."""
 
 from nuiitivet.material.transition_spec import (
-    MaterialDialogTransitionSpec,
-    MaterialPageTransitionSpec,
+    MaterialTransitionSpec,
     MaterialTransitions,
 )
 from nuiitivet.animation.transition_definition import TransitionDefinition
@@ -18,9 +17,10 @@ from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_EFFECTS
 def test_dialog_spec_defaults():
     spec = MaterialTransitions.dialog()
 
-    assert isinstance(spec, MaterialDialogTransitionSpec)
+    assert isinstance(spec, MaterialTransitionSpec)
+    assert spec.barrier_mode == "fade"
     assert isinstance(spec.enter, TransitionDefinition)
-    assert isinstance(spec.exit, TransitionDefinition)
+    assert isinstance(spec.exit_, TransitionDefinition)
 
     # Check default Dialog Enter: Fade | Scale
     assert isinstance(spec.enter.pattern, CompositePattern)
@@ -42,16 +42,17 @@ def test_dialog_spec_custom():
         pattern=ScalePattern(start_scale_x=0.5),
     )
 
-    spec = MaterialTransitions.dialog(enter=custom_enter, exit=custom_exit)
+    spec = MaterialTransitions.dialog(enter=custom_enter, exit_=custom_exit)
 
     assert spec.enter is custom_enter
-    assert spec.exit is custom_exit
+    assert spec.exit_ is custom_exit
 
 
 def test_page_spec_defaults():
     spec = MaterialTransitions.page()
 
-    assert isinstance(spec, MaterialPageTransitionSpec)
+    assert isinstance(spec, MaterialTransitionSpec)
+    assert spec.barrier_mode == "none"
 
     # Page Default Enter is just Fade
     # Wait, check implementation: Is it FadePattern or Composite?
@@ -71,5 +72,5 @@ def test_page_spec_custom():
 
     assert spec.enter is custom
     # Exit should be default
-    assert isinstance(spec.exit.pattern, FadePattern)
-    assert spec.exit.pattern.start_alpha == 1.0
+    assert isinstance(spec.exit_.pattern, FadePattern)
+    assert spec.exit_.pattern.start_alpha == 1.0

--- a/tests/test_side_sheet.py
+++ b/tests/test_side_sheet.py
@@ -5,7 +5,7 @@ import pytest
 from nuiitivet.material.sheet import SideSheet
 from nuiitivet.material.styles.sheet_style import SideSheetStyle
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.transition_spec import MaterialSideSheetTransitionSpec, MaterialTransitions
+from nuiitivet.material.transition_spec import MaterialTransitionSpec, MaterialTransitions
 from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgets.box import Box
@@ -43,19 +43,20 @@ def test_side_sheet_style_is_immutable():
 
 
 # ---------------------------------------------------------------------------
-# MaterialSideSheetTransitionSpec tests
+# MaterialTransitionSpec (side sheet) tests
 # ---------------------------------------------------------------------------
 
 
 def test_side_sheet_transition_spec_defaults():
-    spec = MaterialSideSheetTransitionSpec()
+    spec = MaterialTransitions.side_sheet()
     assert spec.enter is not None
-    assert spec.exit is not None
+    assert spec.exit_ is not None
+    assert spec.barrier_mode == "fade"
 
 
 def test_material_transitions_side_sheet_right():
     spec = MaterialTransitions.side_sheet(side="right")
-    assert isinstance(spec, MaterialSideSheetTransitionSpec)
+    assert isinstance(spec, MaterialTransitionSpec)
     visuals = spec.enter.pattern.resolve(0.0)
     assert visuals.translate_x_fraction is not None
     assert visuals.translate_x_fraction > 0
@@ -63,7 +64,7 @@ def test_material_transitions_side_sheet_right():
 
 def test_material_transitions_side_sheet_left():
     spec = MaterialTransitions.side_sheet(side="left")
-    assert isinstance(spec, MaterialSideSheetTransitionSpec)
+    assert isinstance(spec, MaterialTransitionSpec)
     visuals = spec.enter.pattern.resolve(0.0)
     assert visuals.translate_x_fraction is not None
     assert visuals.translate_x_fraction < 0
@@ -199,7 +200,7 @@ def test_side_sheet_transition_auto_uses_width():
 def test_side_sheet_transition_fallback_for_non_int_width():
     """Fractional slide is dimension-independent: no fallback calculation needed."""
     spec = MaterialTransitions.side_sheet(side="right")
-    visuals_end = spec.exit.pattern.resolve(1.0)
+    visuals_end = spec.exit_.pattern.resolve(1.0)
     assert visuals_end.translate_x_fraction == pytest.approx(1.0)
 
 


### PR DESCRIPTION
Closes #128.

## Summary

Consolidates Material transition spec defaults to address the asymmetry/dead-code issues
reported in #128, and merges the per-kind spec dataclasses into a single
`MaterialTransitionSpec` that carries its barrier behavior as data.

## Changes

### Phase 1 — defaults are the single source of truth
- Parameterize `_default_side_sheet_enter/exit()` with a `side` arg.
- Route `MaterialTransitions.side_sheet()` / `.bottom_sheet()` through these helpers instead of re-building `TransitionDefinition` inline.

### Phase 2 — explicit `is None` checks
- Replace `enter or _default_*()` with `enter if enter is not None else _default_*()` across all preset methods. Avoids relying on `TransitionDefinition.__bool__`.

### Phase 3 — rename `exit` → `exit_` (breaking)
- `exit` shadowed the Python builtin. Renamed the field and the preset keyword argument. All call sites in `overlay.py`, `transition_visual_spec.py`, samples, and tests updated.

### Phase 4 — single `MaterialTransitionSpec` (breaking)
- Replace `MaterialPageTransitionSpec` / `MaterialDialogTransitionSpec` / `MaterialSnackbarTransitionSpec` / `MaterialSideSheetTransitionSpec` / `MaterialBottomSheetTransitionSpec` with a single `MaterialTransitionSpec(enter, exit_, barrier_mode)`.
- New `barrier_mode: Literal["none", "fade"]` makes the scrim behavior data instead of type. `page` / `snackbar` use `"none"`, `dialog` / `side_sheet` / `bottom_sheet` use `"fade"`.
- `transition_visual_spec.py` drops the per-kind `isinstance` dispatch in favor of reading `spec.barrier_mode`.

## Breaking Changes

- `exit` → `exit_` on `MaterialTransitionSpec` and on `MaterialTransitions.{page,dialog,snackbar,side_sheet,bottom_sheet}()`.
- The five per-kind dataclasses are removed. Use `MaterialTransitionSpec` instead. `MaterialTransitions.*()` signatures are unchanged otherwise.

Per project policy, future-proofing is favored over backward compatibility, so these are applied in one pass.

## Verification

- `uv run pytest` — 1203 passed
- `uv run mypy` — Success: no issues found in 507 source files
- `uv run flake8 src tests --max-line-length=120 --extend-ignore=E203` — clean