### PR TITLE
feat(will_pop): add synchronous re-entrancy guard to WillPopScope

### DIFF
--- a/src/nuiitivet/modifiers/will_pop.py
+++ b/src/nuiitivet/modifiers/will_pop.py
@@ -10,7 +10,6 @@ from ..rendering.sizing import SizingLike
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -34,6 +33,7 @@ class WillPopScope(Widget):
     ) -> None:
         super().__init__(width=width, height=height, padding=padding, max_children=1, overflow_policy="replace_last")
         self._on_will_pop = on_will_pop
+        self._handling: bool = False
         self.add_child(child)
 
     def _child(self) -> Optional[Widget]:
@@ -59,11 +59,21 @@ class WillPopScope(Widget):
                     exception_once(_logger, "will_pop_child_handle_back_exc", "Child handle_back_event raised")
                     return True
 
+        if self._handling:
+            return False
+
+        self._handling = True
         try:
             return bool(self._on_will_pop())
         except Exception:
             exception_once(_logger, "will_pop_callback_exc", "on_will_pop callback raised")
             return True
+        finally:
+            self._handling = False
+
+    def on_unmount(self) -> None:
+        self._handling = False
+        super().on_unmount()
 
     def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> Tuple[int, int]:
         child = self._child()

--- a/tests/test_will_pop.py
+++ b/tests/test_will_pop.py
@@ -120,3 +120,94 @@ def test_navigator_pop_calls_will_pop_inside_build() -> None:
     assert calls == ["called"]
     assert nav.can_pop() is True
     assert outgoing.unmounted is False
+
+
+# ---------------------------------------------------------------------------
+# Re-entrancy guard (#53)
+# ---------------------------------------------------------------------------
+
+
+def test_reentrant_back_is_dropped_while_handler_is_active() -> None:
+    """A second back request while on_will_pop is executing must be dropped."""
+    calls: list[str] = []
+    scope_ref: list[object] = []
+
+    def on_will_pop() -> bool:
+        calls.append("enter")
+        # Simulate re-entrant call (e.g. rapid Esc).
+        scope = scope_ref[0]
+        handler = getattr(scope, "handle_back_event", None)
+        assert callable(handler)
+        result = handler()
+        calls.append(f"reentrant={result}")
+        return False
+
+    w = _FlagWidget()
+    scoped = w.modifier(will_pop(on_will_pop))
+    scope_ref.append(scoped)
+
+    handler = getattr(scoped, "handle_back_event", None)
+    assert callable(handler)
+    result = handler()
+
+    assert result is False
+    assert calls == ["enter", "reentrant=False"]
+
+
+def test_handling_flag_is_released_after_normal_return() -> None:
+    """_handling must be False after a successful callback invocation."""
+    scope_ref: list[object] = []
+
+    def on_will_pop() -> bool:
+        return False
+
+    w = _FlagWidget()
+    scoped = w.modifier(will_pop(on_will_pop))
+    scope_ref.append(scoped)
+
+    handler = getattr(scoped, "handle_back_event", None)
+    assert callable(handler)
+    handler()
+
+    assert getattr(scoped, "_handling", True) is False
+
+
+def test_handling_flag_is_released_after_exception() -> None:
+    """_handling must be False even when the callback raises."""
+
+    def on_will_pop() -> bool:
+        raise RuntimeError("boom")
+
+    w = _FlagWidget()
+    scoped = w.modifier(will_pop(on_will_pop))
+
+    handler = getattr(scoped, "handle_back_event", None)
+    assert callable(handler)
+    result = handler()  # fail-open → True
+
+    assert result is True
+    assert getattr(scoped, "_handling", True) is False
+
+
+def test_normal_pop_allowed_works_after_previous_cancel() -> None:
+    """After a cancelled pop, a subsequent allow should still propagate."""
+    call_count = 0
+
+    def on_will_pop() -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count >= 2  # first call cancels, second allows
+
+    nav = Navigator.routes(
+        [
+            PageRoute(builder=lambda: _FlagWidget(label="root")),
+            PageRoute(builder=lambda: _FlagWidget(label="outgoing").modifier(will_pop(on_will_pop))),
+        ]
+    )
+    nav.rebuild()
+
+    nav.pop()
+    assert nav.can_pop() is True  # first pop was cancelled
+
+    nav.pop()
+    assert nav.can_pop() is False  # second pop was allowed


### PR DESCRIPTION
## Summary

Add a synchronous re-entrancy guard to `WillPopScope` so that back requests arriving while an `on_will_pop` callback is actively executing are automatically dropped at the framework level.

## Motivation

Previously, apps had to maintain their own guard flag (e.g., `_confirm_open`) to prevent duplicate dialogs or repeated side effects when Back/Esc was triggered rapidly. This was boilerplate that every `will_pop` user had to write correctly.

## Changes

- **`src/nuiitivet/modifiers/will_pop.py`**: Added `_handling: bool` flag to `WillPopScope`.
  - Set to `True` before invoking `_on_will_pop()`, released in `finally` (covers both normal return and exception).
  - Cleared in `on_unmount()` as a safeguard for future async support (#135).
  - Re-entrant calls to `handle_back_event()` return `False` (drop) while `_handling` is `True`.
- **`tests/test_will_pop.py`**: Added 4 tests covering the Acceptance Criteria of #53.
  - Re-entrant call is dropped while handler is active
  - Flag is released after normal return
  - Flag is released after exception (fail-open)
  - Normal pop works correctly after a previous cancel

## Non-Goals

- Async callback support (`Awaitable` path) is tracked separately in #135.
- No API changes — existing `on_will_pop: Callable[[], bool]` callers are unaffected.

## Related

Closes #53