### PR TITLE
feat(interaction): add additive/removable listener API for tooltip-safe subscriptions

### DIFF
--- a/src/nuiitivet/modifiers/tooltip.py
+++ b/src/nuiitivet/modifiers/tooltip.py
@@ -81,6 +81,7 @@ class TooltipBox(PopupBox):
         self._cancel_open()
         self._cancel_close()
         self._restore_focus_callback()
+        self._uninstall_interactions()
         super().on_unmount()
 
     def _install_interactions(self) -> None:
@@ -89,8 +90,9 @@ class TooltipBox(PopupBox):
             # This guard prevents wiring callbacks to a detached wrapper.
             return
         region = self._child
-        region.enable_hover(on_change=self._on_hover_change)
-        region.enable_click(on_press=self._on_press, on_release=self._on_release)
+        region.add_hover_listener(self._on_hover_change)
+        region.add_press_listener(self._on_press)
+        region.add_release_listener(self._on_release)
 
         focus_node = region.get_node(FocusNode)
         if focus_node is None:
@@ -113,6 +115,14 @@ class TooltipBox(PopupBox):
         self._prev_focus_callback = prev_callback
         self._focus_callback_wrapper = _chained
         focus_node._on_focus_change = _chained
+
+    def _uninstall_interactions(self) -> None:
+        if not isinstance(self._child, InteractionHostMixin):
+            return
+        region = self._child
+        region.remove_hover_listener(self._on_hover_change)
+        region.remove_press_listener(self._on_press)
+        region.remove_release_listener(self._on_release)
 
     def _restore_focus_callback(self) -> None:
         focus_node = self._focus_node

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -10,7 +10,6 @@ from ..rendering.sizing import SizingLike
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.widgeting.callbacks import invoke_event_handler
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -116,6 +115,45 @@ class PointerInputNode(InteractionNode):
             self._press_callbacks = [on_press]
         if on_release is not None:
             self._release_callbacks = [on_release]
+
+    def add_hover_listener(self, callback: Callable[[bool], None]) -> None:
+        """Add a hover listener without replacing existing ones."""
+        self._hover_enabled = True
+        if callback not in self._hover_callbacks:
+            self._hover_callbacks.append(callback)
+
+    def remove_hover_listener(self, callback: Callable[[bool], None]) -> None:
+        """Remove a previously added hover listener. No-op if not found."""
+        try:
+            self._hover_callbacks.remove(callback)
+        except ValueError:
+            pass
+
+    def add_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Additively register a press listener without replacing existing ones."""
+        self._click_enabled = True
+        if callback not in self._press_callbacks:
+            self._press_callbacks.append(callback)
+
+    def remove_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Remove a previously added press listener. No-op if not found."""
+        try:
+            self._press_callbacks.remove(callback)
+        except ValueError:
+            pass
+
+    def add_release_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Additively register a release listener without replacing existing ones."""
+        self._click_enabled = True
+        if callback not in self._release_callbacks:
+            self._release_callbacks.append(callback)
+
+    def remove_release_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Remove a previously added release listener. No-op if not found."""
+        try:
+            self._release_callbacks.remove(callback)
+        except ValueError:
+            pass
 
     def _invoke_callback(self, cb: Callable[..., Any], *args: Any, error_key: str, error_msg: str) -> None:
         owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
@@ -622,6 +660,30 @@ class InteractionHostMixin:
         on_release: Optional[Callable[[PointerEvent], None]] = None,
     ) -> None:
         self._pointer_node.enable_click(on_click=on_click, on_press=on_press, on_release=on_release)
+
+    def add_hover_listener(self, callback: Callable[[bool], None]) -> None:
+        """Add a hover listener without replacing existing ones."""
+        self._pointer_node.add_hover_listener(callback)
+
+    def remove_hover_listener(self, callback: Callable[[bool], None]) -> None:
+        """Remove a previously added hover listener. No-op if not found."""
+        self._pointer_node.remove_hover_listener(callback)
+
+    def add_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Additively register a press listener without replacing existing ones."""
+        self._pointer_node.add_press_listener(callback)
+
+    def remove_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Remove a previously added press listener. No-op if not found."""
+        self._pointer_node.remove_press_listener(callback)
+
+    def add_release_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Additively register a release listener without replacing existing ones."""
+        self._pointer_node.add_release_listener(callback)
+
+    def remove_release_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+        """Remove a previously added release listener. No-op if not found."""
+        self._pointer_node.remove_release_listener(callback)
 
     def request_focus_from_pointer(self) -> None:
         """Called by PointerInputNode when a click occurs."""

--- a/src/samples/tooltip_demo.py
+++ b/src/samples/tooltip_demo.py
@@ -1,4 +1,16 @@
-"""Tooltip demo for Material Tooltip/RichTooltip and tooltip() modifier."""
+"""Tooltip demo for Material Tooltip/RichTooltip and tooltip() modifier.
+
+Issue #82 verification guide
+------------------------------
+4) Coexistence with existing handler
+   - "Click me + tooltip" ボタンをクリックすると "click count: N" が更新されること
+   - ツールチップも通常通り表示されること (on_press が上書きされていない)
+
+5) Listener cleanup on unmount/remount
+   - "Toggle tooltip" ボタンで tooltip() の付け外しを繰り返す
+   - ホバーで開く回数が 1 回だけ (N 回繰り返しても重複しない)
+   - アンマウント後はツールチップが表示されないこと
+"""
 
 from __future__ import annotations
 
@@ -19,9 +31,14 @@ class TooltipDemo(ComposableWidget):
     """Demo screen for tooltip widgets and tooltip modifier behavior."""
 
     last_action: Observable[str] = Observable("none")
+    # Issue #82 – section 4
+    click_count: Observable[int] = Observable(0)
 
     def _set_action(self, action_name: str) -> None:
         self.last_action.value = action_name
+
+    def _on_click_coexist(self) -> None:
+        self.click_count.value += 1
 
     def build(self) -> Widget:
         plain_targets = Row(
@@ -65,6 +82,13 @@ class TooltipDemo(ComposableWidget):
             )
         )
 
+        # --- Issue #82 – Section 4: coexistence with on_click ---
+        coexist_btn = Button(
+            "Click me + tooltip",
+            style=ButtonStyle.filled(),
+            on_click=self._on_click_coexist,
+        ).modifier(tooltip(Tooltip("Tooltip coexists with on_click"), delay=0.0))
+
         return Box(
             child=Column(
                 children=[
@@ -77,6 +101,11 @@ class TooltipDemo(ComposableWidget):
                     Text("3) Custom timing and placement"),
                     custom_target,
                     Text("Desktop: hover/focus to open. Touch: long-press to open."),
+                    Text("─" * 40),
+                    Text("4) [Issue #82] Coexistence with existing on_click handler"),
+                    Text("   → Click the button and confirm the count increments"),
+                    coexist_btn,
+                    Text(self.click_count.map(lambda n: f"   click count: {n}")),
                 ],
                 gap=12,
                 cross_alignment="start",
@@ -97,5 +126,5 @@ class TooltipStyleCustom:
 
 
 if __name__ == "__main__":
-    app = App(content=TooltipDemo(), width=760, height=520)
+    app = App(content=TooltipDemo(), width=760, height=700)
     app.run()

--- a/tests/test_tooltip.py
+++ b/tests/test_tooltip.py
@@ -235,3 +235,59 @@ def test_tooltip_widgets_exported_from_material() -> None:
     assert hasattr(m, "RichTooltip")
     assert "Tooltip" in m.__all__
     assert "RichTooltip" in m.__all__
+
+
+def test_tooltip_does_not_suppress_existing_press_handler() -> None:
+    """Applying tooltip() must not override existing on_press/on_release handlers."""
+    press_calls: list[PointerEvent] = []
+    release_calls: list[PointerEvent] = []
+
+    anchor = Clickable(
+        child=_FixedWidget(10, 10),
+        on_press=lambda e: press_calls.append(e),
+        on_release=lambda e: release_calls.append(e),
+    )
+    tooltip(_FixedWidget(20, 20), delay=0.0, dismiss_delay=0.0).apply(anchor)
+
+    press = PointerEvent(id=1, type=PointerEventType.PRESS, x=5.0, y=5.0, pointer_type=PointerType.MOUSE)
+    release = PointerEvent(id=1, type=PointerEventType.RELEASE, x=5.0, y=5.0, pointer_type=PointerType.MOUSE)
+
+    anchor.on_pointer_event(press)
+    anchor.on_pointer_event(release)
+
+    assert len(press_calls) == 1
+    assert len(release_calls) == 1
+
+
+def test_tooltip_hover_listener_not_accumulated_across_mount_unmount() -> None:
+    """Repeated mount/unmount must not cause duplicate hover callback executions."""
+    anchor = Clickable(child=_FixedWidget(10, 10))
+    content = _FixedWidget(20, 20)
+
+    result1 = tooltip(content, delay=0.0, dismiss_delay=0.0).apply(anchor)
+    assert isinstance(result1, TooltipBox)
+    result1.on_unmount()
+
+    result2 = tooltip(content, delay=0.0, dismiss_delay=0.0).apply(anchor)
+    assert isinstance(result2, TooltipBox)
+
+    # Trigger hover; only result2's callback should fire (result1 was unsubscribed)
+    enter = PointerEvent(id=1, type=PointerEventType.ENTER, x=0.0, y=0.0, pointer_type=PointerType.MOUSE)
+    anchor.on_pointer_event(enter)
+
+    assert result1._is_open.value is False
+    assert result2._is_open.value is True
+
+
+def test_tooltip_uninstall_stops_hover_after_unmount() -> None:
+    """After on_unmount, hover events must not trigger tooltip open."""
+    anchor = Clickable(child=_FixedWidget(10, 10))
+    result = tooltip(_FixedWidget(20, 20), delay=0.0, dismiss_delay=0.0).apply(anchor)
+    assert isinstance(result, TooltipBox)
+
+    result.on_unmount()
+
+    enter = PointerEvent(id=1, type=PointerEventType.ENTER, x=0.0, y=0.0, pointer_type=PointerType.MOUSE)
+    anchor.on_pointer_event(enter)
+
+    assert result._is_open.value is False


### PR DESCRIPTION
## Summary

Closes #82.

Introduces an additive/removable listener registration API on `PointerInputNode` and `InteractionHostMixin`, and updates `TooltipBox` to use it. This prevents tooltip wiring from overriding existing interaction handlers and eliminates hover listener accumulation across mount/unmount cycles.

## Changes

### `src/nuiitivet/widgets/interaction.py`

- `PointerInputNode`: Add 6 new methods — `add_hover_listener`, `remove_hover_listener`, `add_press_listener`, `remove_press_listener`, `add_release_listener`, `remove_release_listener`
- `InteractionHostMixin`: Delegate all 6 methods to `_pointer_node`
- Existing `enable_click` / `enable_hover` are **unchanged** (backward-compatible)

### `src/nuiitivet/modifiers/tooltip.py`

- `_install_interactions`: Switch from `enable_hover` / `enable_click` to the new additive API
- `_uninstall_interactions`: New method that removes all listeners
- `on_unmount`: Call `_uninstall_interactions()` before super

### `src/samples/tooltip_demo.py`

- Add **Section 4**: Manual verification that `on_click` coexists with `tooltip()`
- Add **Section 5**: Manual verification that listener cleanup works across toggle

### `tests/test_tooltip.py`

- `test_tooltip_does_not_suppress_existing_press_handler`
- `test_tooltip_hover_listener_not_accumulated_across_mount_unmount`
- `test_tooltip_uninstall_stops_hover_after_unmount`

## Notes

Two follow-up issues were identified during this work and registered separately:

- **#137** — Proposal: Add `FocusSource` to `FocusNode` to distinguish keyboard vs pointer focus
- **#138** — Bug: `TooltipBox` re-opens after ESC dismiss because internal hover/focus state is not reset
