### PR TITLE
docs: align quick-start examples with public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,14 +268,11 @@ pip install nuiitivet
 To create an application with Nuiitivet, follow these two steps:
 
 - Inherit from `ComposableWidget` to create a UI component
-- Pass the UI component to `MaterialApp` and start the application
+- Pass the UI component to `App` and start the application
 
 ```python
-from nuiitivet.material.app import MaterialApp
-from nuiitivet.material import Text, Button
-from nuiitivet.layout.column import Column
-from nuiitivet.observable import Observable
-from nuiitivet.widgeting.widget import ComposableWidget
+from nuiitivet import Column, ComposableWidget, Observable
+from nuiitivet.material import App, Text, Button
 
 class CounterApp(ComposableWidget):
     def __init__(self):
@@ -308,8 +305,8 @@ def main():
     # Create counter app
     counter_app = CounterApp()
     
-    # Start with MaterialApp
-    app = MaterialApp(content=counter_app)
+    # Start with App
+    app = App(content=counter_app)
     app.run()
 
 if __name__ == "__main__":

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,12 +16,8 @@ layout: default
 ## Quick Example
 
 ```python
-from nuiitivet.material.app import MaterialApp
-from nuiitivet.material import Text, Button
-from nuiitivet.layout.column import Column
-from nuiitivet.observable import Observable
-from nuiitivet.widgeting.widget import ComposableWidget
-from nuiitivet.material import ButtonStyle
+from nuiitivet import Column, ComposableWidget, Observable
+from nuiitivet.material import App, Text, Button, ButtonStyle
 
 
 class CounterApp(ComposableWidget):
@@ -43,5 +39,5 @@ class CounterApp(ComposableWidget):
     )
 
 
-MaterialApp(home=CounterApp()).run()
+App(content=CounterApp()).run()
 ```


### PR DESCRIPTION
## Summary

This PR updates the quick-start documentation examples to use the intended public API surface.

## Changes

- update the README quick-start sample to prefer facade imports
- use `App` from `nuiitivet.material` instead of importing `MaterialApp` from the submodule in user-facing examples
- use top-level imports for `Column`, `ComposableWidget`, and `Observable` where appropriate
- replace the stale `MaterialApp(home=...)` example with `App(content=...)`

## Why

- keeps user-facing documentation aligned with the public API
- makes examples consistent with existing sample usage
- removes a stale initialization pattern from the docs

## Files changed

- README.md
- docs/index.md

## Related

Closes #142