### PR TITLE
fix: align void/bool callback types with async runtime support

### DIFF
--- a/src/nuiitivet/material/button_group.py
+++ b/src/nuiitivet/material/button_group.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 from typing import (
-    Callable,
     List,
     Literal,
     Optional,

--- a/src/nuiitivet/material/button_group.py
+++ b/src/nuiitivet/material/button_group.py
@@ -31,6 +31,7 @@ from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
 from nuiitivet.rendering.sizing import Sizing, SizingLike
 from nuiitivet.theme.types import ColorSpec
+from nuiitivet.widgeting.callbacks import invoke_event_handler, BoolCallback
 from nuiitivet.widgets.box import Box
 
 if TYPE_CHECKING:
@@ -113,7 +114,7 @@ class GroupButton(InteractiveWidget):
         icon: "Symbol | str | ReadOnlyObservableProtocol | None" = None,
         *,
         selected: "bool | ObservableProtocol[bool]" = False,
-        on_change: Optional[Callable[[bool], None]] = None,
+        on_change: Optional[BoolCallback] = None,
         disabled: "bool | ObservableProtocol[bool]" = False,
         width: SizingLike = None,
         style: "Optional[ButtonGroupStyle]" = None,
@@ -140,7 +141,7 @@ class GroupButton(InteractiveWidget):
         self._icon = icon
 
         # on_change is interceptable by the containing group
-        self._on_change: Optional[Callable[[bool], None]] = on_change
+        self._on_change: Optional[BoolCallback] = on_change
 
         # Selected state
         self._selected_external: "Optional[ObservableProtocol[bool]]" = None
@@ -336,7 +337,13 @@ class GroupButton(InteractiveWidget):
         new_selected = not self._selected
         self._set_selected(new_selected)
         if self._on_change is not None:
-            self._on_change(new_selected)
+            invoke_event_handler(
+                self._on_change,
+                new_selected,
+                error_key="group_button_on_change",
+                error_msg="GroupButton on_change raised",
+                owner_name=type(self).__name__,
+            )
 
     # ------------------------------------------------------------------
     # State management
@@ -793,12 +800,18 @@ class ConnectedButtonGroup(_ButtonGroupBase):
 
             def _make_wrapper(
                 item_idx: int,
-                orig_cb: Optional[Callable[[bool], None]],
-            ) -> Callable[[bool], None]:
+                orig_cb: Optional[BoolCallback],
+            ) -> BoolCallback:
                 def _wrapper(selected: bool) -> None:
                     # 1. Item-level callback fires first
                     if orig_cb is not None:
-                        orig_cb(selected)
+                        invoke_event_handler(
+                            orig_cb,
+                            selected,
+                            error_key="group_button_item_on_change",
+                            error_msg="GroupButton item on_change raised",
+                            owner_name=type(item).__name__,
+                        )
                     # 2. Group selection logic
                     self._handle_group_selection_change(item_idx, selected)
 

--- a/src/nuiitivet/material/buttons.py
+++ b/src/nuiitivet/material/buttons.py
@@ -15,7 +15,7 @@ This module contains the unified Material Design 3 button widgets:
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Optional, Tuple, Type, Union, TYPE_CHECKING, cast
+from typing import Any, Optional, Tuple, Type, Union, TYPE_CHECKING, cast
 
 from nuiitivet.common.logging_once import debug_once, exception_once
 from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol

--- a/src/nuiitivet/material/buttons.py
+++ b/src/nuiitivet/material/buttons.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Optional, Tuple, Type, Union, TYPE_CHECKING, c
 
 from nuiitivet.common.logging_once import debug_once, exception_once
 from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
+from nuiitivet.widgeting.callbacks import invoke_event_handler, VoidCallback, BoolCallback
 from nuiitivet.animation import Animatable, LinearMotion, RgbaTupleConverter
 from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL
 from nuiitivet.material.styles.button_style import ButtonStyle, IconButtonStyle, IconToggleButtonStyle
@@ -304,7 +305,7 @@ class MaterialButtonBase(InteractiveWidget):
         self,
         child: Widget,
         *,
-        on_click: Optional[Callable[[], None]] = None,
+        on_click: Optional[VoidCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
         height: SizingLike = None,
@@ -649,7 +650,7 @@ class Button(MaterialButtonBase):
         label: str | ReadOnlyObservableProtocol[str] | None = None,
         icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str] | None = None,
         *,
-        on_click: Optional[Callable[[], None]] = None,
+        on_click: Optional[VoidCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
         height: SizingLike = None,
@@ -724,7 +725,7 @@ class IconButton(MaterialButtonBase):
         self,
         icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str],
         *,
-        on_click: Optional[Callable[[], None]] = None,
+        on_click: Optional[VoidCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         style: Optional[ButtonStyle] = None,
     ):
@@ -822,7 +823,7 @@ class ToggleButtonBase(MaterialButtonBase):
         icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str] | None = None,
         *,
         selected: bool | ObservableProtocol[bool] = False,
-        on_change: Optional[Callable[[bool], None]] = None,
+        on_change: Optional[BoolCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
         height: SizingLike = None,
@@ -930,7 +931,13 @@ class ToggleButtonBase(MaterialButtonBase):
         self._sync_selected_state()
 
         if self.on_change is not None:
-            self.on_change(new_value)
+            invoke_event_handler(
+                self.on_change,
+                new_value,
+                error_key="toggle_button_on_change",
+                error_msg="ToggleButton on_change raised",
+                owner_name=type(self).__name__,
+            )
 
 
 class ToggleButton(ToggleButtonBase):
@@ -949,7 +956,7 @@ class ToggleButton(ToggleButtonBase):
         icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str] | None = None,
         *,
         selected: bool | ObservableProtocol[bool] = False,
-        on_change: Optional[Callable[[bool], None]] = None,
+        on_change: Optional[BoolCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
         height: SizingLike = None,
@@ -994,7 +1001,7 @@ class IconToggleButton(ToggleButtonBase):
         icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str],
         *,
         selected: bool | ObservableProtocol[bool] = False,
-        on_change: Optional[Callable[[bool], None]] = None,
+        on_change: Optional[BoolCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         style: Optional[IconToggleButtonStyle] = None,
     ):
@@ -1036,7 +1043,7 @@ class Fab(MaterialButtonBase):
         self,
         icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str],
         *,
-        on_click: Optional[Callable[[], None]] = None,
+        on_click: Optional[VoidCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         padding: Optional[Union[int, Tuple[int, int, int, int]]] = None,
         style: Optional[FabStyle] = None,

--- a/src/nuiitivet/material/interactive_widget.py
+++ b/src/nuiitivet/material/interactive_widget.py
@@ -18,6 +18,7 @@ from nuiitivet.theme.types import ColorSpec
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.rendering.sizing import SizingLike
+from nuiitivet.widgets.interaction import VoidCallback
 
 if TYPE_CHECKING:
     from nuiitivet.widgeting.widget import Widget
@@ -53,7 +54,7 @@ class InteractiveWidget(Clickable):
     def __init__(
         self,
         child: Optional["Widget"] = None,
-        on_click: Optional[Callable[[], None]] = None,
+        on_click: Optional[VoidCallback] = None,
         state_layer_color: ColorSpec = ColorRole.ON_SURFACE,
         width: SizingLike = None,
         height: SizingLike = None,

--- a/src/nuiitivet/material/interactive_widget.py
+++ b/src/nuiitivet/material/interactive_widget.py
@@ -8,7 +8,7 @@ handling the State Layer visualization (hover, focus, press states).
 from __future__ import annotations
 
 import logging
-from typing import Callable, Optional, Tuple, Union, Any, TYPE_CHECKING
+from typing import Optional, Tuple, Union, Any, TYPE_CHECKING
 
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.rendering.skia.geometry import make_rect, draw_round_rect

--- a/src/nuiitivet/modifiers/clickable.py
+++ b/src/nuiitivet/modifiers/clickable.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget

--- a/src/nuiitivet/modifiers/clickable.py
+++ b/src/nuiitivet/modifiers/clickable.py
@@ -5,12 +5,12 @@ from typing import Callable, Optional
 
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget
-from ..widgets.interaction import InteractionRegion, ensure_interaction_region
+from ..widgets.interaction import InteractionRegion, VoidCallback, ensure_interaction_region
 
 
 @dataclass(slots=True)
 class ClickableModifier(ModifierElement):
-    on_click: Optional[Callable[[], None]] = None
+    on_click: Optional[VoidCallback] = None
 
     def apply(self, widget: Widget) -> Widget:
         region: InteractionRegion = ensure_interaction_region(widget)
@@ -18,5 +18,5 @@ class ClickableModifier(ModifierElement):
         return region
 
 
-def clickable(on_click: Optional[Callable[[], None]] = None) -> ClickableModifier:
+def clickable(on_click: Optional[VoidCallback] = None) -> ClickableModifier:
     return ClickableModifier(on_click=on_click)

--- a/src/nuiitivet/modifiers/focus.py
+++ b/src/nuiitivet/modifiers/focus.py
@@ -2,14 +2,14 @@ from typing import Callable, Optional
 
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget
-from ..widgets.interaction import FocusNode, ensure_interaction_region
+from ..widgets.interaction import FocusNode, BoolCallback, ensure_interaction_region
 
 
 class FocusableModifier(ModifierElement):
     def __init__(
         self,
         enabled: bool = True,
-        on_focus_change: Optional[Callable[[bool], None]] = None,
+        on_focus_change: Optional[BoolCallback] = None,
         on_key: Optional[Callable[[str, int], bool]] = None,
     ) -> None:
         self.enabled = enabled
@@ -47,7 +47,7 @@ class FocusableModifier(ModifierElement):
 
 def focusable(
     enabled: bool = True,
-    on_focus_change: Optional[Callable[[bool], None]] = None,
+    on_focus_change: Optional[BoolCallback] = None,
     on_key: Optional[Callable[[str, int], bool]] = None,
 ) -> FocusableModifier:
     """

--- a/src/nuiitivet/modifiers/tooltip.py
+++ b/src/nuiitivet/modifiers/tooltip.py
@@ -16,6 +16,7 @@ from nuiitivet.widgets.interaction import (
     FocusNode,
     InteractionHostMixin,
     ensure_interaction_region,
+    BoolCallback,
 )
 
 if TYPE_CHECKING:
@@ -73,7 +74,7 @@ class TooltipBox(PopupBox):
         self._is_focused = False
         self._active_touch_pointer_id: Optional[int] = None
         self._focus_node: Optional[FocusNode] = None
-        self._prev_focus_callback: Optional[Callable[[bool], None]] = None
+        self._prev_focus_callback: Optional[BoolCallback] = None
         self._focus_callback_wrapper: Optional[Callable[[bool], None]] = None
         self._install_interactions()
 

--- a/src/nuiitivet/widgeting/callbacks.py
+++ b/src/nuiitivet/widgeting/callbacks.py
@@ -3,12 +3,32 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-from typing import Any, Callable
+from collections.abc import Awaitable
+from typing import Any, Callable, Optional, Union
 
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.observable import detach_batch
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Shared type aliases for user-facing event handler parameters.
+# Each alias accepts both a synchronous and an async callable so that
+# users can write either ``def on_click(): ...`` or
+# ``async def on_click(): ...`` without mypy errors.
+# ---------------------------------------------------------------------------
+
+#: No-arg, fire-and-forget callback (e.g. on_click).
+VoidCallback = Union[Callable[[], None], Callable[[], Awaitable[None]]]
+#: Single ``bool`` argument callback (e.g. on_hover, on_focus_change).
+BoolCallback = Union[Callable[[bool], None], Callable[[bool], Awaitable[None]]]
+#: Optional ``bool`` argument callback (e.g. on_change for tristate toggles).
+OptionalBoolCallback = Union[
+    Callable[[Optional[bool]], None],
+    Callable[[Optional[bool]], Awaitable[None]],
+]
+#: Single ``str`` argument callback (e.g. on_change for text inputs).
+StrCallback = Union[Callable[[str], None], Callable[[str], Awaitable[None]]]
 
 
 def invoke_event_handler(

--- a/src/nuiitivet/widgets/clickable.py
+++ b/src/nuiitivet/widgets/clickable.py
@@ -4,13 +4,19 @@ import logging
 from typing import Callable, Optional, Tuple, Union, cast
 
 from nuiitivet.widgets.box import Box
-from nuiitivet.widgets.interaction import InteractionHostMixin, InteractionState, FocusNode
+from nuiitivet.widgets.interaction import (
+    InteractionHostMixin,
+    InteractionState,
+    FocusNode,
+    VoidCallback,
+    BoolCallback,
+    PointerEventCallback,
+)
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.observable import ObservableProtocol
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import Widget
-
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +30,10 @@ class Clickable(InteractionHostMixin, Box):
     def __init__(
         self,
         child: Optional[Widget] = None,
-        on_click: Optional[Callable[[], None]] = None,
-        on_hover: Optional[Callable[[bool], None]] = None,
-        on_press: Optional[Callable[[PointerEvent], None]] = None,
-        on_release: Optional[Callable[[PointerEvent], None]] = None,
+        on_click: Optional[VoidCallback] = None,
+        on_hover: Optional[BoolCallback] = None,
+        on_press: Optional[PointerEventCallback] = None,
+        on_release: Optional[PointerEventCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         focusable: bool = True,
         width: SizingLike = None,

--- a/src/nuiitivet/widgets/clickable.py
+++ b/src/nuiitivet/widgets/clickable.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable, Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union, cast
 
 from nuiitivet.widgets.box import Box
 from nuiitivet.widgets.interaction import (
@@ -15,7 +15,6 @@ from nuiitivet.widgets.interaction import (
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.observable import ObservableProtocol
 from nuiitivet.theme.types import ColorSpec
-from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import Widget
 
 logger = logging.getLogger(__name__)

--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable, Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union, cast
 
 from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import Widget

--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional, Tuple, Union, cast
 
 from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import Widget
+from nuiitivet.widgeting.callbacks import invoke_event_handler, StrCallback, BoolCallback
 from nuiitivet.input.codes import (
     MOD_CTRL,
     MOD_META,
@@ -46,8 +47,8 @@ class EditableText(InteractionHostMixin, Widget):
     def __init__(
         self,
         value: Union[str, ObservableProtocol[str]] = "",
-        on_change: Optional[Callable[[str], None]] = None,
-        on_focus_change: Optional[Callable[[bool], None]] = None,
+        on_change: Optional[StrCallback] = None,
+        on_focus_change: Optional[BoolCallback] = None,
         text_color: ColorSpec = "#000000",
         cursor_color: ColorSpec = "#000000",
         selection_color: ColorSpec = "#B3D7FF",  # Default selection color
@@ -198,14 +199,13 @@ class EditableText(InteractionHostMixin, Widget):
                 # scenarios: an Observable -> on_change -> observable.value
                 # cycle terminates because the second delivery is a no-op.
                 if self._on_change:
-                    try:
-                        self._on_change(new_text)
-                    except Exception:
-                        exception_once(
-                            _logger,
-                            "editable_text_external_on_change_exc",
-                            "EditableText external on_change raised",
-                        )
+                    invoke_event_handler(
+                        self._on_change,
+                        new_text,
+                        error_key="editable_text_external_on_change",
+                        error_msg="EditableText external on_change raised",
+                        owner_name=type(self).__name__,
+                    )
 
             self._external_sub = self._external_str_obs.subscribe(_on_external_change)
 
@@ -237,7 +237,13 @@ class EditableText(InteractionHostMixin, Widget):
         self.invalidate()
 
         if current.text != new_value.text and self._on_change:
-            self._on_change(new_value.text)
+            invoke_event_handler(
+                self._on_change,
+                new_value.text,
+                error_key="editable_text_on_change",
+                error_msg="EditableText on_change raised",
+                owner_name=type(self).__name__,
+            )
 
     def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> Tuple[int, int]:
         font = self._get_font()
@@ -371,7 +377,13 @@ class EditableText(InteractionHostMixin, Widget):
             self._focus_from_pointer = False
         self.invalidate()
         if self._on_focus_change_callback:
-            self._on_focus_change_callback(focused)
+            invoke_event_handler(
+                self._on_focus_change_callback,
+                focused,
+                error_key="editable_text_on_focus_change",
+                error_msg="EditableText on_focus_change raised",
+                owner_name=type(self).__name__,
+            )
 
     def _handle_text(self, text: str) -> bool:
         current_value = self._state_internal.value

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -2,13 +2,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any, Callable, Optional, Sequence, Tuple, cast
+from collections.abc import Awaitable
+from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast
 
 from ..input.pointer import PointerEvent, PointerEventType
 from ..widgeting.widget import Widget
 from ..rendering.sizing import SizingLike
 from nuiitivet.common.logging_once import exception_once
-from nuiitivet.widgeting.callbacks import invoke_event_handler
+from nuiitivet.widgeting.callbacks import invoke_event_handler, VoidCallback, BoolCallback
+
+# PointerEvent-specific callback aliases (defined here to avoid circular imports).
+PointerEventCallback = Union[
+    Callable[[PointerEvent], None],
+    Callable[[PointerEvent], Awaitable[None]],
+]
+DragUpdateCallback = Union[
+    Callable[[PointerEvent, float, float], None],
+    Callable[[PointerEvent, float, float], Awaitable[None]],
+]
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +90,10 @@ class PointerInputNode(InteractionNode):
             self.attach(owner)
         self._explicit_state = state
         self._hit_test = hit_test
-        self._hover_callbacks: list[Callable[[bool], None]] = []
-        self._click_callbacks: list[Callable[[], None]] = []
-        self._press_callbacks: list[Callable[[PointerEvent], None]] = []
-        self._release_callbacks: list[Callable[[PointerEvent], None]] = []
+        self._hover_callbacks: list[BoolCallback] = []
+        self._click_callbacks: list[VoidCallback] = []
+        self._press_callbacks: list[PointerEventCallback] = []
+        self._release_callbacks: list[PointerEventCallback] = []
         self._hover_enabled = False
         self._click_enabled = False
         self._active_pointer_id: Optional[int] = None
@@ -93,7 +104,7 @@ class PointerInputNode(InteractionNode):
             return self._explicit_state
         return super().state
 
-    def enable_hover(self, *, on_change: Optional[Callable[[bool], None]] = None) -> None:
+    def enable_hover(self, *, on_change: Optional[BoolCallback] = None) -> None:
         self._hover_enabled = True
         if on_change is not None:
             self._hover_callbacks.append(on_change)
@@ -101,9 +112,9 @@ class PointerInputNode(InteractionNode):
     def enable_click(
         self,
         *,
-        on_click: Optional[Callable[[], None]] = None,
-        on_press: Optional[Callable[[PointerEvent], None]] = None,
-        on_release: Optional[Callable[[PointerEvent], None]] = None,
+        on_click: Optional[VoidCallback] = None,
+        on_press: Optional[PointerEventCallback] = None,
+        on_release: Optional[PointerEventCallback] = None,
     ) -> None:
         self._click_enabled = True
         # Treat enable_click as a setter.
@@ -116,39 +127,39 @@ class PointerInputNode(InteractionNode):
         if on_release is not None:
             self._release_callbacks = [on_release]
 
-    def add_hover_listener(self, callback: Callable[[bool], None]) -> None:
+    def add_hover_listener(self, callback: BoolCallback) -> None:
         """Add a hover listener without replacing existing ones."""
         self._hover_enabled = True
         if callback not in self._hover_callbacks:
             self._hover_callbacks.append(callback)
 
-    def remove_hover_listener(self, callback: Callable[[bool], None]) -> None:
+    def remove_hover_listener(self, callback: BoolCallback) -> None:
         """Remove a previously added hover listener. No-op if not found."""
         try:
             self._hover_callbacks.remove(callback)
         except ValueError:
             pass
 
-    def add_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+    def add_press_listener(self, callback: PointerEventCallback) -> None:
         """Additively register a press listener without replacing existing ones."""
         self._click_enabled = True
         if callback not in self._press_callbacks:
             self._press_callbacks.append(callback)
 
-    def remove_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+    def remove_press_listener(self, callback: PointerEventCallback) -> None:
         """Remove a previously added press listener. No-op if not found."""
         try:
             self._press_callbacks.remove(callback)
         except ValueError:
             pass
 
-    def add_release_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+    def add_release_listener(self, callback: PointerEventCallback) -> None:
         """Additively register a release listener without replacing existing ones."""
         self._click_enabled = True
         if callback not in self._release_callbacks:
             self._release_callbacks.append(callback)
 
-    def remove_release_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+    def remove_release_listener(self, callback: PointerEventCallback) -> None:
         """Remove a previously added release listener. No-op if not found."""
         try:
             self._release_callbacks.remove(callback)
@@ -310,9 +321,9 @@ class DraggableNode(InteractionNode):
     def __init__(
         self,
         *,
-        on_drag_start: Optional[Callable[[PointerEvent], None]] = None,
-        on_drag_update: Optional[Callable[[PointerEvent, float, float], None]] = None,
-        on_drag_end: Optional[Callable[[PointerEvent], None]] = None,
+        on_drag_start: Optional[PointerEventCallback] = None,
+        on_drag_update: Optional[DragUpdateCallback] = None,
+        on_drag_end: Optional[PointerEventCallback] = None,
         hit_test: Optional[Callable[[float, float], bool]] = None,
     ) -> None:
         super().__init__()
@@ -322,6 +333,10 @@ class DraggableNode(InteractionNode):
         self._hit_test = hit_test
         self._active_pointer_id: Optional[int] = None
         self._last_pos: Optional[Tuple[float, float]] = None
+
+    def _invoke_callback(self, cb: Callable[..., Any], *args: Any, error_key: str, error_msg: str) -> None:
+        owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
+        invoke_event_handler(cb, *args, error_key=error_key, error_msg=error_msg, owner_name=owner_name)
 
     def activate(self, event: PointerEvent) -> None:
         """Programmatically start a drag session.
@@ -354,16 +369,12 @@ class DraggableNode(InteractionNode):
             self.owner.invalidate()
 
         if self._on_drag_start:
-            try:
-                self._on_drag_start(event)
-            except Exception:
-                owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
-                exception_once(
-                    logger,
-                    f"draggable_activate_on_drag_start_exc:{owner_name}",
-                    "on_drag_start raised during activate (owner=%s)",
-                    owner_name,
-                )
+            self._invoke_callback(
+                self._on_drag_start,
+                event,
+                error_key="draggable_activate_on_drag_start",
+                error_msg="on_drag_start raised during activate",
+            )
 
     def handle_pointer_event(self, event: PointerEvent, bounds: Optional[Sequence[float]] = None) -> bool:
         if self.state.disabled:
@@ -407,16 +418,12 @@ class DraggableNode(InteractionNode):
             self.owner.invalidate()
 
         if self._on_drag_start:
-            try:
-                self._on_drag_start(event)
-            except Exception:
-                owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
-                exception_once(
-                    logger,
-                    f"draggable_on_drag_start_exc:{owner_name}",
-                    "on_drag_start raised (owner=%s)",
-                    owner_name,
-                )
+            self._invoke_callback(
+                self._on_drag_start,
+                event,
+                error_key="draggable_on_drag_start",
+                error_msg="on_drag_start raised",
+            )
         return True
 
     def _handle_move(self, event: PointerEvent) -> bool:
@@ -428,16 +435,14 @@ class DraggableNode(InteractionNode):
             dy = event.y - self._last_pos[1]
             self._last_pos = (event.x, event.y)
             if self._on_drag_update:
-                try:
-                    self._on_drag_update(event, dx, dy)
-                except Exception:
-                    owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
-                    exception_once(
-                        logger,
-                        f"draggable_on_drag_update_exc:{owner_name}",
-                        "on_drag_update raised (owner=%s)",
-                        owner_name,
-                    )
+                self._invoke_callback(
+                    self._on_drag_update,
+                    event,
+                    dx,
+                    dy,
+                    error_key="draggable_on_drag_update",
+                    error_msg="on_drag_update raised",
+                )
             if self.owner:
                 self.owner.invalidate()
         return True
@@ -476,16 +481,12 @@ class DraggableNode(InteractionNode):
             self.owner.invalidate()
 
         if self._on_drag_end:
-            try:
-                self._on_drag_end(event)
-            except Exception:
-                owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
-                exception_once(
-                    logger,
-                    f"draggable_on_drag_end_exc:{owner_name}",
-                    "on_drag_end raised (owner=%s)",
-                    owner_name,
-                )
+            self._invoke_callback(
+                self._on_drag_end,
+                event,
+                error_key="draggable_on_drag_end",
+                error_msg="on_drag_end raised",
+            )
 
     def _point_inside(self, bounds: Optional[Sequence[float]], x: float, y: float) -> bool:
         if self._hit_test:
@@ -505,7 +506,7 @@ class FocusNode(InteractionNode):
     def __init__(
         self,
         *,
-        on_focus_change: Optional[Callable[[bool], None]] = None,
+        on_focus_change: Optional[BoolCallback] = None,
         on_key: Optional[Callable[[str, int], bool]] = None,
         on_text: Optional[Callable[[str], bool]] = None,
         on_text_motion: Optional[Callable[[int, bool], bool]] = None,
@@ -568,7 +569,14 @@ class FocusNode(InteractionNode):
         if self.region:
             cast(Widget, self.region).invalidate()
         if self._on_focus_change:
-            self._on_focus_change(value)
+            owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
+            invoke_event_handler(
+                self._on_focus_change,
+                value,
+                error_key="focus_change_callback",
+                error_msg="Focus change callback raised",
+                owner_name=owner_name,
+            )
 
     def handle_key_event(self, key: str, modifiers: int) -> bool:
         if self._on_key:
@@ -649,31 +657,31 @@ class InteractionHostMixin:
     def state(self) -> InteractionState:
         return self._state
 
-    def enable_hover(self, *, on_change: Optional[Callable[[bool], None]] = None) -> None:
+    def enable_hover(self, *, on_change: Optional[BoolCallback] = None) -> None:
         self._pointer_node.enable_hover(on_change=on_change)
 
     def enable_click(
         self,
         *,
-        on_click: Optional[Callable[[], None]] = None,
-        on_press: Optional[Callable[[PointerEvent], None]] = None,
-        on_release: Optional[Callable[[PointerEvent], None]] = None,
+        on_click: Optional[VoidCallback] = None,
+        on_press: Optional[PointerEventCallback] = None,
+        on_release: Optional[PointerEventCallback] = None,
     ) -> None:
         self._pointer_node.enable_click(on_click=on_click, on_press=on_press, on_release=on_release)
 
-    def add_hover_listener(self, callback: Callable[[bool], None]) -> None:
+    def add_hover_listener(self, callback: BoolCallback) -> None:
         """Add a hover listener without replacing existing ones."""
         self._pointer_node.add_hover_listener(callback)
 
-    def remove_hover_listener(self, callback: Callable[[bool], None]) -> None:
+    def remove_hover_listener(self, callback: BoolCallback) -> None:
         """Remove a previously added hover listener. No-op if not found."""
         self._pointer_node.remove_hover_listener(callback)
 
-    def add_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+    def add_press_listener(self, callback: PointerEventCallback) -> None:
         """Additively register a press listener without replacing existing ones."""
         self._pointer_node.add_press_listener(callback)
 
-    def remove_press_listener(self, callback: Callable[[PointerEvent], None]) -> None:
+    def remove_press_listener(self, callback: PointerEventCallback) -> None:
         """Remove a previously added press listener. No-op if not found."""
         self._pointer_node.remove_press_listener(callback)
 

--- a/src/nuiitivet/widgets/text_field.py
+++ b/src/nuiitivet/widgets/text_field.py
@@ -7,7 +7,7 @@ without any specific design system styling.
 from __future__ import annotations
 
 import logging
-from typing import Callable, Optional, Tuple, TypeVar, Union
+from typing import Optional, Tuple, TypeVar, Union
 
 from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import ComposableWidget, Widget

--- a/src/nuiitivet/widgets/text_field.py
+++ b/src/nuiitivet/widgets/text_field.py
@@ -17,7 +17,7 @@ from nuiitivet.widgets.interaction import InteractionHostMixin
 from nuiitivet.widgets.editable_text import EditableText
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.platform import get_system_clipboard
-
+from nuiitivet.widgeting.callbacks import invoke_event_handler, StrCallback
 
 _logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class TextFieldBase(InteractionHostMixin, ComposableWidget):
         cls: type[TTextFieldBase],
         value: ObservableProtocol[str],
         *,
-        on_change: Optional[Callable[[str], None]] = None,
+        on_change: Optional[StrCallback] = None,
         **kwargs,
     ) -> TTextFieldBase:
         """Create a two-way bound TextField."""
@@ -62,19 +62,19 @@ class TextFieldBase(InteractionHostMixin, ComposableWidget):
                     _logger, "text_field_base_two_way_set_value_exc", "TextFieldBase.two_way failed to set value"
                 )
             if on_change is not None:
-                try:
-                    on_change(new_text)
-                except Exception:
-                    exception_once(
-                        _logger, "text_field_base_two_way_on_change_exc", "TextFieldBase.two_way on_change raised"
-                    )
+                invoke_event_handler(
+                    on_change,
+                    new_text,
+                    error_key="text_field_base_two_way_on_change",
+                    error_msg="TextFieldBase.two_way on_change raised",
+                )
 
         return cls(value=value, on_change=_bound_on_change, **kwargs)
 
     def __init__(
         self,
         value: Union[str, ObservableProtocol[str]] = "",
-        on_change: Optional[Callable[[str], None]] = None,
+        on_change: Optional[StrCallback] = None,
         text_color: str = "#000000",
         cursor_color: str = "#000000",
         selection_color: str = "#0000FF",
@@ -119,7 +119,13 @@ class TextFieldBase(InteractionHostMixin, ComposableWidget):
     def _handle_editable_change(self, new_text: str) -> None:
         """Called when the editable text changes."""
         if self._on_change:
-            self._on_change(new_text)
+            invoke_event_handler(
+                self._on_change,
+                new_text,
+                error_key="text_field_on_change",
+                error_msg="TextField on_change raised",
+                owner_name=type(self).__name__,
+            )
 
     def _on_editable_focus_change(self, focused: bool) -> None:
         """Called when the editable text focus changes."""

--- a/src/nuiitivet/widgets/toggleable.py
+++ b/src/nuiitivet/widgets/toggleable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Optional, Union, cast
+from typing import Optional, Union, cast
 
 from nuiitivet.widgets.clickable import Clickable
 from nuiitivet.observable import Observable, ObservableProtocol

--- a/src/nuiitivet/widgets/toggleable.py
+++ b/src/nuiitivet/widgets/toggleable.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional, Union, cast
 from nuiitivet.widgets.clickable import Clickable
 from nuiitivet.observable import Observable, ObservableProtocol
 from nuiitivet.rendering.sizing import SizingLike
+from nuiitivet.widgeting.callbacks import invoke_event_handler, OptionalBoolCallback
 
 
 class Toggleable(Clickable):
@@ -19,7 +20,7 @@ class Toggleable(Clickable):
     def __init__(
         self,
         value: Union[bool, None, ObservableProtocol[Optional[bool]]] = False,
-        on_change: Optional[Callable[[Optional[bool]], None]] = None,
+        on_change: Optional[OptionalBoolCallback] = None,
         tristate: bool = False,
         disabled: bool | ObservableProtocol[bool] = False,
         # Clickable args
@@ -90,7 +91,13 @@ class Toggleable(Clickable):
         self.value = new_val
 
         if self.on_change:
-            self.on_change(new_val)
+            invoke_event_handler(
+                self.on_change,
+                new_val,
+                error_key="toggleable_on_change",
+                error_msg="Toggleable on_change raised",
+                owner_name=type(self).__name__,
+            )
 
     def _on_value_change(self, new_val: Optional[bool]):
         # Update InteractionState


### PR DESCRIPTION
## Summary

Resolves #96

Extends the async callback support beyond `on_click` to **all fire-and-forget callbacks** across the widget layer. Introduces shared type aliases and routes every in-scope callback through `invoke_event_handler` so async coroutines are scheduled correctly instead of being silently discarded.

## Changes

### New type aliases (`widgeting/callbacks.py`)

| Alias | Type |
|---|---|
| `VoidCallback` | `Callable[[], None] \| Callable[[], Awaitable[None]]` |
| `BoolCallback` | `Callable[[bool], None] \| Callable[[bool], Awaitable[None]]` |
| `OptionalBoolCallback` | `Callable[[bool \| None], None] \| Callable[[bool \| None], Awaitable[None]]` |
| `StrCallback` | `Callable[[str], None] \| Callable[[str], Awaitable[None]]` |

### Updated files

- `widgets/interaction.py` — `PointerInputNode`, `DraggableNode`, `FocusNode`, `InteractionHostMixin`
- `widgets/clickable.py` — `on_click`, `on_hover`, `on_press`, `on_release`
- `widgets/toggleable.py` — `on_change`
- `widgets/text_field.py` — `on_change`
- `widgets/editable_text.py` — `on_change`, `on_focus_change`
- `modifiers/clickable.py` — `on_click`
- `modifiers/focus.py` — `on_focus_change`
- `modifiers/tooltip.py` — `_prev_focus_callback`
- `material/buttons.py` — `on_click`, `on_change`
- `material/button_group.py` — `on_change`
- `material/interactive_widget.py` — `on_click`

### Out of scope

- `on_key`, `on_text`, `on_text_motion`, `on_ime_composition` — bool-returning pyglet event protocols (sync only by design)
- `on_will_pop` — tracked separately as #135

## Testing

- All 1210 pytest tests pass
- mypy: no errors (498 source files)