### PR TITLE
refactor(nav): remove PageRoute, rename DialogRoute to OverlayRoute

### DIFF
--- a/docs/design/NAVIGATION.md
+++ b/docs/design/NAVIGATION.md
@@ -11,7 +11,7 @@ The user-facing API should be intuitive and reflect the physical structure, whil
 - `Navigator.push()` to "transition screens"
 - `Overlay.show_modal()` / `Overlay.show_modeless()` / `Overlay.show_light_dismiss()` to "display on the topmost layer"
 
-Internally, the `Navigator` acts as a stack managing `PageRoute` objects, while the `Overlay` maintains an internal `_modal_navigator` that treats Dialogs and Snackbars as routes.
+Internally, the `Navigator` acts as a stack managing `Route` objects, while the `Overlay` maintains an internal `_modal_navigator` that treats Dialogs and Snackbars as routes.
 
 ```text
 ┌─────────────────────────────────────┐
@@ -20,7 +20,7 @@ Internally, the `Navigator` acts as a stack managing `PageRoute` objects, while 
 │  ┌───────────────────────────────┐  │
 │  │ Overlay (Physical Layer)       │  │ ← Always on top
 │  │  Internal: _modal_navigator   │  │
-│  │    ├─ DialogRoute             │  │
+│  │    ├─ OverlayRoute            │  │
 │  │    └─ SnackbarRoute           │  │
 │  └───────────────────────────────┘  │
 │                                      │
@@ -28,8 +28,8 @@ Internally, the `Navigator` acts as a stack managing `PageRoute` objects, while 
 │  │ Content                       │  │
 │  │  ┌──────────────────┐         │  │
 │  │  │ Navigator (Part) │         │  │ ← Placed by user
-│  │  │  ├─ PageRoute    │         │  │
-│  │  │  └─ PageRoute    │         │  │
+│  │  │  ├─ Route         │         │  │
+│  │  │  └─ Route         │         │  │
 │  │  └──────────────────┘         │  │
 │  └───────────────────────────────┘  │
 └─────────────────────────────────────┘
@@ -150,8 +150,8 @@ class ProductDetailIntent:
 
 ```python
 routes: dict[type, callable[[object], "Route"]] = {
-    HomeIntent: lambda intent: PageRoute(builder=lambda: HomeScreen()),
-    ProductDetailIntent: lambda intent: PageRoute(
+    HomeIntent: lambda intent: Route(builder=lambda: HomeScreen()),
+    ProductDetailIntent: lambda intent: Route(
         builder=lambda: ProductDetailScreen(intent.product_id)
     ),
 }
@@ -172,7 +172,7 @@ Navigator.root().push(ProductDetailIntent(product_id=123))
 Navigator.root().push(SettingsScreen())
 
 # Pattern 2: Route
-Navigator.root().push(PageRoute(builder=lambda: SettingsScreen()))
+Navigator.root().push(Route(builder=lambda: SettingsScreen()))
 
 # Pattern 3: Intent
 Navigator.root().push(SettingsIntent())
@@ -197,9 +197,9 @@ App(
     Navigator.intents(
         initial_route=HomeIntent(),
         routes={
-            HomeIntent: lambda intent: PageRoute(builder=...),
-            DetailIntent: lambda intent: PageRoute(builder=...),
-            SettingsIntent: lambda intent: PageRoute(builder=...),
+            HomeIntent: lambda intent: Route(builder=...),
+            DetailIntent: lambda intent: Route(builder=...),
+            SettingsIntent: lambda intent: Route(builder=...),
         },
     ),
     title="My App",

--- a/docs/design/OVERLAY.md
+++ b/docs/design/OVERLAY.md
@@ -38,8 +38,8 @@ Note: The `Overlay` core provides only `show_modal()` / `show_modeless()` / `sho
 │  │ Content                       │  │
 │  │  ┌──────────────────┐         │  │
 │  │  │ Navigator (Part) │         │  │ ← Placed by user
-│  │  │  ├─ PageRoute    │         │  │
-│  │  │  └─ PageRoute    │         │  │
+│  │  │  ├─ Route         │         │  │
+│  │  │  └─ Route         │         │  │
 │  │  └──────────────────┘         │  │
 │  └───────────────────────────────┘  │
 └─────────────────────────────────────┘

--- a/docs/design/PROGRAMMING_PARADIMS.md
+++ b/docs/design/PROGRAMMING_PARADIMS.md
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     overlay = Overlay(
         # Register Intent (standard intents available by default)
         dialogs={
-            ConfirmIntent: lambda intent: DialogRoute(
+            ConfirmIntent: lambda intent: OverlayRoute(
                 builder=lambda: AlertDialog(
                     title=Text(intent.title),
                     content=Text(intent.message),
@@ -264,11 +264,11 @@ class CartViewModel:
 
 # 3. View (Bind Intent to Widget via Navigator configuration)
 Navigator(
-    initial_routes=[PageRoute(builder=lambda: ProductListScreen())],
+    initial_routes=[Route(builder=lambda: ProductListScreen())],
     routes={
-        ProductListIntent: lambda _: PageRoute(builder=lambda: ProductListScreen()),
-        CartIntent: lambda _: PageRoute(builder=lambda: CartScreen()),
-        OrderCompleteIntent: lambda _: PageRoute(builder=lambda: OrderCompleteScreen()),
+        ProductListIntent: lambda _: Route(builder=lambda: ProductListScreen()),
+        CartIntent: lambda _: Route(builder=lambda: CartScreen()),
+        OrderCompleteIntent: lambda _: Route(builder=lambda: OrderCompleteScreen()),
     }
 )
 ```
@@ -291,22 +291,22 @@ class MainScreen(Widget):
                     # This Navigator manages transitions within this tab
                     Navigator(
                         key="home_nav",
-                        initial_routes=[PageRoute(builder=lambda: ProductListScreen())],
+                        initial_routes=[Route(builder=lambda: ProductListScreen())],
                         routes={
-                            ProductListIntent: lambda _: PageRoute(builder=lambda: ProductListScreen()),
-                            CartIntent: lambda _: PageRoute(builder=lambda: CartScreen()),
+                            ProductListIntent: lambda _: Route(builder=lambda: ProductListScreen()),
+                            CartIntent: lambda _: Route(builder=lambda: CartScreen()),
                             # ...
                         }
                     ),
                     # Tab 2: Search (Standard Navigation)
                     Navigator(
                         key="search_nav",
-                        initial_routes=[PageRoute(builder=lambda: SearchScreen())]
+                        initial_routes=[Route(builder=lambda: SearchScreen())]
                     ),
                     # Tab 3: Profile
                     Navigator(
                         key="profile_nav",
-                        initial_routes=[PageRoute(builder=lambda: ProfileScreen())]
+                        initial_routes=[Route(builder=lambda: ProfileScreen())]
                     ),
                 ]
             ),

--- a/docs/guide/dialogs.md
+++ b/docs/guide/dialogs.md
@@ -175,7 +175,7 @@ class CounterDialog(ComposableWidget, OverlayAware[int]):
 - `OverlayAware` works with **all** overlay show APIs, including
   `dialog`, `show_modal`, `show_modeless`, `show_light_dismiss`, `side_sheet`,
   `bottom_sheet`, and `loading`. It also works when the widget is wrapped in a
-  `Route` (e.g. `DialogRoute(builder=lambda: CounterDialog())`).
+  `Route` (e.g. `OverlayRoute(builder=lambda: CounterDialog())`).
 - Attempting to display the same `OverlayAware` widget instance while its
   previous handle is still active raises `RuntimeError`. Re-displaying after
   the previous handle has completed is allowed.

--- a/docs/guide/modifier_others.md
+++ b/docs/guide/modifier_others.md
@@ -38,7 +38,7 @@ from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material import Overlay
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.observable import Observable
 from nuiitivet.material import ButtonStyle
 
@@ -49,7 +49,7 @@ class HomeIntent:
 class HomeScreen(nv.ComposableWidget):
     def build(self):
         def _open_editor() -> None:
-            Navigator.root().push(PageRoute(builder=lambda: EditScreen()))
+            Navigator.root().push(Route(builder=lambda: EditScreen()))
 
         return nv.Container(
             padding=24,
@@ -135,7 +135,7 @@ def main() -> None:
     md.App(
         Navigator.intents(
             initial_route=HomeIntent(),
-            routes={HomeIntent: lambda _i: PageRoute(builder=HomeScreen)},
+            routes={HomeIntent: lambda _i: Route(builder=HomeScreen)},
         ),
     ).run()
 ```

--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -83,6 +83,6 @@ This stack-based approach makes it easy to manage complex navigation flows and e
 
 ## Next Steps
 
-- Learn how to customize transitions using [PageRoute](navigation_route.md).
+- Learn how to customize transitions using [Route](navigation_route.md).
 - Discover how to decouple navigation logic using [Intents](navigation_intent.md).
 - Explore advanced navigation patterns with [MaterialNavigator](navigation_sub.md).

--- a/docs/guide/navigation_route.md
+++ b/docs/guide/navigation_route.md
@@ -1,10 +1,10 @@
-# PageRoute and Animations
+# Route and Animations
 
-While you can push widgets directly to the `Navigator`, using `PageRoute` gives you more control over the transition animations and lifecycle of the screen.
+While you can push widgets directly to the `Navigator`, using `Route` gives you more control over the transition animations and lifecycle of the screen.
 
 ## Customizing Animations
 
-By default, `App` applies a standard Material Design transition when navigating between screens. However, you can customize this behavior by providing a `TransitionSpec` to a `PageRoute`.
+By default, `App` applies a standard Material Design transition when navigating between screens. However, you can customize this behavior by providing a `TransitionSpec` to a `Route`.
 
 Nuiitivet provides built-in transition effects such as `FadeIn`, `FadeOut`, `ScaleIn`, `ScaleOut`, `SlideInVertically`, and `SlideOutVertically`. You can combine these effects using the `|` operator to create complex animations.
 
@@ -13,7 +13,7 @@ Nuiitivet provides built-in transition effects such as `FadeIn`, `FadeOut`, `Sca
 ```python
 import nuiitivet as nv
 
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.material import (Text, MaterialTransitions, FadeIn, SlideInVertically, FadeOut, SlideOutVertically, Button)
 from nuiitivet.layout.column import Column
 from nuiitivet.widgeting.widget import ComposableWidget
@@ -43,7 +43,7 @@ def navigate_with_custom_animation():
         exit=FadeOut() | SlideOutVertically(target_offset_y=50.0)
     )
 
-    route = PageRoute(
+    route = Route(
         builder=lambda: AnimatedScreen(),
         transition_spec=custom_transition
     )
@@ -57,7 +57,7 @@ If you want to transition to a new screen instantly without any animation, you c
 ```python
 import nuiitivet as nv
 
-from nuiitivet.navigation import Navigator, PageRoute, Transitions
+from nuiitivet.navigation import Navigator, Route, Transitions
 from nuiitivet.material import Text, Button
 from nuiitivet.layout.column import Column
 from nuiitivet.widgeting.widget import ComposableWidget
@@ -81,11 +81,11 @@ class InstantScreen(ComposableWidget):
         )
 
 def navigate_instantly():
-    route = PageRoute(
+    route = Route(
         builder=lambda: InstantScreen(),
         transition_spec=Transitions.empty()
     )
     Navigator.root().push(route)
 ```
 
-Using `PageRoute` and `TransitionSpec` allows you to create smooth, visually appealing transitions or optimize for speed by disabling them entirely.
+Using `Route` and `TransitionSpec` allows you to create smooth, visually appealing transitions or optimize for speed by disabling them entirely.

--- a/docs/guide/navigation_sub.md
+++ b/docs/guide/navigation_sub.md
@@ -16,7 +16,7 @@ from nuiitivet.material.navigator import MaterialNavigator
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.layout.container import Container
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle
@@ -90,7 +90,7 @@ class MainScreen(ComposableWidget):
                     width=nv.Sizing.flex(1),
                     height=nv.Sizing.flex(1),
                     child=MaterialNavigator(
-                        routes=[PageRoute(builder=lambda: NestedHome())]
+                        routes=[Route(builder=lambda: NestedHome())]
                     ),
                 ),
             ],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,7 +146,7 @@ nav:
           - guide/dialogs.md
       - Navigation:
           - Overview: guide/navigation.md
-          - PageRoute & Animations: guide/navigation_route.md
+          - Route & Animations: guide/navigation_route.md
           - Intent-Based Navigation: guide/navigation_intent.md
           - Nested Navigation: guide/navigation_sub.md
       - Window:

--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -18,7 +18,7 @@ from nuiitivet.layout.deck import Deck
 # Primitives / Widgets
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import Widget, ComposableWidget
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator
 
 # State Management
 from nuiitivet.observable import Observable, batch
@@ -45,7 +45,6 @@ __all__: list[str] = [
     "Widget",
     "ComposableWidget",
     "Navigator",
-    "PageRoute",
     "Observable",
     "batch",
     "set_default_font_family",

--- a/src/nuiitivet/material/navigator.py
+++ b/src/nuiitivet/material/navigator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from nuiitivet.navigation.navigator import Navigator
-from nuiitivet.navigation.route import PageRoute, Route
+from nuiitivet.navigation.route import Route
 from nuiitivet.widgeting.widget import Widget
 
 from .transition_spec import MaterialTransitions
@@ -13,7 +13,7 @@ class MaterialNavigator(Navigator):
     """Navigator that applies Material default transition specs."""
 
     def _route_from_widget(self, widget: Widget) -> Route:
-        return PageRoute(
+        return Route(
             builder=lambda: widget,
             transition_spec=MaterialTransitions.page(),
         )

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -11,7 +11,7 @@ from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material.snackbar import Snackbar
 from nuiitivet.navigation.route import Route
-from nuiitivet.overlay.dialog_route import DialogRoute
+from nuiitivet.overlay.overlay_route import OverlayRoute
 from nuiitivet.overlay import Overlay
 from nuiitivet.overlay.intent_resolver import IntentResolver
 from nuiitivet.overlay.overlay_handle import OverlayHandle
@@ -54,7 +54,7 @@ class MaterialOverlay(Overlay):
 
         if intent_resolver is None:
             defaults: dict[type[Any], Callable[[Any], Widget | Route]] = {
-                AlertDialogIntent: lambda i: DialogRoute(
+                AlertDialogIntent: lambda i: OverlayRoute(
                     builder=lambda: AlertDialog(
                         title=i.title,
                         message=i.message,
@@ -70,7 +70,7 @@ class MaterialOverlay(Overlay):
                     ),
                     transition_spec=MaterialTransitions.dialog(),
                 ),
-                LoadingIntent: lambda _: DialogRoute(
+                LoadingIntent: lambda _: OverlayRoute(
                     builder=lambda: LoadingIndicator(),
                     transition_spec=MaterialTransitions.dialog(),
                     barrier_dismissible=False,
@@ -151,7 +151,7 @@ class MaterialOverlay(Overlay):
             return resolved
 
         widget = resolved
-        return DialogRoute(
+        return OverlayRoute(
             builder=lambda: widget,
             transition_spec=transition or MaterialTransitions.dialog(),
             barrier_dismissible=bool(dismiss_on_outside_tap),
@@ -236,7 +236,7 @@ class MaterialOverlay(Overlay):
 
         alignment = "top-right" if sheet.side == "right" else "top-left"
 
-        route = DialogRoute(
+        route = OverlayRoute(
             builder=lambda: sheet,
             transition_spec=transition,
             barrier_dismissible=bool(dismiss_on_outside_tap),
@@ -270,7 +270,7 @@ class MaterialOverlay(Overlay):
         if transition is None:
             transition = MaterialTransitions.bottom_sheet()
 
-        route = DialogRoute(
+        route = OverlayRoute(
             builder=lambda: sheet,
             transition_spec=transition,
             barrier_dismissible=bool(dismiss_on_outside_tap),

--- a/src/nuiitivet/navigation/__init__.py
+++ b/src/nuiitivet/navigation/__init__.py
@@ -9,7 +9,7 @@ from nuiitivet.navigation.layer_composer import (
     NavigationLayerCompositionContext,
     NavigationTransitionKind,
 )
-from nuiitivet.navigation.route import PageRoute, Route
+from nuiitivet.navigation.route import Route
 from nuiitivet.navigation.stack_runtime import EntryLifecycle, RouteStackEntry, RouteStackRuntime
 from nuiitivet.navigation.transition_state import TransitionLifecycle, TransitionState
 from nuiitivet.navigation.transition_engine import TransitionEngine, TransitionMotionPreset, TransitionMotions
@@ -25,7 +25,6 @@ __all__ = [
     "NavigationLayerComposer",
     "NavigationLayerCompositionContext",
     "NavigationTransitionKind",
-    "PageRoute",
     "EmptyTransitionSpec",
     "Route",
     "EntryLifecycle",

--- a/src/nuiitivet/navigation/navigator.py
+++ b/src/nuiitivet/navigation/navigator.py
@@ -9,7 +9,7 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 
 from .layer_composer import NavigationLayerComposer, NavigationLayerCompositionContext
-from .route import PageRoute, Route
+from .route import Route
 from .stack_runtime import RouteStackRuntime
 from .transition_engine import TransitionEngine, TransitionHandle
 from .transition_spec import EmptyTransitionSpec, TransitionPhase
@@ -201,7 +201,7 @@ class Navigator(ComposableWidget):
 
     def _route_from_widget(self, widget: Widget) -> Route:
         """Wrap a widget into a page route for navigator runtime."""
-        return PageRoute(builder=lambda: widget)
+        return Route(builder=lambda: widget)
 
     def _resolve_intent_to_route(self, intent: Any) -> Route:
         """Resolve an intent and normalize the result to a Route."""

--- a/src/nuiitivet/navigation/route.py
+++ b/src/nuiitivet/navigation/route.py
@@ -33,10 +33,3 @@ class Route:
 
         self._widget.unmount()
         self._widget = None
-
-
-class PageRoute(Route):
-    """Route for a page widget."""
-
-    def __init__(self, builder: Callable[[], Widget], transition_spec: TransitionSpec | None = None) -> None:
-        super().__init__(builder=builder, transition_spec=transition_spec or Transitions.empty())

--- a/src/nuiitivet/overlay/__init__.py
+++ b/src/nuiitivet/overlay/__init__.py
@@ -1,6 +1,6 @@
 """Overlay system for transient layers."""
 
-from .dialog_route import DialogRoute
+from .overlay_route import OverlayRoute
 from .intent_resolver import IntentResolver
 from .overlay_aware import OverlayAware
 from .overlay_handle import OverlayHandle
@@ -16,7 +16,7 @@ from .intents import PlainDialogIntent, LoadingDialogIntent
 __all__ = [
     "AnchoredOverlayPosition",
     "PlainDialogIntent",
-    "DialogRoute",
+    "OverlayRoute",
     "IntentResolver",
     "LoadingDialogIntent",
     "Overlay",

--- a/src/nuiitivet/overlay/overlay.py
+++ b/src/nuiitivet/overlay/overlay.py
@@ -14,7 +14,7 @@ from nuiitivet.modifiers.background import background
 from nuiitivet.modifiers.clickable import clickable
 from nuiitivet.observable import Observable
 from nuiitivet.observable import runtime
-from nuiitivet.navigation import PageRoute, Route
+from nuiitivet.navigation import Route
 from nuiitivet.navigation.stack_runtime import RouteStackRuntime
 from nuiitivet.navigation.transition_engine import TransitionEngine
 from nuiitivet.navigation.transition_spec import EmptyTransitionSpec, TransitionPhase, TransitionSpec, Transitions
@@ -289,7 +289,7 @@ class Overlay(ComposableWidget):
 
         # Overlay entries are implemented as routes on a private modal navigator.
         # A base route keeps the navigator mounted even when empty.
-        self._base_route: Route = PageRoute(builder=lambda: Container(), transition_spec=Transitions.empty())
+        self._base_route: Route = Route(builder=lambda: Container(), transition_spec=Transitions.empty())
         self._modal_navigator: _ModalNavigator = _ModalNavigator(base_route=self._base_route)
         self._entry_to_route: Dict[OverlayEntry, _OverlayEntryRoute] = {}
         self._entry_to_future: Dict[OverlayEntry, asyncio.Future[OverlayResult[Any]]] = {}
@@ -376,7 +376,7 @@ class Overlay(ComposableWidget):
             return content
 
         widget = content
-        return PageRoute(builder=lambda: widget, transition_spec=Transitions.empty())
+        return Route(builder=lambda: widget, transition_spec=Transitions.empty())
 
     def _to_overlay_entry_route(
         self,
@@ -606,7 +606,7 @@ class Overlay(ComposableWidget):
         return self._modal_navigator
 
     def insert_entry(self, entry: OverlayEntry) -> None:
-        route = PageRoute(builder=entry.build_widget, transition_spec=Transitions.empty())
+        route = Route(builder=entry.build_widget, transition_spec=Transitions.empty())
         self._insert_entry_with_route(entry, route)
         self.rebuild()
 

--- a/src/nuiitivet/overlay/overlay_route.py
+++ b/src/nuiitivet/overlay/overlay_route.py
@@ -1,4 +1,4 @@
-"""DialogRoute for modal overlay dialogs."""
+"""OverlayRoute for modal overlay layers."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from nuiitivet.navigation.route import Route
 from nuiitivet.widgeting.widget import Widget
 
 
-class DialogRoute(Route):
+class OverlayRoute(Route):
     """A modal route shown on the Overlay layer."""
 
     def __init__(

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -7,7 +7,7 @@ from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material import Overlay
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.observable import Observable
 from nuiitivet.material import ButtonStyle
 
@@ -20,7 +20,7 @@ class HomeIntent:
 class HomeScreen(nv.ComposableWidget):
     def build(self):
         def _open_editor() -> None:
-            Navigator.root().push(PageRoute(builder=lambda: EditScreen()))
+            Navigator.root().push(Route(builder=lambda: EditScreen()))
 
         return nv.Container(
             padding=24,
@@ -106,7 +106,7 @@ def main(png: str = ""):
         Navigator.intents(
             initial_route=HomeIntent(),
             routes={
-                HomeIntent: lambda _i: PageRoute(builder=HomeScreen),
+                HomeIntent: lambda _i: Route(builder=HomeScreen),
             },
         ),
         width=400,

--- a/src/samples/navigation/route.py
+++ b/src/samples/navigation/route.py
@@ -11,7 +11,7 @@ from nuiitivet.material import (
     Button,
 )
 from nuiitivet.layout.column import Column
-from nuiitivet.navigation import Navigator, PageRoute, Transitions
+from nuiitivet.navigation import Navigator, Route, Transitions
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle
@@ -44,14 +44,14 @@ class HomeScreen(ComposableWidget):
                 enter=FadeIn() | SlideInVertically(initial_offset_y=50.0),
                 exit_=FadeOut() | SlideOutVertically(target_offset_y=50.0),
             )
-            route = PageRoute(
+            route = Route(
                 builder=lambda: DetailsScreen(),
                 transition_spec=custom_transition,
             )
             Navigator.root().push(route)
 
         def navigate_instantly() -> None:
-            route = PageRoute(
+            route = Route(
                 builder=lambda: DetailsScreen(),
                 transition_spec=Transitions.empty(),
             )

--- a/src/samples/overlay_navigator_demo.py
+++ b/src/samples/overlay_navigator_demo.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.modifiers import background
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material import App
 from nuiitivet.material import Overlay
@@ -179,9 +179,9 @@ def main() -> None:
         Navigator.intents(
             initial_route=HomeIntent(),
             routes={
-                HomeIntent: lambda _i: PageRoute(builder=HomePage),
-                DetailsIntent: lambda _i: PageRoute(builder=DetailsPage),
-                SettingsIntent: lambda _i: PageRoute(builder=SettingsPage),
+                HomeIntent: lambda _i: Route(builder=HomePage),
+                DetailsIntent: lambda _i: Route(builder=DetailsPage),
+                SettingsIntent: lambda _i: Route(builder=SettingsPage),
             },
         ),
         overlay_routes={

--- a/tests/test_intent_system.py
+++ b/tests/test_intent_system.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from nuiitivet.navigation import Navigator, PageRoute, Route
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.material.overlay import MaterialOverlay
 from nuiitivet.overlay import Overlay
 from nuiitivet.widgeting.widget import Widget
@@ -43,7 +43,7 @@ def test_navigator_push_intent_resolves_to_route() -> None:
     nav = Navigator.intents(
         initial_route=_PushIntent(label="home"),
         routes={
-            _PushIntent: lambda i: PageRoute(builder=lambda: _FlagWidget(label=i.label)),
+            _PushIntent: lambda i: Route(builder=lambda: _FlagWidget(label=i.label)),
         },
     )
 
@@ -55,7 +55,7 @@ def test_navigator_push_intent_resolves_to_route() -> None:
 
 
 def test_navigator_push_intent_raises_when_unregistered() -> None:
-    nav = Navigator(PageRoute(builder=_FlagWidget))
+    nav = Navigator(Route(builder=_FlagWidget))
 
     with pytest.raises(RuntimeError, match=r"No route is registered for intent"):
         nav.push(_PushIntent(label="x"))
@@ -113,7 +113,7 @@ def test_overlay_dialog_route_disposes_route_on_remove() -> None:
             return self
 
     route_widget = _UnmountCountWidget()
-    route: Route = PageRoute(builder=lambda: route_widget)
+    route: Route = Route(builder=lambda: route_widget)
 
     handle = overlay.show_modal(route)
 
@@ -129,7 +129,7 @@ def test_overlay_dialog_route_disposes_route_on_remove() -> None:
 
 def test_overlay_normalize_to_route_passes_route_through() -> None:
     overlay = Overlay()
-    route = PageRoute(builder=_FlagWidget)
+    route = Route(builder=_FlagWidget)
 
     normalized = overlay._normalize_to_route(route)
 

--- a/tests/test_navigation_layer_composer.py
+++ b/tests/test_navigation_layer_composer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
 from tests.helpers.layer_composer import (
     RecordingNavigationComposer,
@@ -22,7 +22,7 @@ class _FlagWidget(Widget):
 
 def test_navigator_delegates_static_paint_to_layer_composer() -> None:
     spy = RecordingNavigationComposer()
-    nav = Navigator(PageRoute(builder=_FlagWidget), layer_composer=spy)
+    nav = Navigator(Route(builder=_FlagWidget), layer_composer=spy)
 
     nav.paint(canvas=None, x=0, y=0, width=100, height=100)
 
@@ -33,12 +33,12 @@ def test_navigator_delegates_static_paint_to_layer_composer() -> None:
 def test_navigator_delegates_transition_paint_to_layer_composer() -> None:
     spy = RecordingNavigationComposer()
     nav = Navigator(
-        PageRoute(builder=_FlagWidget, transition_spec=_AnimatedTransitionSpec()),
+        Route(builder=_FlagWidget, transition_spec=_AnimatedTransitionSpec()),
         layer_composer=spy,
     )
     nav._app = object()  # type: ignore[attr-defined]
 
-    nav.push(PageRoute(builder=_FlagWidget, transition_spec=_AnimatedTransitionSpec()))
+    nav.push(Route(builder=_FlagWidget, transition_spec=_AnimatedTransitionSpec()))
     nav.paint(canvas=None, x=0, y=0, width=100, height=100)
 
     assert spy.transition_paints == 1

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -1,6 +1,6 @@
 """Tests for Navigator (Phase 3 MVP)."""
 
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -34,7 +34,7 @@ def test_navigator_push_sets_built_child() -> None:
 
 
 def test_navigator_pop_disposes_route_widget() -> None:
-    nav = Navigator(PageRoute(builder=_FlagWidget))
+    nav = Navigator(Route(builder=_FlagWidget))
 
     page2 = _FlagWidget()
     nav.push(page2)
@@ -45,7 +45,7 @@ def test_navigator_pop_disposes_route_widget() -> None:
 
 
 def test_navigator_pop_noop_when_single_route() -> None:
-    nav = Navigator(PageRoute(builder=_FlagWidget))
+    nav = Navigator(Route(builder=_FlagWidget))
     nav.rebuild()
     nav.pop()
     assert nav.can_pop() is False

--- a/tests/test_navigator_intent_and_back.py
+++ b/tests/test_navigator_intent_and_back.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from nuiitivet.navigation import Navigator, PageRoute, Route
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -71,14 +71,14 @@ def test_navigator_push_intent_resolves_route() -> None:
 
 
 def test_navigator_push_unknown_intent_raises() -> None:
-    nav = Navigator(PageRoute(builder=_FlagWidget))
+    nav = Navigator(Route(builder=_FlagWidget))
 
     with pytest.raises(RuntimeError, match=r"No route is registered for intent: _GoIntent"):
         nav.push(_GoIntent("x"))
 
 
 def test_navigator_normalize_to_route_passes_route_through() -> None:
-    nav = Navigator(PageRoute(builder=_FlagWidget))
+    nav = Navigator(Route(builder=_FlagWidget))
     route = Route(builder=_FlagWidget)
 
     normalized = nav._normalize_to_route(route)
@@ -87,7 +87,7 @@ def test_navigator_normalize_to_route_passes_route_through() -> None:
 
 
 def test_navigator_normalize_to_route_wraps_widget() -> None:
-    nav = Navigator(PageRoute(builder=_FlagWidget))
+    nav = Navigator(Route(builder=_FlagWidget))
     widget = _FlagWidget()
 
     normalized = nav._normalize_to_route(widget)
@@ -109,7 +109,7 @@ def test_navigator_normalize_to_route_resolves_intent() -> None:
 
 
 def test_navigator_request_back_is_canceled_by_top_widget_handler() -> None:
-    bottom = PageRoute(builder=_FlagWidget)
+    bottom = Route(builder=_FlagWidget)
     top_widget = _BackCancelWidget()
 
     nav = Navigator(bottom)
@@ -124,7 +124,7 @@ def test_navigator_request_back_is_canceled_by_top_widget_handler() -> None:
 
 
 def test_navigator_push_widget_and_route_have_same_pop_behavior() -> None:
-    nav_widget = Navigator(PageRoute(builder=_FlagWidget))
+    nav_widget = Navigator(Route(builder=_FlagWidget))
     top_widget = _FlagWidget()
     nav_widget.push(top_widget)
 
@@ -133,7 +133,7 @@ def test_navigator_push_widget_and_route_have_same_pop_behavior() -> None:
     assert nav_widget.can_pop() is False
     assert top_widget.unmounted is True
 
-    nav_route = Navigator(PageRoute(builder=_FlagWidget))
+    nav_route = Navigator(Route(builder=_FlagWidget))
     top_route_widget = _FlagWidget()
     nav_route.push(Route(builder=lambda: top_route_widget))
 

--- a/tests/test_navigator_pop_transition_repeat.py
+++ b/tests/test_navigator_pop_transition_repeat.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -37,7 +37,7 @@ class _Handle:
 
 
 def test_pop_finishes_when_pop_transition_running() -> None:
-    nav = Navigator.routes([PageRoute(builder=_FlagWidget), PageRoute(builder=_FlagWidget)])
+    nav = Navigator.routes([Route(builder=_FlagWidget), Route(builder=_FlagWidget)])
 
     # Simulate an in-flight pop transition without requiring App.animate.
     handle = _Handle()

--- a/tests/test_overlay_aware.py
+++ b/tests/test_overlay_aware.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from nuiitivet.layout.container import Container
-from nuiitivet.overlay import DialogRoute, Overlay, OverlayAware, OverlayHandle
+from nuiitivet.overlay import OverlayRoute, Overlay, OverlayAware, OverlayHandle
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 
 
@@ -44,7 +44,7 @@ def test_overlay_aware_injected_on_show_light_dismiss() -> None:
 def test_overlay_aware_injected_when_passed_via_route() -> None:
     overlay = Overlay()
     dialog = _AwareDialog()
-    route = DialogRoute(builder=lambda: dialog)
+    route = OverlayRoute(builder=lambda: dialog)
 
     handle = overlay.show_modal(route, dismiss_on_outside_tap=False)
 

--- a/tests/test_overlay_dialog.py
+++ b/tests/test_overlay_dialog.py
@@ -5,7 +5,7 @@ import asyncio
 from nuiitivet.layout.stack import Stack
 from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.overlay.dialog_route import DialogRoute
+from nuiitivet.overlay.overlay_route import OverlayRoute
 from nuiitivet.overlay import Overlay
 from nuiitivet.overlay.result import OverlayDismissReason
 from nuiitivet.overlay.result import OverlayResult
@@ -103,7 +103,7 @@ def test_overlay_dialog_ok_button_clickable_via_app_routing() -> None:
     assert clicked == [True]
 
 
-def test_overlay_dialog_dialogroute_barrier_dismissible_true_closes_on_barrier_click() -> None:
+def test_overlay_dialog_overlayroute_barrier_dismissible_true_closes_on_barrier_click() -> None:
     overlay = Overlay()
     overlay.show_modal(AlertDialog(title="Title"), dismiss_on_outside_tap=True)
 
@@ -210,9 +210,9 @@ def test_overlay_dialog_async_resolves_none_on_close_without_result() -> None:
     assert result.reason is OverlayDismissReason.CLOSED
 
 
-def test_overlay_dialogroute_uses_barrier_dismissible_default_true() -> None:
+def test_overlay_overlayroute_uses_barrier_dismissible_default_true() -> None:
     overlay = Overlay()
-    route = DialogRoute(builder=lambda: AlertDialog(title="Route Dialog"), barrier_dismissible=True)
+    route = OverlayRoute(builder=lambda: AlertDialog(title="Route Dialog"), barrier_dismissible=True)
     overlay.show_modal(route)
 
     root = Stack(children=[overlay], alignment="center")
@@ -225,9 +225,9 @@ def test_overlay_dialogroute_uses_barrier_dismissible_default_true() -> None:
     assert overlay.has_entries() is False
 
 
-def test_overlay_dialogroute_uses_barrier_dismissible_default_false() -> None:
+def test_overlay_overlayroute_uses_barrier_dismissible_default_false() -> None:
     overlay = Overlay()
-    route = DialogRoute(builder=lambda: AlertDialog(title="Route Dialog"), barrier_dismissible=False)
+    route = OverlayRoute(builder=lambda: AlertDialog(title="Route Dialog"), barrier_dismissible=False)
     overlay.show_modal(route)
 
     root = Stack(children=[overlay], alignment="center")
@@ -263,7 +263,7 @@ def test_overlay_show_modal_widget_and_route_have_disposal_parity() -> None:
 
     overlay_route = Overlay()
     route_widget = _UnmountCountWidget()
-    route_input = DialogRoute(builder=lambda: route_widget, barrier_dismissible=False)
+    route_input = OverlayRoute(builder=lambda: route_widget, barrier_dismissible=False)
     overlay_route.show_modal(route_input, dismiss_on_outside_tap=False)
     overlay_route.close_topmost()
 

--- a/tests/test_overlay_intent_and_loading.py
+++ b/tests/test_overlay_intent_and_loading.py
@@ -11,7 +11,7 @@ from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.material.overlay import MaterialOverlay
 from nuiitivet.overlay.intents import LoadingDialogIntent
 from nuiitivet.overlay.dialogs import PlainLoadingDialog
-from nuiitivet.overlay.dialog_route import DialogRoute
+from nuiitivet.overlay.overlay_route import OverlayRoute
 from nuiitivet.navigation.transition_spec import EmptyTransitionSpec
 from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
@@ -67,7 +67,7 @@ def test_material_overlay_dialog_accepts_widget_without_manual_dialog_route() ->
 
     route = overlay._normalize_dialog_to_route(widget, dismiss_on_outside_tap=False)
 
-    assert isinstance(route, DialogRoute)
+    assert isinstance(route, OverlayRoute)
     assert route.barrier_dismissible is False
 
     overlay.dialog(widget, dismiss_on_outside_tap=False)
@@ -76,7 +76,7 @@ def test_material_overlay_dialog_accepts_widget_without_manual_dialog_route() ->
 
 def test_material_overlay_dialog_accepts_custom_route_without_wrapping() -> None:
     overlay = MaterialOverlay(intents={})
-    route = DialogRoute(builder=lambda: AlertDialog(title="Custom route"), barrier_dismissible=False)
+    route = OverlayRoute(builder=lambda: AlertDialog(title="Custom route"), barrier_dismissible=False)
 
     normalized = overlay._normalize_dialog_to_route(route, dismiss_on_outside_tap=False)
 

--- a/tests/test_overlay_transition_lifecycle.py
+++ b/tests/test_overlay_transition_lifecycle.py
@@ -7,7 +7,7 @@ from nuiitivet.layout.stack import Stack
 from nuiitivet.material.dialogs import AlertDialog
 from nuiitivet.observable import runtime as observable_runtime
 from nuiitivet.overlay import Overlay
-from nuiitivet.overlay.dialog_route import DialogRoute
+from nuiitivet.overlay.overlay_route import OverlayRoute
 from nuiitivet.overlay.overlay_entry import OverlayEntry
 from nuiitivet.overlay.overlay import _OverlayEntryRoute
 from nuiitivet.navigation.transition_spec import TransitionPhase
@@ -53,7 +53,7 @@ def test_overlay_route_enter_exit_lifecycle_is_transition_driven() -> None:
         root.mount(_DummyApp())
         root.layout(800, 600)
 
-        route = DialogRoute(
+        route = OverlayRoute(
             builder=lambda: AlertDialog(title="Lifecycle"),
             transition_spec=_AnimatedTransitionSpec(),
             barrier_dismissible=False,
@@ -99,7 +99,7 @@ def test_overlay_transition_does_not_leak_clock_callbacks_after_repeated_show_cl
         root.layout(800, 600)
 
         for _ in range(10):
-            route = DialogRoute(
+            route = OverlayRoute(
                 builder=lambda: AlertDialog(title="Perf"),
                 transition_spec=_AnimatedTransitionSpec(),
                 barrier_dismissible=False,
@@ -137,7 +137,7 @@ def test_overlay_on_disposed_runs_once_after_exit_complete() -> None:
             callback_calls.append(has_modal)
 
         entry = OverlayEntry(builder=_build, on_dispose=_on_disposed)
-        route = DialogRoute(
+        route = OverlayRoute(
             builder=entry.build_widget,
             transition_spec=_AnimatedTransitionSpec(),
             barrier_dismissible=False,

--- a/tests/test_will_pop.py
+++ b/tests/test_will_pop.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from nuiitivet.modifiers import will_pop
-from nuiitivet.navigation import Navigator, PageRoute
+from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -47,8 +47,8 @@ def test_navigator_pop_respects_will_pop_cancel() -> None:
 
     nav = Navigator.routes(
         [
-            PageRoute(builder=lambda: _FlagWidget(label="root")),
-            PageRoute(builder=lambda: outgoing.modifier(will_pop(on_will_pop))),
+            Route(builder=lambda: _FlagWidget(label="root")),
+            Route(builder=lambda: outgoing.modifier(will_pop(on_will_pop))),
         ]
     )
 
@@ -70,8 +70,8 @@ def test_navigator_pop_respects_will_pop_allow() -> None:
 
     nav = Navigator.routes(
         [
-            PageRoute(builder=lambda: _FlagWidget(label="root")),
-            PageRoute(builder=lambda: outgoing.modifier(will_pop(on_will_pop))),
+            Route(builder=lambda: _FlagWidget(label="root")),
+            Route(builder=lambda: outgoing.modifier(will_pop(on_will_pop))),
         ]
     )
 
@@ -107,8 +107,8 @@ def test_navigator_pop_calls_will_pop_inside_build() -> None:
     outgoing = Outgoing()
     nav = Navigator.routes(
         [
-            PageRoute(builder=lambda: _FlagWidget(label="root")),
-            PageRoute(builder=lambda: outgoing),
+            Route(builder=lambda: _FlagWidget(label="root")),
+            Route(builder=lambda: outgoing),
         ]
     )
 
@@ -200,8 +200,8 @@ def test_normal_pop_allowed_works_after_previous_cancel() -> None:
 
     nav = Navigator.routes(
         [
-            PageRoute(builder=lambda: _FlagWidget(label="root")),
-            PageRoute(builder=lambda: _FlagWidget(label="outgoing").modifier(will_pop(on_will_pop))),
+            Route(builder=lambda: _FlagWidget(label="root")),
+            Route(builder=lambda: _FlagWidget(label="outgoing").modifier(will_pop(on_will_pop))),
         ]
     )
     nav.rebuild()


### PR DESCRIPTION
## Summary

Closes #152

Clarifies route class naming to better reflect their actual roles.

## Changes

- **Remove `PageRoute`**: The subclass added no fields or behavior over `Route`.
  `Navigator`, `MaterialNavigator`, and `Overlay` now use `Route` directly.
- **Rename `DialogRoute` → `OverlayRoute`**: `DialogRoute` was used for dialogs,
  loading indicators, bottom sheets, and side sheets — far broader than "dialog".
  `OverlayRoute` accurately reflects this responsibility and aligns with the
  `Overlay` class naming.
- **File rename**: `overlay/dialog_route.py` → `overlay/overlay_route.py`
- **Docs & samples updated**: All references in `docs/`, `src/samples/`, and
  `mkdocs.yml` updated accordingly.

## Result

```
Route               ← replaces PageRoute; used by Navigator
  └─ OverlayRoute   ← replaces DialogRoute; used by Overlay
```

## Checklist

- [x] Remove `PageRoute`; `Navigator` / `MaterialNavigator` use `Route` directly
- [x] Rename `dialog_route.py` → `overlay_route.py` and `DialogRoute` → `OverlayRoute`
- [x] Update all import sites across `src/` and `tests/`
- [x] mypy ✅  pytest (1210 passed) ✅  flake8 ✅