### PR TITLE
refactor(dialogs): rename AlertDialog → BasicDialog to align with MD3 terminology

### DIFF
--- a/docs/design/MODIFIER.md
+++ b/docs/design/MODIFIER.md
@@ -74,7 +74,7 @@ For details on the node-based interaction system, see [INTERACTION_ARCHITECTURE.
 
 * **`will_pop(on_will_pop)`**: Intercepts and potentially cancels a back-navigation (pop) request.
 * **Callback**: `on_will_pop` is an `async` function that returns `True` (allow pop) or `False` (cancel pop).
-* **Usage**: Commonly used to show an `AlertDialog` for confirming unsaved changes before leaving a screen. For more details on navigation flow, see [NAVIGATION.md](NAVIGATION.md).
+* **Usage**: Commonly used to show a `BasicDialog` for confirming unsaved changes before leaving a screen. For more details on navigation flow, see [NAVIGATION.md](NAVIGATION.md).
 
 ### Visibility
 

--- a/docs/design/NAVIGATION.md
+++ b/docs/design/NAVIGATION.md
@@ -277,7 +277,7 @@ async def _on_will_pop(self) -> bool:
     """Return True to continue pop, False to cancel."""
     if self.has_unsaved_changes.value:
         confirmed = await Overlay.root().dialog(
-            AlertDialog(
+            BasicDialog(
                 title=Text("Confirmation"),
                 content=Text("Go back without saving?"),
                 actions=[

--- a/docs/design/OVERLAY.md
+++ b/docs/design/OVERLAY.md
@@ -193,7 +193,7 @@ Scenario-specific APIs are moved to subclasses.
 - `MaterialOverlay` allows for `IntentResolver` injection.
   - Alternatively, pass `intents: Mapping[type[Any], Callable[[Any], Widget | Route]]` (internally builds a mapping resolver).
 - Register standard intents by default:
-  - `AlertDialogIntent`
+  - `BasicDialogIntent`
   - `LoadingDialogIntent`
 
 #### Provided APIs (v1)
@@ -237,7 +237,7 @@ In the Material implementation, `MaterialApp` sets `overlay_factory` internally 
 ### 2.8 Note: Scope of core APIs
 
 - `Overlay.show_modal()` / `Overlay.show_modeless()` / `Overlay.show_light_dismiss()` are not responsible for intent registration or providing standard dialog/widgets.
-- Standard UI components (e.g., `AlertDialog`, `LoadingDialog`) and intents are provided by `MaterialOverlay`.
+- Standard UI components (e.g., `BasicDialog`, `LoadingDialog`) and intents are provided by `MaterialOverlay`.
 
 ## 3. Asynchronous Processing and Lifecycle
 

--- a/docs/design/PROGRAMMING_PARADIMS.md
+++ b/docs/design/PROGRAMMING_PARADIMS.md
@@ -36,7 +36,7 @@ Some UI components sit on the boundary between declarative (structure) and imper
 from nuiitivet.material import ButtonStyle
 # Use await within an event handler to wait for result
 result = await Overlay.dialog(
-    child=AlertDialog(
+    child=BasicDialog(
         title=Text("Confirm"),
         content=Text("Are you sure?"),
         actions=[
@@ -56,7 +56,7 @@ The `Overlay` is defined as a layer independent of the root content and is passe
 
 ##### 1. Using Standard Dialogs
 
-The framework provides standard dialog Widgets (e.g., `AlertDialog`) and makes standard Dialog Intents available by default.
+The framework provides standard dialog Widgets (e.g., `BasicDialog`) and makes standard Dialog Intents available by default.
 
 A ViewModel does not create Widgets directly but issues Intents to an abstract interface like `IOverlay`.
 The actual Widget creation is delegated to the View layer (via `dialogs` configuration), allowing for the reuse of dialogs with a standard look and feel.
@@ -67,7 +67,7 @@ class MyViewModel:
         self.overlay = overlay
 
     async def on_error(self, error_msg):
-        await self.overlay.dialog(AlertDialogIntent(title="Error", message=error_msg))
+        await self.overlay.dialog(BasicDialogIntent(title="Error", message=error_msg))
 ```
 
 ##### 2. Using Custom Dialogs
@@ -89,7 +89,7 @@ if __name__ == "__main__":
         # Register Intent (standard intents available by default)
         dialogs={
             ConfirmIntent: lambda intent: OverlayRoute(
-                builder=lambda: AlertDialog(
+                builder=lambda: BasicDialog(
                     title=Text(intent.title),
                     content=Text(intent.message),
                     actions=[

--- a/docs/guide/dialogs.md
+++ b/docs/guide/dialogs.md
@@ -1,12 +1,12 @@
 ## Introduction
 
-nuiitivet offers a robust dialog system built on top of the Overlay architecture. While `AlertDialog` is the most common use case, the system is flexible enough to display any widget as a modal dialog and supports advanced architectural patterns like MVVM.
+nuiitivet offers a robust dialog system built on top of the Overlay architecture. While `BasicDialog` is the most common use case, the system is flexible enough to display any widget as a modal dialog and supports advanced architectural patterns like MVVM.
 
 ![Overlay System](../assets/overlay_dialog_toast.png)
 
 ## Basic Usage
 
-The most straightforward way to show a dialog is to create an `AlertDialog` widget and pass it to `Overlay.root().dialog()`.
+The most straightforward way to show a dialog is to create an `BasicDialog` widget and pass it to `Overlay.root().dialog()`.
 
 The `dialog()` method is **awaitable**, meaning you can wait for the user to close the dialog and receive a result.
 
@@ -22,7 +22,7 @@ class BasicDialogDemo(ComposableWidget):
         overlay = Overlay.root()
 
         # Create the dialog widget
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="CONFIRMATION",
             message="Do you want to proceed with this action?",
             actions=[
@@ -71,7 +71,7 @@ class BasicDialogDemo(ComposableWidget):
 
 ## Custom Dialogs
 
-You are not limited to `AlertDialog`. Any Widget can be shown in the overlay. This is useful for custom forms, interactive tools, or specialized prompts.
+You are not limited to `BasicDialog`. Any Widget can be shown in the overlay. This is useful for custom forms, interactive tools, or specialized prompts.
 
 ```python
 from nuiitivet.material import ButtonStyle
@@ -196,7 +196,7 @@ from nuiitivet.material import ButtonStyle
 
 class CoupledViewModel:
     """
-    This ViewModel knows about types like AlertDialog.
+    This ViewModel knows about types like BasicDialog.
     It imports widgets which ties it to the UI layer.
     """
     
@@ -207,7 +207,7 @@ class CoupledViewModel:
         self.status.value = "Processing..."
         
         # Logic creates UI components directly
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="Operation Complete",
             message="Process finished successfully.",
             icon="check_circle",
@@ -229,12 +229,12 @@ class DirectViewModelDemo(ComposableWidget):
 
 For those who prefer a stricter separation of concerns, nuiitivet supports **Intents**. An Intent is a plain data class that describes *what* needs to happen, not *how* it looks. The ViewModel emits an Intent, and the View (or Overlay system) decides how to render it.
 
-By using `AlertDialogIntent`, the ViewModel remains pure logic.
+By using `BasicDialogIntent`, the ViewModel remains pure logic.
 
 ```python
 # src/samples/dialogs/view_model_intent.py (Excerpt)
 
-from nuiitivet.material.intents import AlertDialogIntent
+from nuiitivet.material.intents import BasicDialogIntent
 
 class DecoupledViewModel:
     """
@@ -249,7 +249,7 @@ class DecoupledViewModel:
         self.status.value = "Processing..."
         
         # We just create a data description of what we want
-        intent = AlertDialogIntent(
+        intent = BasicDialogIntent(
             title="Operation Complete",
             message="Process finished successfully.",
             icon="check_circle"

--- a/docs/guide/modifier_others.md
+++ b/docs/guide/modifier_others.md
@@ -34,7 +34,7 @@ import nuiitivet as nv
 import nuiitivet.material as md
 from dataclasses import dataclass
 from nuiitivet.material.buttons import Button
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material import Overlay
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
@@ -92,7 +92,7 @@ class EditScreen(nv.ComposableWidget):
             Navigator.root().pop()
 
         Overlay.root().dialog(
-            AlertDialog(
+            BasicDialog(
                 title="Discard changes?",
                 message="You have unsaved changes.",
                 actions=[

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from .card import Card
     from .styles.card_style import CardStyle
     from .chip import AssistChip, FilterChip, InputChip, SuggestionChip
-    from .dialogs import AlertDialog
+    from .dialogs import BasicDialog
     from .loading_indicator import LoadingIndicator
     from .progress_indicators import (
         CircularProgressIndicator,
@@ -104,7 +104,7 @@ __all__ = [
     "RailItem",
     "MaterialOverlay",
     "Overlay",
-    "AlertDialog",
+    "BasicDialog",
     "LoadingIndicator",
     "LinearProgressIndicator",
     "IndeterminateLinearProgressIndicator",
@@ -185,7 +185,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "RailItem": ("navigation_rail", "RailItem"),
     "MaterialOverlay": ("overlay", "MaterialOverlay"),
     "Overlay": ("overlay", "MaterialOverlay"),
-    "AlertDialog": ("dialogs", "AlertDialog"),
+    "BasicDialog": ("dialogs", "BasicDialog"),
     "LoadingIndicator": ("loading_indicator", "LoadingIndicator"),
     "LinearProgressIndicator": ("progress_indicators", "LinearProgressIndicator"),
     "IndeterminateLinearProgressIndicator": ("progress_indicators", "IndeterminateLinearProgressIndicator"),

--- a/src/nuiitivet/material/app.py
+++ b/src/nuiitivet/material/app.py
@@ -23,7 +23,7 @@ class MaterialApp(App):
 
     This class configures the App with Material Design defaults:
     - Material Theme (light/dark)
-    - Material Dialogs (Alert, Loading)
+    - Material Overlay (Dialog, Loading)
     - Material Background color
     - Material Navigator (with Material page transitions)
 

--- a/src/nuiitivet/material/dialogs.py
+++ b/src/nuiitivet/material/dialogs.py
@@ -1,7 +1,6 @@
 """Material Design Basic Dialog implementation.
 
-This module contains the implementation of the Material Design 3 Basic Dialog,
-specifically AlertDialog.
+This module contains the implementation of the Material Design 3 Basic Dialog.
 """
 
 from __future__ import annotations
@@ -26,8 +25,8 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-class AlertDialog(ComposableWidget):
-    """Material Alert dialog widget (Basic Dialog).
+class BasicDialog(ComposableWidget):
+    """Material dialog widget (Basic Dialog).
 
     Displays a modal dialog with optional icon, title, content, and action buttons.
     Follows Material Design 3 dialog guidelines.
@@ -60,7 +59,7 @@ class AlertDialog(ComposableWidget):
         style: Optional[DialogStyle] = None,
         width: float = 280.0,
     ):
-        """Initialize AlertDialog.
+        """Initialize BasicDialog.
 
         Args:
             title: Optional title text source.
@@ -89,7 +88,7 @@ class AlertDialog(ComposableWidget):
 
         theme_data = manager.current.extension(MaterialThemeData)
         if theme_data:
-            return theme_data.alert_dialog_style
+            return theme_data.basic_dialog_style
 
         return DialogStyle.basic()
 

--- a/src/nuiitivet/material/intents.py
+++ b/src/nuiitivet/material/intents.py
@@ -10,8 +10,8 @@ from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
-class AlertDialogIntent:
-    """Intent for showing a Material Alert Dialog.
+class BasicDialogIntent:
+    """Intent for showing a Material Basic Dialog.
 
     Attributes:
         title (str | None): The title of the dialog.

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Literal, Mapping
 from nuiitivet.material.loading_indicator import LoadingIndicator
 from nuiitivet.material.buttons import Button
 from nuiitivet.material.styles.button_style import ButtonStyle
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.snackbar import Snackbar
 from nuiitivet.navigation.route import Route
 from nuiitivet.overlay.overlay_route import OverlayRoute
@@ -24,7 +24,7 @@ from .transition_spec import (
     MaterialTransitionSpec,
 )
 
-from .intents import AlertDialogIntent, LoadingIntent
+from .intents import BasicDialogIntent, LoadingIntent
 
 
 class _MappingIntentResolver(IntentResolver):
@@ -54,8 +54,8 @@ class MaterialOverlay(Overlay):
 
         if intent_resolver is None:
             defaults: dict[type[Any], Callable[[Any], Widget | Route]] = {
-                AlertDialogIntent: lambda i: OverlayRoute(
-                    builder=lambda: AlertDialog(
+                BasicDialogIntent: lambda i: OverlayRoute(
+                    builder=lambda: BasicDialog(
                         title=i.title,
                         message=i.message,
                         icon=i.icon,

--- a/src/nuiitivet/material/styles/dialog_style.py
+++ b/src/nuiitivet/material/styles/dialog_style.py
@@ -62,8 +62,3 @@ class DialogStyle:
     def basic(cls) -> "DialogStyle":
         """Default Basic Dialog style."""
         return cls()
-
-    @classmethod
-    def alert(cls) -> "DialogStyle":
-        """Alert Dialog style (alias for basic, can be customized)."""
-        return cls()

--- a/src/nuiitivet/material/theme/theme_data.py
+++ b/src/nuiitivet/material/theme/theme_data.py
@@ -63,7 +63,7 @@ class MaterialThemeData(ThemeExtension):
     _radio_button_style: "RadioButtonStyle | None" = None
     _switch_style: "SwitchStyle | None" = None
     _slider_style: "SliderStyle | None" = None
-    _alert_dialog_style: "DialogStyle | None" = None
+    _basic_dialog_style: "DialogStyle | None" = None
     _icon_style: "IconStyle | None" = None
     _text_style: "TextStyle | None" = None
 
@@ -247,10 +247,10 @@ class MaterialThemeData(ThemeExtension):
         return SliderStyle.xs()
 
     @property
-    def alert_dialog_style(self) -> "DialogStyle":
+    def basic_dialog_style(self) -> "DialogStyle":
         """Get DialogStyle for this theme."""
-        if self._alert_dialog_style is not None:
-            return self._alert_dialog_style
+        if self._basic_dialog_style is not None:
+            return self._basic_dialog_style
         from nuiitivet.material.styles.dialog_style import DialogStyle
 
         return DialogStyle.basic()

--- a/src/nuiitivet/overlay/overlay.py
+++ b/src/nuiitivet/overlay/overlay.py
@@ -273,7 +273,7 @@ class Overlay(ComposableWidget):
 
         # Show a dialog
         def build_dialog():
-            return AlertDialog(...)
+            return BasicDialog(...)
 
         entry = OverlayEntry(builder=build_dialog)
         overlay.insert_entry(entry)

--- a/src/nuiitivet/overlay/overlay_entry.py
+++ b/src/nuiitivet/overlay/overlay_entry.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from nuiitivet.common.logging_once import exception_once
 
-
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -23,7 +22,7 @@ class OverlayEntry:
 
     Example:
         def build_dialog():
-            return AlertDialog(
+            return BasicDialog(
                 title="Confirm",
                 content="Are you sure?",
                 actions=[

--- a/src/samples/async_demo.py
+++ b/src/samples/async_demo.py
@@ -41,7 +41,7 @@ class AsyncDemoApp(nv.ComposableWidget):
 
         # 2. Show confirmation dialog and await result
         result = await md.Overlay.root().dialog(
-            md.AlertDialog(
+            md.BasicDialog(
                 title="Task Finished",
                 message=f"Count reached {self.counter.value}. Reset?",
                 actions=[

--- a/src/samples/dialogs/basic_usage.py
+++ b/src/samples/dialogs/basic_usage.py
@@ -1,12 +1,12 @@
 """
 Basic Dialog Usage
 
-Shows how to display a standard AlertDialog using Overlay.
+Shows how to display a standard BasicDialog using Overlay.
 """
 
 from nuiitivet.material import App
 from nuiitivet.material.buttons import Button
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.layout.column import Column
@@ -24,18 +24,12 @@ class BasicDialogDemo(ComposableWidget):
         overlay = Overlay.root()
 
         # Create the dialog widget
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="CONFIRMATION",
             message="Do you want to proceed with this action?",
             actions=[
-                Button(
-                    "CANCEL",
-                    on_click=lambda: overlay.close("Canceled"),
-                    style=ButtonStyle.text()),
-                Button(
-                    "OK",
-                    on_click=lambda: overlay.close("Confirmed"),
-                    style=ButtonStyle.text()),
+                Button("CANCEL", on_click=lambda: overlay.close("Canceled"), style=ButtonStyle.text()),
+                Button("OK", on_click=lambda: overlay.close("Confirmed"), style=ButtonStyle.text()),
             ],
         )
 
@@ -53,10 +47,7 @@ class BasicDialogDemo(ComposableWidget):
                 gap=20,
                 children=[
                     Text(self.result_text),
-                    Button(
-                        "Show Alert Dialog",
-                        on_click=self._show_dialog,
-                        style=ButtonStyle.filled()),
+                    Button("Show Basic Dialog", on_click=self._show_dialog, style=ButtonStyle.filled()),
                 ],
             ),
         )
@@ -65,7 +56,7 @@ class BasicDialogDemo(ComposableWidget):
 def main(png_path: str = ""):
     if png_path:
         # For screenshot, render the dialog directly
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="CONFIRMATION",
             message="Do you want to proceed with this action?",
             actions=[Button("CANCEL", style=ButtonStyle.text()), Button("OK", style=ButtonStyle.text())],

--- a/src/samples/dialogs/view_model_direct.py
+++ b/src/samples/dialogs/view_model_direct.py
@@ -1,13 +1,13 @@
 """
 ViewModel Direct Usage (Coupled)
 
-Shows a ViewModel pattern where the ViewModel depends directly on UI components (AlertDialog).
+Shows a ViewModel pattern where the ViewModel depends directly on UI components (BasicDialog).
 This is simpler but creates strong coupling between Logic and View.
 """
 
 from nuiitivet.material import App
 from nuiitivet.material.buttons import Button
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.layout.column import Column
@@ -26,8 +26,8 @@ class CoupledViewModel:
     async def process_action(self, overlay: Overlay):
         self.status.value = "Processing..."
 
-        # ViewModel creates and configures the View (AlertDialog)
-        dialog = AlertDialog(
+        # ViewModel creates and configures the View (BasicDialog)
+        dialog = BasicDialog(
             title="Operation Complete",
             message="Process finished successfully.",
             icon="check_circle",
@@ -56,10 +56,7 @@ class DirectViewModelDemo(ComposableWidget):
                 gap=20,
                 children=[
                     Text(self.vm.status),
-                    Button(
-                        "Run Process",
-                        on_click=self._on_run_click,
-                        style=ButtonStyle.filled()),
+                    Button("Run Process", on_click=self._on_run_click, style=ButtonStyle.filled()),
                 ],
             ),
         )
@@ -68,7 +65,7 @@ class DirectViewModelDemo(ComposableWidget):
 def main(png_path: str = ""):
     if png_path:
         # Screenshot: Render the dialog that the ViewModel would create
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="Operation Complete",
             message="Process finished successfully.",
             icon="check_circle",

--- a/src/samples/dialogs/view_model_intent.py
+++ b/src/samples/dialogs/view_model_intent.py
@@ -1,14 +1,14 @@
 """
 ViewModel Intent Usage
 
-Shows how to trigger a standard AlertDialog using an Intent from a ViewModel-like structure.
+Shows how to trigger a standard BasicDialog using an Intent from a ViewModel-like structure.
 This decouples the presentation logic (ViewModel) from the View implementation.
 """
 
 from nuiitivet.material import App
 from nuiitivet.material.buttons import Button
-from nuiitivet.material.dialogs import AlertDialog
-from nuiitivet.material.intents import AlertDialogIntent
+from nuiitivet.material.dialogs import BasicDialog
+from nuiitivet.material.intents import BasicDialogIntent
 from nuiitivet.material import Overlay
 from nuiitivet.material.text import Text
 from nuiitivet.layout.column import Column
@@ -28,7 +28,7 @@ class DecoupledViewModel:
         self.status.value = "Processing..."
 
         # Express the intent to show an operation complete dialog
-        intent = AlertDialogIntent(
+        intent = BasicDialogIntent(
             title="Operation Complete", message="Process finished successfully.", icon="check_circle"
         )
 
@@ -52,10 +52,7 @@ class IntentDemo(ComposableWidget):
                 gap=20,
                 children=[
                     Text(self.vm.status),
-                    Button(
-                        "Run Process",
-                        on_click=self._on_run_click,
-                        style=ButtonStyle.filled()),
+                    Button("Run Process", on_click=self._on_run_click, style=ButtonStyle.filled()),
                 ],
             ),
         )
@@ -63,7 +60,7 @@ class IntentDemo(ComposableWidget):
 
 def main(png_path: str = ""):
     if png_path:
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="Operation Complete",
             message="Process finished successfully.",
             icon="check_circle",

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import nuiitivet as nv
 import nuiitivet.material as md
 from nuiitivet.material.buttons import Button
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material import Overlay
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
@@ -63,7 +63,7 @@ class EditScreen(nv.ComposableWidget):
             Navigator.root().pop()
 
         Overlay.root().dialog(
-            AlertDialog(
+            BasicDialog(
                 title="Discard changes?",
                 message="You have unsaved changes.",
                 actions=[

--- a/src/samples/overlay_demo.py
+++ b/src/samples/overlay_demo.py
@@ -1,8 +1,8 @@
-"""Overlay Demo - Snackbar and AlertDialog examples.
+"""Overlay Demo - Snackbar and BasicDialog examples.
 
 This demo shows how to use the Overlay system:
 - Snackbar messages with auto-removal
-- AlertDialog with custom content and actions
+- BasicDialog with custom content and actions
 """
 
 import logging
@@ -12,12 +12,11 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.observable import Observable
 from nuiitivet.material import Overlay
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.buttons import Button
 from nuiitivet.material import Text
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.material import ButtonStyle
-
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +56,7 @@ class OverlayDemo(ComposableWidget):
             overlay.close_topmost()
 
         overlay.dialog(
-            AlertDialog(
+            BasicDialog(
                 title="Information",
                 message="This is an information dialog.",
                 actions=[
@@ -83,7 +82,7 @@ class OverlayDemo(ComposableWidget):
             overlay.close_topmost()
 
         overlay.dialog(
-            AlertDialog(
+            BasicDialog(
                 title="Confirm Action",
                 message="Are you sure you want to proceed?",
                 actions=[
@@ -107,7 +106,7 @@ class OverlayDemo(ComposableWidget):
         from nuiitivet.material.styles.dialog_style import DialogStyle
 
         overlay.dialog(
-            AlertDialog(
+            BasicDialog(
                 title="Custom Dialog",
                 message="This dialog has custom content.\nMultiple lines are supported.",
                 actions=[

--- a/src/samples/overlay_navigator_demo.py
+++ b/src/samples/overlay_navigator_demo.py
@@ -16,7 +16,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.modifiers import background
 from nuiitivet.navigation import Navigator, Route
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material import App
 from nuiitivet.material import Overlay
 from nuiitivet.material.buttons import Button
@@ -149,7 +149,7 @@ def main() -> None:
         def on_ok() -> None:
             Overlay.root().close("OK", target=dialog)
 
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="Hello",
             message="This dialog is rendered via Overlay (Intent).",
             actions=[_filled("OK", on_click=on_ok)],
@@ -165,7 +165,7 @@ def main() -> None:
         def on_reset() -> None:
             Overlay.root().close(True, target=dialog)
 
-        dialog = AlertDialog(
+        dialog = BasicDialog(
             title="Confirm",
             message="Reset settings?",
             actions=[

--- a/tests/test_basic_dialog.py
+++ b/tests/test_basic_dialog.py
@@ -1,6 +1,6 @@
-"""Tests for AlertDialog widget."""
+"""Tests for BasicDialog widget."""
 
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.styles.dialog_style import DialogStyle
 from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
@@ -13,9 +13,9 @@ def material_theme():
     manager.set_theme(MaterialTheme.light("#6750A4"))
 
 
-def test_alert_dialog_creation():
-    """Test creating an AlertDialog."""
-    dialog = AlertDialog(
+def test_basic_dialog_creation():
+    """Test creating a BasicDialog."""
+    dialog = BasicDialog(
         title="Test Title",
         message="Test Content",
     )
@@ -25,8 +25,8 @@ def test_alert_dialog_creation():
     assert dialog.actions == []
 
 
-def test_alert_dialog_with_actions():
-    """Test AlertDialog with action buttons."""
+def test_basic_dialog_with_actions():
+    """Test BasicDialog with action buttons."""
     from nuiitivet.material.buttons import Button
 
     actions = [
@@ -34,7 +34,7 @@ def test_alert_dialog_with_actions():
         Button("OK", style=ButtonStyle.text()),
     ]
 
-    dialog = AlertDialog(
+    dialog = BasicDialog(
         title="Confirm",
         message="Are you sure?",
         actions=actions,
@@ -43,9 +43,9 @@ def test_alert_dialog_with_actions():
     assert len(dialog.actions) == 2
 
 
-def test_alert_dialog_build():
-    """Test building an AlertDialog."""
-    dialog = AlertDialog(
+def test_basic_dialog_build():
+    """Test building a BasicDialog."""
+    dialog = BasicDialog(
         title="Title",
         message="Content",
     )
@@ -65,9 +65,9 @@ def test_alert_dialog_build():
     # Or just ensure it built.
 
 
-def test_alert_dialog_minimal():
-    """Test minimal AlertDialog (no title, content, or actions)."""
-    dialog = AlertDialog()
+def test_basic_dialog_minimal():
+    """Test minimal BasicDialog (no title, content, or actions)."""
+    dialog = BasicDialog()
 
     assert dialog.title is None
     assert dialog.message is None
@@ -78,20 +78,20 @@ def test_alert_dialog_minimal():
     assert built is not None
 
 
-def test_alert_dialog_style_override():
-    """Test AlertDialog with custom style."""
+def test_basic_dialog_style_override():
+    """Test BasicDialog with custom style."""
     custom_style = DialogStyle(corner_radius=16.0, min_width=400.0, padding=32)
 
-    dialog = AlertDialog(title="Props", style=custom_style)
+    dialog = BasicDialog(title="Props", style=custom_style)
 
     assert dialog.style.corner_radius == 16.0
     assert dialog.style.min_width == 400.0
     assert dialog.style.padding == 32
 
 
-def test_alert_dialog_only_title():
-    """Test AlertDialog with only title."""
-    dialog = AlertDialog(
+def test_basic_dialog_only_title():
+    """Test BasicDialog with only title."""
+    dialog = BasicDialog(
         title="Title only",
     )
 
@@ -100,9 +100,9 @@ def test_alert_dialog_only_title():
     assert dialog.actions == []
 
 
-def test_alert_dialog_only_content():
-    """Test AlertDialog with only content."""
-    dialog = AlertDialog(
+def test_basic_dialog_only_content():
+    """Test BasicDialog with only content."""
+    dialog = BasicDialog(
         message="Content only",
     )
 
@@ -110,9 +110,9 @@ def test_alert_dialog_only_content():
     assert dialog.message is not None
 
 
-def test_alert_dialog_with_icon():
-    """Test AlertDialog with icon."""
-    dialog = AlertDialog(icon="home", title="With Icon")
+def test_basic_dialog_with_icon():
+    """Test BasicDialog with icon."""
+    dialog = BasicDialog(icon="home", title="With Icon")
     assert dialog.icon == "home"
 
     dialog.build()
@@ -120,7 +120,7 @@ def test_alert_dialog_with_icon():
     # but at least it builds.
 
 
-def test_alert_dialog_default_background_is_surface_container_high():
+def test_basic_dialog_default_background_is_surface_container_high():
     """MD3 Basic Dialog uses surface-container-high (not highest)."""
     from nuiitivet.material.theme.color_role import ColorRole
 
@@ -128,17 +128,17 @@ def test_alert_dialog_default_background_is_surface_container_high():
     assert style.background == ColorRole.SURFACE_CONTAINER_HIGH
 
 
-def test_alert_dialog_default_width_is_md3_min():
-    """AlertDialog default width is the MD3 minimum (280dp)."""
-    dialog = AlertDialog(title="t")
+def test_basic_dialog_default_width_is_md3_min():
+    """BasicDialog default width is the MD3 minimum (280dp)."""
+    dialog = BasicDialog(title="t")
     assert dialog.width == 280.0
 
 
-def test_alert_dialog_custom_width_propagates_to_box():
-    """AlertDialog forwards custom width to the underlying Box."""
+def test_basic_dialog_custom_width_propagates_to_box():
+    """BasicDialog forwards custom width to the underlying Box."""
     from nuiitivet.widgets.box import Box
 
-    dialog = AlertDialog(title="t", width=420.0)
+    dialog = BasicDialog(title="t", width=420.0)
     assert dialog.width == 420.0
 
     built = dialog.build()

--- a/tests/test_overlay_dialog.py
+++ b/tests/test_overlay_dialog.py
@@ -4,7 +4,7 @@ import asyncio
 
 from nuiitivet.layout.stack import Stack
 from nuiitivet.input.pointer import PointerEventType
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.overlay.overlay_route import OverlayRoute
 from nuiitivet.overlay import Overlay
 from nuiitivet.overlay.result import OverlayDismissReason
@@ -30,7 +30,7 @@ def material_theme():
 
 def test_overlay_dialog_inserts_entry_with_barrier_and_dialog() -> None:
     overlay = Overlay()
-    dialog = AlertDialog(title="Title", message="Body")
+    dialog = BasicDialog(title="Title", message="Body")
 
     overlay.show_modal(dialog, dismiss_on_outside_tap=False)
 
@@ -60,7 +60,7 @@ def test_overlay_dialog_inserts_entry_with_barrier_and_dialog() -> None:
 
 def test_overlay_show_modal_dismiss_on_outside_tap_false_does_not_close_on_barrier_click() -> None:
     overlay = Overlay()
-    dialog = AlertDialog(title="Title")
+    dialog = BasicDialog(title="Title")
 
     overlay.show_modal(dialog, dismiss_on_outside_tap=False)
 
@@ -82,7 +82,7 @@ def test_overlay_dialog_ok_button_clickable_via_app_routing() -> None:
 
     overlay = Overlay()
     ok_button = Button("OK", on_click=on_ok, style=ButtonStyle.filled())
-    dialog = AlertDialog(title="Title", message="Body", actions=[ok_button])
+    dialog = BasicDialog(title="Title", message="Body", actions=[ok_button])
 
     overlay.show_modal(dialog, dismiss_on_outside_tap=False)
 
@@ -105,7 +105,7 @@ def test_overlay_dialog_ok_button_clickable_via_app_routing() -> None:
 
 def test_overlay_dialog_overlayroute_barrier_dismissible_true_closes_on_barrier_click() -> None:
     overlay = Overlay()
-    overlay.show_modal(AlertDialog(title="Title"), dismiss_on_outside_tap=True)
+    overlay.show_modal(BasicDialog(title="Title"), dismiss_on_outside_tap=True)
 
     root = Stack(children=[overlay], alignment="center")
     root.mount(None)
@@ -125,7 +125,7 @@ def test_overlay_show_modeless_passthrough_allows_background_click() -> None:
 
     bg = Container(width="100%", height="100%").modifier(clickable(on_click=on_bg))
     overlay = Overlay()
-    overlay.show_modeless(AlertDialog(title="Title"))
+    overlay.show_modeless(BasicDialog(title="Title"))
 
     bg.width_sizing = Sizing.flex(100)
     bg.height_sizing = Sizing.flex(100)
@@ -150,7 +150,7 @@ def test_overlay_show_light_dismiss_closes_and_blocks_background_click() -> None
 
     bg = Container(width="100%", height="100%").modifier(clickable(on_click=on_bg))
     overlay = Overlay()
-    overlay.show_light_dismiss(AlertDialog(title="Title"))
+    overlay.show_light_dismiss(BasicDialog(title="Title"))
 
     bg.width_sizing = Sizing.flex(100)
     bg.height_sizing = Sizing.flex(100)
@@ -172,7 +172,7 @@ def test_overlay_show_light_dismiss_closes_and_blocks_background_click() -> None
 def test_overlay_dialog_route_is_disposed_on_close_topmost() -> None:
     overlay = Overlay()
 
-    route = Route(builder=lambda: AlertDialog(title="Title"))
+    route = Route(builder=lambda: BasicDialog(title="Title"))
     overlay.show_modal(route, dismiss_on_outside_tap=False)
 
     # Route widget is created eagerly by Overlay.dialog().
@@ -186,7 +186,7 @@ def test_overlay_dialog_async_resolves_with_close_result() -> None:
     overlay = Overlay()
 
     async def run() -> OverlayResult[bool]:
-        handle = overlay.show_modal(AlertDialog(title="Title"), dismiss_on_outside_tap=False)
+        handle = overlay.show_modal(BasicDialog(title="Title"), dismiss_on_outside_tap=False)
         await asyncio.sleep(0)
         handle.close(True)
         return await handle
@@ -200,7 +200,7 @@ def test_overlay_dialog_async_resolves_none_on_close_without_result() -> None:
     overlay = Overlay()
 
     async def run() -> OverlayResult[None]:
-        handle = overlay.show_modal(AlertDialog(title="Title"), dismiss_on_outside_tap=False)
+        handle = overlay.show_modal(BasicDialog(title="Title"), dismiss_on_outside_tap=False)
         await asyncio.sleep(0)
         handle.close()
         return await handle
@@ -212,7 +212,7 @@ def test_overlay_dialog_async_resolves_none_on_close_without_result() -> None:
 
 def test_overlay_overlayroute_uses_barrier_dismissible_default_true() -> None:
     overlay = Overlay()
-    route = OverlayRoute(builder=lambda: AlertDialog(title="Route Dialog"), barrier_dismissible=True)
+    route = OverlayRoute(builder=lambda: BasicDialog(title="Route Dialog"), barrier_dismissible=True)
     overlay.show_modal(route)
 
     root = Stack(children=[overlay], alignment="center")
@@ -227,7 +227,7 @@ def test_overlay_overlayroute_uses_barrier_dismissible_default_true() -> None:
 
 def test_overlay_overlayroute_uses_barrier_dismissible_default_false() -> None:
     overlay = Overlay()
-    route = OverlayRoute(builder=lambda: AlertDialog(title="Route Dialog"), barrier_dismissible=False)
+    route = OverlayRoute(builder=lambda: BasicDialog(title="Route Dialog"), barrier_dismissible=False)
     overlay.show_modal(route)
 
     root = Stack(children=[overlay], alignment="center")

--- a/tests/test_overlay_handle.py
+++ b/tests/test_overlay_handle.py
@@ -6,7 +6,7 @@ import asyncio
 
 import pytest
 
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.overlay import Overlay
 from nuiitivet.overlay.result import OverlayResult
 from nuiitivet.overlay.result import OverlayDismissReason
@@ -22,7 +22,7 @@ def material_theme():
 def test_overlay_handle_done_and_result_when_closed_before_await() -> None:
     overlay = Overlay()
 
-    handle = overlay.show_modal(AlertDialog(title="Title"), dismiss_on_outside_tap=False)
+    handle = overlay.show_modal(BasicDialog(title="Title"), dismiss_on_outside_tap=False)
     handle.close(True)
 
     assert handle.done() is True
@@ -39,7 +39,7 @@ def test_overlay_handle_result_available_after_await_and_close() -> None:
     overlay = Overlay()
 
     async def run() -> OverlayResult[str]:
-        handle = overlay.show_modal(AlertDialog(title="Title"), dismiss_on_outside_tap=False)
+        handle = overlay.show_modal(BasicDialog(title="Title"), dismiss_on_outside_tap=False)
 
         async def _wait() -> OverlayResult[str]:
             return await handle

--- a/tests/test_overlay_intent_and_loading.py
+++ b/tests/test_overlay_intent_and_loading.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.overlay import MaterialOverlay
 from nuiitivet.overlay.intents import LoadingDialogIntent
 from nuiitivet.overlay.dialogs import PlainLoadingDialog
@@ -30,7 +30,7 @@ class _ConfirmIntent:
 def test_overlay_dialog_intent_resolves_to_widget() -> None:
     overlay = MaterialOverlay(
         intents={
-            _ConfirmIntent: lambda i: AlertDialog(title="Confirm", message=i.message),
+            _ConfirmIntent: lambda i: BasicDialog(title="Confirm", message=i.message),
         }
     )
 
@@ -46,7 +46,7 @@ def test_overlay_dialog_intent_resolves_to_route() -> None:
 
     overlay = MaterialOverlay(
         intents={
-            _ConfirmIntent: lambda i: Route(builder=lambda: AlertDialog(title=i.message)),
+            _ConfirmIntent: lambda i: Route(builder=lambda: BasicDialog(title=i.message)),
         }
     )
 
@@ -63,7 +63,7 @@ def test_overlay_dialog_unknown_intent_raises() -> None:
 
 def test_material_overlay_dialog_accepts_widget_without_manual_dialog_route() -> None:
     overlay = MaterialOverlay(intents={})
-    widget = AlertDialog(title="Widget dialog")
+    widget = BasicDialog(title="Widget dialog")
 
     route = overlay._normalize_dialog_to_route(widget, dismiss_on_outside_tap=False)
 
@@ -76,7 +76,7 @@ def test_material_overlay_dialog_accepts_widget_without_manual_dialog_route() ->
 
 def test_material_overlay_dialog_accepts_custom_route_without_wrapping() -> None:
     overlay = MaterialOverlay(intents={})
-    route = OverlayRoute(builder=lambda: AlertDialog(title="Custom route"), barrier_dismissible=False)
+    route = OverlayRoute(builder=lambda: BasicDialog(title="Custom route"), barrier_dismissible=False)
 
     normalized = overlay._normalize_dialog_to_route(route, dismiss_on_outside_tap=False)
 

--- a/tests/test_overlay_layer_composer.py
+++ b/tests/test_overlay_layer_composer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.overlay import MaterialOverlay
 from nuiitivet.material.overlay_visual_state import MaterialOverlayLayerComposer
 from nuiitivet.overlay import Overlay
@@ -18,7 +18,7 @@ def test_overlay_delegates_layer_composition_to_injected_composer() -> None:
     composer = RecordingOverlayComposer(sentinel)
     overlay = Overlay(layer_composer=composer)
 
-    dialog = AlertDialog(title="Title", message="Body")
+    dialog = BasicDialog(title="Title", message="Body")
     overlay.show_modal(dialog, dismiss_on_outside_tap=False)
 
     entry = next(iter(overlay._entry_to_route.keys()))

--- a/tests/test_overlay_transition_lifecycle.py
+++ b/tests/test_overlay_transition_lifecycle.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from nuiitivet.layout.stack import Stack
-from nuiitivet.material.dialogs import AlertDialog
+from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.observable import runtime as observable_runtime
 from nuiitivet.overlay import Overlay
 from nuiitivet.overlay.overlay_route import OverlayRoute
@@ -54,7 +54,7 @@ def test_overlay_route_enter_exit_lifecycle_is_transition_driven() -> None:
         root.layout(800, 600)
 
         route = OverlayRoute(
-            builder=lambda: AlertDialog(title="Lifecycle"),
+            builder=lambda: BasicDialog(title="Lifecycle"),
             transition_spec=_AnimatedTransitionSpec(),
             barrier_dismissible=False,
         )
@@ -100,7 +100,7 @@ def test_overlay_transition_does_not_leak_clock_callbacks_after_repeated_show_cl
 
         for _ in range(10):
             route = OverlayRoute(
-                builder=lambda: AlertDialog(title="Perf"),
+                builder=lambda: BasicDialog(title="Perf"),
                 transition_spec=_AnimatedTransitionSpec(),
                 barrier_dismissible=False,
             )
@@ -128,8 +128,8 @@ def test_overlay_on_disposed_runs_once_after_exit_complete() -> None:
 
         callback_calls: list[bool] = []
 
-        def _build() -> AlertDialog:
-            return AlertDialog(title="Dispose ordering")
+        def _build() -> BasicDialog:
+            return BasicDialog(title="Dispose ordering")
 
         def _on_disposed() -> None:
             routes = overlay._modal_navigator._routes  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Renames all dialog-related symbols to match Material Design 3 terminology ("Basic Dialog"), replacing the Flutter/Android-derived `AlertDialog` naming convention.

## Changes

| Before | After | Location |
|--------|-------|----------|
| `AlertDialog` | `BasicDialog` | `src/nuiitivet/material/dialogs.py` |
| `AlertDialogIntent` | `BasicDialogIntent` | `src/nuiitivet/material/intents.py` |
| `alert_dialog_style` | `basic_dialog_style` | `src/nuiitivet/material/theme/theme_data.py` |
| `DialogStyle.alert()` | *(removed)* | `src/nuiitivet/material/styles/dialog_style.py` |
| `tests/test_alert_dialog.py` | `tests/test_basic_dialog.py` | tests/ |

All sample files, documentation, and internal references have been updated accordingly.

## Breaking Changes

- `AlertDialog` → `BasicDialog`
- `AlertDialogIntent` → `BasicDialogIntent`
- `alert_dialog_style` → `basic_dialog_style` (on `MaterialThemeData`)
- `DialogStyle.alert()` removed (was an unused alias for `basic()`)

## Testing

All 1210 existing tests pass. No new tests required (rename only).

Closes #103