### PR TITLE
feat(overlay): split MaterialOverlay.loading() into handle and context-manager forms

### DIFF
--- a/docs/design/ASYNCIO_INTEGRATION.md
+++ b/docs/design/ASYNCIO_INTEGRATION.md
@@ -97,7 +97,7 @@ Async handlers and awaited workflows tend to outlive synchronous scopes.
 
 See `src/samples/async_demo.py` for an end-to-end demonstration:
 
-- `async with MaterialOverlay.root().loading(...)` while awaiting work.
+- `async with MaterialOverlay.root().while_loading(...)` while awaiting work.
 - Awaiting `MaterialOverlay.root().dialog(...)`.
 - Updating `Observable` values from async code without `dispatch_to_ui()`.
 

--- a/docs/design/OVERLAY.md
+++ b/docs/design/OVERLAY.md
@@ -210,8 +210,11 @@ Scenario-specific APIs are moved to subclasses.
   - Background input remains interactive (modeless).
   - Automatically dismisses after `timeout=duration`.
   - Default position: `OverlayPosition.alignment("bottom-center", offset=(0, -24))`.
-- `MaterialOverlay.loading(message="Loading...")`
-  - Displays `LoadingDialogIntent` and ensures it closes upon exiting a context manager.
+- `MaterialOverlay.loading(indicator=None)` → `OverlayHandle[Any]`
+  - Displays the loading indicator and returns a handle for manual dismissal.
+  - `handle.close(None)` dismisses the overlay.
+- `MaterialOverlay.while_loading(indicator=None)` → context manager
+  - Displays `LoadingIntent` and ensures it closes upon exiting the block (sync or async).
 
 ### 2.7 Swapping the Root Overlay: `overlay_factory`
 

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -170,18 +170,13 @@ class MaterialOverlay(Overlay):
         )
 
     class _LoadingContext(AbstractContextManager[None], AbstractAsyncContextManager[None]):
-        def __init__(self, overlay: "MaterialOverlay", indicator: Widget | Route) -> None:
+        def __init__(self, overlay: "MaterialOverlay", indicator: Widget | Route | Any | None) -> None:
             self._overlay = overlay
             self._indicator = indicator
             self._handle: OverlayHandle[Any] | None = None
 
         def __enter__(self) -> None:
-            self._handle = self._overlay.show_modal(
-                self._indicator,
-                dismiss_on_outside_tap=False,
-                timeout=None,
-                position=OverlayPosition.alignment("center"),
-            )
+            self._handle = self._overlay.loading(self._indicator)
             return None
 
         def __exit__(self, exc_type, exc, tb) -> Literal[False]:
@@ -200,14 +195,53 @@ class MaterialOverlay(Overlay):
     def loading(
         self,
         indicator: Widget | Route | Any | None = None,
-    ) -> "MaterialOverlay._LoadingContext":
+    ) -> OverlayHandle[Any]:
+        """Show a loading indicator overlay and return a handle for manual dismissal.
+
+        Args:
+            indicator: Widget, Route, or intent to display as the loading indicator.
+                Defaults to the built-in :class:`LoadingIndicator`.
+
+        Returns:
+            An :class:`OverlayHandle` that can be closed via ``handle.close(None)``.
+        """
         if indicator is None:
             resolved: Widget | Route = self._intent_resolver.resolve(LoadingIntent())
         elif isinstance(indicator, (Widget, Route)):
             resolved = indicator
         else:
             resolved = self._intent_resolver.resolve(indicator)
-        return MaterialOverlay._LoadingContext(self, resolved)
+        return self.show_modal(
+            resolved,
+            dismiss_on_outside_tap=False,
+            timeout=None,
+            position=OverlayPosition.alignment("center"),
+        )
+
+    def while_loading(
+        self,
+        indicator: Widget | Route | Any | None = None,
+    ) -> "_LoadingContext":
+        """Return a context manager that shows a loading indicator for the duration of a block.
+
+        Use this form when the loading state is scoped to a ``with`` or ``async with`` block::
+
+            with MaterialOverlay.of(self).while_loading():
+                do_work()
+
+            async with MaterialOverlay.of(self).while_loading():
+                await fetch_data()
+
+        Internally delegates show/close to :meth:`loading`.
+
+        Args:
+            indicator: Widget, Route, or intent to display as the loading indicator.
+                Defaults to the built-in :class:`LoadingIndicator`.
+
+        Returns:
+            A context manager that shows the indicator on entry and closes it on exit.
+        """
+        return MaterialOverlay._LoadingContext(self, indicator)
 
     def side_sheet(
         self,

--- a/src/samples/async_demo.py
+++ b/src/samples/async_demo.py
@@ -2,7 +2,7 @@
 
 This sample demonstrates:
 1. Using `async` event handlers (on_click).
-2. Using `async with Overlay.loading()` while awaiting.
+2. Using `async with Overlay.while_loading()` while awaiting.
 3. Updating UI (Observable) from within an async handler without blocking.
 4. Awaiting `Overlay.dialog` results directly.
 """
@@ -36,7 +36,7 @@ class AsyncDemoApp(nv.ComposableWidget):
         """Handler for the 'Start Task' button."""
 
         # 1. Show loading dialog using async context manager
-        async with md.Overlay.root().loading():
+        async with md.Overlay.root().while_loading():
             await self._heavy_task()
 
         # 2. Show confirmation dialog and await result
@@ -45,8 +45,8 @@ class AsyncDemoApp(nv.ComposableWidget):
                 title="Task Finished",
                 message=f"Count reached {self.counter.value}. Reset?",
                 actions=[
-                    md.TextButton("No", on_click=lambda: md.Overlay.root().close(False)),
-                    md.TextButton("Yes", on_click=lambda: md.Overlay.root().close(True)),
+                    md.Button("No", on_click=lambda: md.Overlay.root().close(False), style=md.ButtonStyle.text()),
+                    md.Button("Yes", on_click=lambda: md.Overlay.root().close(True), style=md.ButtonStyle.text()),
                 ],
             )
         )
@@ -115,17 +115,20 @@ class AsyncDemoApp(nv.ComposableWidget):
                     children=[
                         md.Text("Async/Await Demo"),
                         status_card,
-                        md.TextButton(
+                        md.Button(
                             "Start Heavy Task (with Overlay.loading)",
                             on_click=self.on_start_task_click,
+                            style=md.ButtonStyle.text(),
                         ),
-                        md.TextButton(
+                        md.Button(
                             "Test Non-blocking Wait (3s)",
                             on_click=self.on_concurrent_test_click,
+                            style=md.ButtonStyle.text(),
                         ),
-                        md.TextButton(
+                        md.Button(
                             "Increment Counter Manually",
                             on_click=lambda: setattr(self.counter, "value", self.counter.value + 1),
+                            style=md.ButtonStyle.text(),
                         ),
                         md.Text(
                             "Try clicking 'Increment Counter Manually' while 'Test Non-blocking Wait' is running.\n"

--- a/src/samples/loading_demo.py
+++ b/src/samples/loading_demo.py
@@ -1,4 +1,4 @@
-"""Overlay.loading() demo.
+"""Overlay.loading() / while_loading() demo.
 
 Shows how to display a centered loading indicator overlay.
 """
@@ -15,7 +15,6 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.observable import runtime
 from nuiitivet.overlay import OverlayHandle
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -23,7 +22,6 @@ class LoadingDemo(nv.ComposableWidget):
     def __init__(self) -> None:
         super().__init__()
         self._active_handle: OverlayHandle[Any] | None = None
-        self._active_ctx: md.Overlay._LoadingContext | None = None
 
     def show_manual_overlay_loading(self) -> None:
         overlay = md.Overlay.root()
@@ -42,17 +40,16 @@ class LoadingDemo(nv.ComposableWidget):
         runtime.clock.schedule_once(_close, 2.0)
 
     def show_loading_context_non_blocking(self) -> None:
-        """Show Overlay.loading() without blocking the UI thread."""
+        """Show loading indicator using the handle form of loading()."""
         overlay = md.Overlay.root()
-        ctx = overlay.loading()
-        ctx.__enter__()
-        self._active_ctx = ctx
+        handle = overlay.loading()
+        self._active_handle = handle
 
         def _close(_dt: float) -> None:
             try:
-                ctx.__exit__(None, None, None)
+                handle.close(None)
             except Exception:
-                exception_once(_logger, "loading_dialog_demo_ctx_exit_exc", "Overlay loading context __exit__ raised")
+                exception_once(_logger, "loading_dialog_demo_close_exc", "Overlay handle.close raised")
 
         runtime.clock.schedule_once(_close, 10.0)
 
@@ -61,10 +58,10 @@ class LoadingDemo(nv.ComposableWidget):
             padding=32,
             child=nv.Column(
                 children=[
-                    md.Text("Overlay.loading() Demo"),
-                    md.FilledButton("Show Overlay (manual, 2s)", on_click=self.show_manual_overlay_loading),
-                    md.FilledButton(
-                        "Show Overlay.loading() (context, 2s)",
+                    md.Text("Overlay.loading() / while_loading() Demo"),
+                    md.Button("Show Overlay (manual, 2s)", on_click=self.show_manual_overlay_loading),
+                    md.Button(
+                        "Show Overlay.loading() (handle, 10s)",
                         on_click=self.show_loading_context_non_blocking,
                     ),
                     md.Text("Tip: Press Esc to close overlays."),

--- a/tests/test_async_integration.py
+++ b/tests/test_async_integration.py
@@ -43,11 +43,22 @@ async def test_overlay_dialog_await():
 
 
 @pytest.mark.asyncio
-async def test_overlay_loading_async_with():
+async def test_overlay_loading_returns_handle():
     overlay = MaterialOverlay(intents={LoadingDialogIntent: lambda i: PlainLoadingDialog(i.message)})
     Overlay.set_root(overlay)
 
-    async with overlay.loading():
+    handle = overlay.loading()
+    assert overlay.has_entries()
+    handle.close(None)
+    assert not overlay.has_entries()
+
+
+@pytest.mark.asyncio
+async def test_overlay_while_loading_async_with():
+    overlay = MaterialOverlay(intents={LoadingDialogIntent: lambda i: PlainLoadingDialog(i.message)})
+    Overlay.set_root(overlay)
+
+    async with overlay.while_loading():
         assert overlay.has_entries()
         await asyncio.sleep(0.1)
 

--- a/tests/test_loading_dialog.py
+++ b/tests/test_loading_dialog.py
@@ -5,11 +5,21 @@ from nuiitivet.overlay import Overlay, LoadingDialogIntent
 from nuiitivet.overlay.dialogs import PlainLoadingDialog
 
 
-def test_overlay_loading_context_manager_opens_and_closes() -> None:
+def test_overlay_loading_returns_handle() -> None:
+    overlay = MaterialOverlay(intents={LoadingDialogIntent: lambda i: PlainLoadingDialog(i.message)})
+    Overlay.set_root(overlay)
+
+    handle = overlay.loading()
+    assert overlay.has_entries() is True
+    handle.close(None)
+    assert overlay.has_entries() is False
+
+
+def test_overlay_while_loading_context_manager_opens_and_closes() -> None:
     overlay = MaterialOverlay(intents={LoadingDialogIntent: lambda i: PlainLoadingDialog(i.message)})
     Overlay.set_root(overlay)
 
     assert overlay.has_entries() is False
-    with overlay.loading():
+    with overlay.while_loading():
         assert overlay.has_entries() is True
     assert overlay.has_entries() is False

--- a/tests/test_overlay_intent_and_loading.py
+++ b/tests/test_overlay_intent_and_loading.py
@@ -86,21 +86,30 @@ def test_material_overlay_dialog_accepts_custom_route_without_wrapping() -> None
     assert overlay.has_entries() is True
 
 
-def test_overlay_loading_context_closes_on_exit() -> None:
+def test_overlay_loading_returns_handle() -> None:
     overlay = MaterialOverlay(intents={LoadingDialogIntent: lambda i: PlainLoadingDialog(i)})
 
-    with overlay.loading():
+    handle = overlay.loading()
+    assert overlay.has_entries() is True
+    handle.close(None)
+    assert overlay.has_entries() is False
+
+
+def test_overlay_while_loading_context_closes_on_exit() -> None:
+    overlay = MaterialOverlay(intents={LoadingDialogIntent: lambda i: PlainLoadingDialog(i)})
+
+    with overlay.while_loading():
         assert overlay.has_entries() is True
 
     assert overlay.has_entries() is False
 
 
-def test_overlay_loading_async_context_closes_on_exception() -> None:
+def test_overlay_while_loading_async_context_closes_on_exception() -> None:
     overlay = MaterialOverlay(intents={LoadingDialogIntent: lambda i: PlainLoadingDialog(i)})
 
     async def run() -> None:
         with pytest.raises(RuntimeError, match="boom"):
-            async with overlay.loading():
+            async with overlay.while_loading():
                 assert overlay.has_entries() is True
                 raise RuntimeError("boom")
 


### PR DESCRIPTION
## Summary

Splits `MaterialOverlay.loading()` into two forms aligned with the existing `dialog()` / `snackbar()` API conventions.

## Changes

### `src/nuiitivet/material/overlay.py`

- **`loading(indicator=None) → OverlayHandle[Any]`** — renamed semantics; now shows the loading indicator and returns a handle for event-driven dismissal.
- **`while_loading(indicator=None) → _LoadingContext`** — new method; returns a sync/async context manager that calls `loading()` on entry and `handle.close(None)` on exit.
- `_LoadingContext.__enter__` now delegates to `loading()` instead of calling `show_modal()` directly, eliminating logic duplication.

### Breaking Change

Existing `with overlay.loading():` callers must migrate to `with overlay.while_loading():`.

### Tests

| File | Change |
|---|---|
| `tests/test_loading_dialog.py` | Added handle-form test; migrated CM test to `while_loading()` |
| `tests/test_overlay_intent_and_loading.py` | Same |
| `tests/test_async_integration.py` | Added handle-form test; migrated `async with` test to `while_loading()` |

### Samples & Docs

- `src/samples/loading_demo.py` — uses `loading()` handle form directly
- `src/samples/async_demo.py` — migrated `async with` to `while_loading()`; fixed `TextButton` → `Button(style=ButtonStyle.text())`
- `docs/design/OVERLAY.md` / `ASYNCIO_INTEGRATION.md` — updated API descriptions

## Closes

#127