### PR TITLE
fix(overlay): use show_modeless for loading indicator and remove dialog transition

### DIFF
--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -71,7 +71,7 @@ class MaterialOverlay(Overlay):
                 ),
                 LoadingIntent: lambda _: OverlayRoute(
                     builder=lambda: LoadingIndicator(),
-                    transition_spec=MaterialTransitions.dialog(),
+                    transition_spec=None,
                     barrier_dismissible=False,
                 ),
             }
@@ -211,9 +211,8 @@ class MaterialOverlay(Overlay):
             resolved = indicator
         else:
             resolved = self._intent_resolver.resolve(indicator)
-        return self.show_modal(
+        return self.show_modeless(
             resolved,
-            dismiss_on_outside_tap=False,
             timeout=None,
             position=OverlayPosition.alignment("center"),
         )

--- a/src/samples/loading_demo.py
+++ b/src/samples/loading_demo.py
@@ -25,9 +25,8 @@ class LoadingDemo(nv.ComposableWidget):
 
     def show_manual_overlay_loading(self) -> None:
         overlay = md.Overlay.root()
-        handle = overlay.show_modal(
+        handle = overlay.show_modeless(
             md.LoadingIndicator(size=48),
-            dismiss_on_outside_tap=False,
         )
         self._active_handle = handle
 


### PR DESCRIPTION
## Summary

`Overlay.loading()` was using `show_modal()` internally, which renders a semi-transparent black barrier (scrim) that is not part of the Material Design 3 specification for loading indicators.

## Changes

- `overlay.py`: Changed `loading()` to call `show_modeless()` instead of `show_modal()` to eliminate the barrier.
- `overlay.py`: Removed `transition_spec=MaterialTransitions.dialog()` from `LoadingIntent` factory so that closing the indicator (e.g. via Esc) is immediate.
- `loading_demo.py`: Updated the manual demo button to use `show_modeless()` consistently.

## Related

Closes #159