### PR TITLE
feat(focus): introduce FocusSource enum and thread through focus-change callbacks

### DIFF
--- a/src/nuiitivet/material/interactive_widget.py
+++ b/src/nuiitivet/material/interactive_widget.py
@@ -13,7 +13,7 @@ from typing import Optional, Tuple, Union, Any, TYPE_CHECKING
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.rendering.skia.geometry import make_rect, draw_round_rect
 from nuiitivet.widgets.clickable import Clickable
-from nuiitivet.widgets.interaction import FocusNode
+from nuiitivet.widgets.interaction import FocusNode, FocusSource
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.theme.resolver import resolve_color_to_rgba
@@ -93,7 +93,7 @@ class InteractiveWidget(Clickable):
             return True
         return False
 
-    def _handle_focus_change(self, focused: bool) -> None:
+    def _handle_focus_change(self, focused: bool, source: FocusSource) -> None:
         """Handle focus state changes."""
         if not focused:
             self._focus_from_pointer = False

--- a/src/nuiitivet/material/menu.py
+++ b/src/nuiitivet/material/menu.py
@@ -23,7 +23,7 @@ from nuiitivet.overlay.overlay_position import AnchoredOverlayPosition
 from nuiitivet.material.theme.elevation import md3_elevation_to_shadow
 from nuiitivet.rendering.sizing import Sizing, SizingLike
 from nuiitivet.theme.types import ColorBase, ColorSpec
-from nuiitivet.widgets.interaction import FocusNode
+from nuiitivet.widgets.interaction import FocusNode, FocusSource
 from nuiitivet.widgeting.widget import Widget
 
 if TYPE_CHECKING:
@@ -259,8 +259,8 @@ class MenuItem(InteractiveWidget):
     def _handle_release(self, _event: PointerEvent) -> None:
         self._apply_style(self._menu_style)
 
-    def _handle_focus_change(self, focused: bool) -> None:
-        super()._handle_focus_change(focused)
+    def _handle_focus_change(self, focused: bool, source: FocusSource) -> None:
+        super()._handle_focus_change(focused, source)
         self._apply_style(self._menu_style)
 
 

--- a/src/nuiitivet/material/text_fields.py
+++ b/src/nuiitivet/material/text_fields.py
@@ -15,7 +15,7 @@ from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
 from nuiitivet.rendering.sizing import SizingLike
-from nuiitivet.widgets.interaction import FocusNode
+from nuiitivet.widgets.interaction import FocusNode, FocusSource
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.rendering.skia import (
     draw_round_rect,
@@ -480,7 +480,7 @@ class TextField(InteractiveWidget):
         if self._on_change:
             self._on_change(new_text)
 
-    def _on_editable_focus_change(self, focused: bool) -> None:
+    def _on_editable_focus_change(self, focused: bool, source: FocusSource) -> None:
         self._update_label_state()
         self.invalidate()
 

--- a/src/nuiitivet/modifiers/focus.py
+++ b/src/nuiitivet/modifiers/focus.py
@@ -2,14 +2,14 @@ from typing import Callable, Optional
 
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget
-from ..widgets.interaction import FocusNode, BoolCallback, ensure_interaction_region
+from ..widgets.interaction import FocusNode, BoolCallback, ensure_interaction_region, FocusChangeCallback, FocusSource
 
 
 class FocusableModifier(ModifierElement):
     def __init__(
         self,
         enabled: bool = True,
-        on_focus_change: Optional[BoolCallback] = None,
+        on_focus_change: Optional[FocusChangeCallback] = None,
         on_key: Optional[Callable[[str, int], bool]] = None,
     ) -> None:
         self.enabled = enabled

--- a/src/nuiitivet/modifiers/focus.py
+++ b/src/nuiitivet/modifiers/focus.py
@@ -2,7 +2,7 @@ from typing import Callable, Optional
 
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget
-from ..widgets.interaction import FocusNode, BoolCallback, ensure_interaction_region, FocusChangeCallback, FocusSource
+from ..widgets.interaction import FocusNode, ensure_interaction_region, FocusChangeCallback
 
 
 class FocusableModifier(ModifierElement):
@@ -47,7 +47,7 @@ class FocusableModifier(ModifierElement):
 
 def focusable(
     enabled: bool = True,
-    on_focus_change: Optional[BoolCallback] = None,
+    on_focus_change: Optional[FocusChangeCallback] = None,
     on_key: Optional[Callable[[str, int], bool]] = None,
 ) -> FocusableModifier:
     """

--- a/src/nuiitivet/modifiers/tooltip.py
+++ b/src/nuiitivet/modifiers/tooltip.py
@@ -17,6 +17,8 @@ from nuiitivet.widgets.interaction import (
     InteractionHostMixin,
     ensure_interaction_region,
     BoolCallback,
+    FocusChangeCallback,
+    FocusSource,
 )
 
 if TYPE_CHECKING:
@@ -74,8 +76,8 @@ class TooltipBox(PopupBox):
         self._is_focused = False
         self._active_touch_pointer_id: Optional[int] = None
         self._focus_node: Optional[FocusNode] = None
-        self._prev_focus_callback: Optional[BoolCallback] = None
-        self._focus_callback_wrapper: Optional[Callable[[bool], None]] = None
+        self._prev_focus_callback: Optional[FocusChangeCallback] = None
+        self._focus_callback_wrapper: Optional[FocusChangeCallback] = None
         self._install_interactions()
 
     def on_unmount(self) -> None:
@@ -107,10 +109,10 @@ class TooltipBox(PopupBox):
                 return
         prev_callback = focus_node._on_focus_change
 
-        def _chained(on: bool) -> None:
+        def _chained(on: bool, source: FocusSource) -> None:
             if prev_callback is not None:
-                prev_callback(on)
-            self._on_focus_change(on)
+                prev_callback(on, source)
+            self._on_focus_change(on, source)
 
         self._focus_node = focus_node
         self._prev_focus_callback = prev_callback
@@ -142,7 +144,9 @@ class TooltipBox(PopupBox):
             return
         self._schedule_close(self.dismiss_delay)
 
-    def _on_focus_change(self, focused: bool) -> None:
+    def _on_focus_change(self, focused: bool, source: FocusSource) -> None:
+        if source == FocusSource.POINTER:
+            return  # pointer-click focus must not keep the tooltip open
         self._is_focused = bool(focused)
         if self._is_focused:
             self._schedule_open(self.delay)

--- a/src/nuiitivet/modifiers/tooltip.py
+++ b/src/nuiitivet/modifiers/tooltip.py
@@ -16,7 +16,6 @@ from nuiitivet.widgets.interaction import (
     FocusNode,
     InteractionHostMixin,
     ensure_interaction_region,
-    BoolCallback,
     FocusChangeCallback,
     FocusSource,
 )

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -20,7 +20,7 @@ from ..theme import manager as theme_manager
 from nuiitivet.theme.plain_theme import PlainColorRole, PlainTheme
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.theme.types import ColorSpec
-from ..widgets.interaction import FocusNode, InteractionHostMixin
+from ..widgets.interaction import FocusNode, InteractionHostMixin, FocusSource
 from nuiitivet.common.logging_once import debug_once, exception_once
 from .app_events import (
     dispatch_mouse_motion as _dispatch_mouse_motion_fn,
@@ -724,7 +724,7 @@ class App:
         _dispatch_mouse_motion_fn(self, x, y)
 
     # --- Keyboard / focus helpers ---------------------------------
-    def request_focus(self, node: Optional[FocusNode]) -> None:
+    def request_focus(self, node: Optional[FocusNode], source: FocusSource = FocusSource.KEYBOARD) -> None:
         """Set focus to the given FocusNode. Pass ``None`` to clear focus."""
         if self._focused_node is node:
             return
@@ -736,7 +736,7 @@ class App:
         # Focus new node
         self._focused_node = node
         if node:
-            node._set_focused(True)
+            node._set_focused(True, source)
             # Also update legacy target if the node belongs to a widget
             if node.region:
                 self._focused_target = node.region
@@ -808,7 +808,7 @@ class App:
                         cur = None
 
                     if cur is None:
-                        self.request_focus(nodes[0])
+                        self.request_focus(nodes[0], FocusSource.KEYBOARD)
                         return True
 
                     # Allow composite widgets to consume Tab internally
@@ -825,7 +825,7 @@ class App:
                         next_idx = (idx - 1) % len(nodes)
                     else:
                         next_idx = (idx + 1) % len(nodes)
-                    self.request_focus(nodes[next_idx])
+                    self.request_focus(nodes[next_idx], FocusSource.KEYBOARD)
                     return True
                 except Exception:
                     exception_once(logger, "app_dispatch_tab_traversal_exc", "Tab focus traversal raised")

--- a/src/nuiitivet/widgeting/callbacks.py
+++ b/src/nuiitivet/widgeting/callbacks.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 #: No-arg, fire-and-forget callback (e.g. on_click).
 VoidCallback = Union[Callable[[], None], Callable[[], Awaitable[None]]]
-#: Single ``bool`` argument callback (e.g. on_hover, on_focus_change).
+#: Single ``bool`` argument callback (e.g. on_hover).
 BoolCallback = Union[Callable[[bool], None], Callable[[bool], Awaitable[None]]]
 #: Optional ``bool`` argument callback (e.g. on_change for tristate toggles).
 OptionalBoolCallback = Union[

--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -19,7 +19,13 @@ from nuiitivet.input.codes import (
 from nuiitivet.observable import Disposable, Observable, ObservableProtocol
 from nuiitivet.platform import IMEManager, get_system_clipboard
 from nuiitivet.rendering.sizing import SizingLike
-from nuiitivet.widgets.interaction import InteractionHostMixin, FocusNode, DraggableNode
+from nuiitivet.widgets.interaction import (
+    InteractionHostMixin,
+    FocusNode,
+    DraggableNode,
+    FocusChangeCallback,
+    FocusSource,
+)
 from nuiitivet.widgets.text_editing import TextEditingValue, TextRange
 from nuiitivet.rendering.skia import (
     make_font,
@@ -48,7 +54,7 @@ class EditableText(InteractionHostMixin, Widget):
         self,
         value: Union[str, ObservableProtocol[str]] = "",
         on_change: Optional[StrCallback] = None,
-        on_focus_change: Optional[BoolCallback] = None,
+        on_focus_change: Optional[FocusChangeCallback] = None,
         text_color: ColorSpec = "#000000",
         cursor_color: ColorSpec = "#000000",
         selection_color: ColorSpec = "#B3D7FF",  # Default selection color
@@ -370,7 +376,7 @@ class EditableText(InteractionHostMixin, Widget):
 
         return len(text)
 
-    def _handle_focus_change(self, focused: bool):
+    def _handle_focus_change(self, focused: bool, source: FocusSource):
         if not focused:
             # Clear the pointer-origin marker so the next keyboard focus
             # acquisition correctly shows the focus ring.
@@ -380,6 +386,7 @@ class EditableText(InteractionHostMixin, Widget):
             invoke_event_handler(
                 self._on_focus_change_callback,
                 focused,
+                source,
                 error_key="editable_text_on_focus_change",
                 error_msg="EditableText on_focus_change raised",
                 owner_name=type(self).__name__,

--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple, Union, cast
 
 from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import Widget
-from nuiitivet.widgeting.callbacks import invoke_event_handler, StrCallback, BoolCallback
+from nuiitivet.widgeting.callbacks import invoke_event_handler, StrCallback
 from nuiitivet.input.codes import (
     MOD_CTRL,
     MOD_META,

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 import logging
 from collections.abc import Awaitable
 from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast
@@ -19,6 +20,25 @@ PointerEventCallback = Union[
 DragUpdateCallback = Union[
     Callable[[PointerEvent, float, float], None],
     Callable[[PointerEvent, float, float], Awaitable[None]],
+]
+
+
+class FocusSource(str, Enum):
+    """Indicates how a :class:`FocusNode` acquired focus.
+
+    Args:
+        KEYBOARD: Focus acquired via keyboard navigation (Tab / Shift-Tab).
+        POINTER: Focus acquired via a pointer interaction (click-to-focus).
+    """
+
+    KEYBOARD = "keyboard"
+    POINTER = "pointer"
+
+
+#: Focus-change callback: receives ``(focused: bool, source: FocusSource)``.
+FocusChangeCallback = Union[
+    Callable[[bool, FocusSource], None],
+    Callable[[bool, FocusSource], Awaitable[None]],
 ]
 
 logger = logging.getLogger(__name__)
@@ -506,7 +526,7 @@ class FocusNode(InteractionNode):
     def __init__(
         self,
         *,
-        on_focus_change: Optional[BoolCallback] = None,
+        on_focus_change: Optional[FocusChangeCallback] = None,
         on_key: Optional[Callable[[str, int], bool]] = None,
         on_text: Optional[Callable[[str], bool]] = None,
         on_text_motion: Optional[Callable[[int, bool], bool]] = None,
@@ -536,11 +556,11 @@ class FocusNode(InteractionNode):
             return self._wants_tab(modifiers)
         return False
 
-    def request_focus(self) -> None:
+    def request_focus(self, source: FocusSource = FocusSource.KEYBOARD) -> None:
         if self.region and hasattr(self.region, "_app") and self.region._app:
-            self.region._app.request_focus(self)
+            self.region._app.request_focus(self, source)
         else:
-            self._set_focused(True)
+            self._set_focused(True, source)
 
     @property
     def parent(self) -> Optional["FocusNode"]:
@@ -562,7 +582,7 @@ class FocusNode(InteractionNode):
             current = getattr(current, "_parent", None)
         return None
 
-    def _set_focused(self, value: bool) -> None:
+    def _set_focused(self, value: bool, source: FocusSource = FocusSource.KEYBOARD) -> None:
         if self.state.focused == value:
             return
         self.state.focused = value
@@ -573,6 +593,7 @@ class FocusNode(InteractionNode):
             invoke_event_handler(
                 self._on_focus_change,
                 value,
+                source,
                 error_key="focus_change_callback",
                 error_msg="Focus change callback raised",
                 owner_name=owner_name,
@@ -697,7 +718,7 @@ class InteractionHostMixin:
         """Called by PointerInputNode when a click occurs."""
         focus_node = self.get_node(FocusNode)
         if focus_node and isinstance(focus_node, FocusNode):
-            focus_node.request_focus()
+            focus_node.request_focus(FocusSource.POINTER)
 
     def on_pointer_event(self, event: PointerEvent) -> bool:
         # Dispatch to all nodes that can handle pointer events

--- a/src/nuiitivet/widgets/text_field.py
+++ b/src/nuiitivet/widgets/text_field.py
@@ -13,11 +13,11 @@ from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.observable import ObservableProtocol
 from nuiitivet.rendering.sizing import SizingLike
-from nuiitivet.widgets.interaction import InteractionHostMixin
+from nuiitivet.widgeting.callbacks import invoke_event_handler, StrCallback
+from nuiitivet.widgets.interaction import InteractionHostMixin, FocusSource
 from nuiitivet.widgets.editable_text import EditableText
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.platform import get_system_clipboard
-from nuiitivet.widgeting.callbacks import invoke_event_handler, StrCallback
 
 _logger = logging.getLogger(__name__)
 
@@ -127,7 +127,7 @@ class TextFieldBase(InteractionHostMixin, ComposableWidget):
                 owner_name=type(self).__name__,
             )
 
-    def _on_editable_focus_change(self, focused: bool) -> None:
+    def _on_editable_focus_change(self, focused: bool, source: FocusSource) -> None:
         """Called when the editable text focus changes."""
         self.invalidate()
 

--- a/tests/test_button_group.py
+++ b/tests/test_button_group.py
@@ -60,7 +60,7 @@ def _mount_group(group) -> None:
         def invalidate(self) -> None:
             pass
 
-        def request_focus(self, node) -> None:
+        def request_focus(self, node, source=None) -> None:
             pass
 
     group.mount(_FakeApp())

--- a/tests/test_text_field_animation.py
+++ b/tests/test_text_field_animation.py
@@ -3,6 +3,7 @@ from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.animation import Animatable
 from nuiitivet.observable import runtime
+from nuiitivet.widgets.interaction import FocusSource
 
 
 class _FakeClock:
@@ -42,7 +43,7 @@ def test_text_field_animates_label_on_focus():
 
         # Focus
         tf._editable.state.focused = True
-        tf._on_editable_focus_change(True)
+        tf._on_editable_focus_change(True, FocusSource.KEYBOARD)
 
         assert tf._label_progress.target == 1.0
         # Start should be 0.0
@@ -80,7 +81,7 @@ def test_text_field_animates_indicator_width_on_focus():
 
         # Focus
         tf._editable.state.focused = True
-        tf._on_editable_focus_change(True)
+        tf._on_editable_focus_change(True, FocusSource.KEYBOARD)
 
         assert tf._anim_indicator_width.target == 2.0
 

--- a/tests/test_text_field_issue121.py
+++ b/tests/test_text_field_issue121.py
@@ -19,6 +19,7 @@ from nuiitivet.runtime.app_events import dispatch_mouse_press
 from nuiitivet.widgets.editable_text import EditableText
 from nuiitivet.widgets.interaction import FocusNode
 from nuiitivet.widgets.text_editing import TextRange
+from nuiitivet.widgets.interaction import FocusSource
 
 # ---------------------------------------------------------------------------
 # 1. Japanese rendering uses locale-aware font fallback for label/supporting.
@@ -64,7 +65,7 @@ class _FakeApp:
         self.root.hit_test = MagicMock(return_value=hit_target)
         self.invalidate = MagicMock()
 
-    def request_focus(self, node):
+    def request_focus(self, node, source=None):
         if self._focused_node is node:
             return
         if self._focused_node is not None:
@@ -384,7 +385,7 @@ def test_pointer_focus_hides_focus_ring() -> None:
     # editable's pointer-focus entry point, marking it as pointer-origin.
     tf._editable.request_focus_from_pointer()
     tf._editable.state.focused = True
-    tf._on_editable_focus_change(True)
+    tf._on_editable_focus_change(True, FocusSource.KEYBOARD)
 
     # Even though the editable is focused, the ring must stay hidden
     # because focus originated from a pointer interaction.
@@ -399,7 +400,7 @@ def test_keyboard_focus_shows_focus_ring() -> None:
     # collects EditableText's FocusNode since TextField has none).
     tf._editable.focus()
     tf._editable.state.focused = True
-    tf._on_editable_focus_change(True)
+    tf._on_editable_focus_change(True, FocusSource.KEYBOARD)
 
     assert tf._editable.is_focus_from_pointer is False
     assert tf.should_show_focus_ring is True
@@ -410,14 +411,16 @@ def test_blur_resets_pointer_focus_flag() -> None:
 
     tf._editable.request_focus_from_pointer()
     tf._editable.state.focused = True
-    tf._on_editable_focus_change(True)
+    tf._editable.request_focus_from_pointer()
+    tf._editable.state.focused = True
+    tf._on_editable_focus_change(True, FocusSource.KEYBOARD)
     assert tf._editable.is_focus_from_pointer is True
 
     # Releasing focus should clear the pointer-origin flag so that the next
     # keyboard focus correctly shows the ring.
-    tf._editable._handle_focus_change(False)
+    tf._editable._handle_focus_change(False, FocusSource.KEYBOARD)
     tf._editable.state.focused = False
-    tf._on_editable_focus_change(False)
+    tf._on_editable_focus_change(False, FocusSource.KEYBOARD)
     assert tf._editable.is_focus_from_pointer is False
 
 
@@ -429,7 +432,7 @@ def test_pointer_press_on_editable_propagates_to_text_field() -> None:
     # Simulate the path taken when EditableText handles the press itself.
     tf._editable.request_focus_from_pointer()
     tf._editable.state.focused = True
-    tf._on_editable_focus_change(True)
+    tf._on_editable_focus_change(True, FocusSource.KEYBOARD)
 
     assert tf._editable.is_focus_from_pointer is True
     assert tf.should_show_focus_ring is False


### PR DESCRIPTION
## Summary
Introduce `FocusSource` enum to `FocusNode` so consumers can distinguish keyboard-driven focus from pointer-driven (click-to-focus) focus.

## Changes
- Add `FocusSource` enum (`KEYBOARD` / `POINTER`) in `widgets/interaction.py`
- Add `FocusChangeCallback` type alias (replaces `Callable[[bool], None]`)
- Thread `source` through `FocusNode._set_focused`, `request_focus`, `_on_focus_change`
- `App.request_focus` accepts `source`; Tab traversal explicitly passes `FocusSource.KEYBOARD`
- `TooltipBox` ignores `POINTER` focus — fixes tooltip staying open after click-to-focus
- Update all `_handle_focus_change` / `_on_editable_focus_change` signatures
- Update affected tests

## Related
- Closes #137
- Follow-up refactor tracked in #161