### PR TITLE
refactor(focus): template method pattern for focus state hook in InteractiveWidget

### DIFF
--- a/src/nuiitivet/material/interactive_widget.py
+++ b/src/nuiitivet/material/interactive_widget.py
@@ -94,13 +94,15 @@ class InteractiveWidget(Clickable):
         return False
 
     def _handle_focus_change(self, focused: bool, source: FocusSource) -> None:
-        """Handle focus state changes."""
-        if not focused:
-            self._focus_from_pointer = False
+        """Handle focus state changes. Internal — wired to FocusNode._on_focus_change."""
+        self._focus_from_pointer = focused and source == FocusSource.POINTER
+        self._on_focused(focused, source)
+
+    def _on_focused(self, focused: bool, source: FocusSource) -> None:
+        """Called when the focus state changes. Override in subclasses to react."""
 
     def request_focus_from_pointer(self) -> None:
         """Request focus originating from a pointer (e.g. click)."""
-        self._focus_from_pointer = True
         super().request_focus_from_pointer()
 
     @property

--- a/src/nuiitivet/material/menu.py
+++ b/src/nuiitivet/material/menu.py
@@ -259,8 +259,7 @@ class MenuItem(InteractiveWidget):
     def _handle_release(self, _event: PointerEvent) -> None:
         self._apply_style(self._menu_style)
 
-    def _handle_focus_change(self, focused: bool, source: FocusSource) -> None:
-        super()._handle_focus_change(focused, source)
+    def _on_focused(self, focused: bool, source: FocusSource) -> None:
         self._apply_style(self._menu_style)
 
 


### PR DESCRIPTION
## Summary
Apply the Template Method pattern to `InteractiveWidget._handle_focus_change` to eliminate the need for subclasses to call `super()` and to be aware of internal focus state management.

## Changes
- `InteractiveWidget._handle_focus_change` now owns all internal state updates and calls `_on_focused` as a subclass hook
- `_on_focused(focused, source)` is a new protected method with a docstring indicating it should be overridden
- `MenuItem._handle_focus_change` replaced with `_on_focused` — no longer needs `super()` call
- `_focus_from_pointer` assignment consolidated:
  `focused and source == FocusSource.POINTER` (single expression, no preemptive set in `request_focus_from_pointer`)

## Related
- Closes #161
- Depends on #137 (merged)