### PR TITLE
fix(tooltip): suppress re-open after ESC while pointer remains on anchor

### DIFF
--- a/src/nuiitivet/modifiers/popup.py
+++ b/src/nuiitivet/modifiers/popup.py
@@ -204,10 +204,20 @@ class PopupBox(Widget):
                 self._handle = None
                 self._cancel_handle_monitor()
                 if self._is_open.value:
+                    self._on_closed_externally()
                     self._is_open.value = False
 
         self._handle_monitor_callback = _monitor
         runtime.clock.schedule_interval(_monitor, 1.0 / 60.0)
+
+    def _on_closed_externally(self) -> None:
+        """Hook called when the overlay is closed by an external actor.
+
+        Called while ``is_open`` is still ``True``, immediately before it is
+        set to ``False`` by the handle monitor.  Subclasses may override to
+        react to externally-initiated closes (e.g. ESC, light-dismiss tap).
+        The default implementation is a no-op.
+        """
 
     def _cancel_handle_monitor(self) -> None:
         callback = self._handle_monitor_callback

--- a/src/nuiitivet/modifiers/tooltip.py
+++ b/src/nuiitivet/modifiers/tooltip.py
@@ -77,11 +77,14 @@ class TooltipBox(PopupBox):
         self._focus_node: Optional[FocusNode] = None
         self._prev_focus_callback: Optional[FocusChangeCallback] = None
         self._focus_callback_wrapper: Optional[FocusChangeCallback] = None
+        self._user_dismissed: bool = False
+        self._dismiss_reset_callback: Optional[Callable[[float], None]] = None
         self._install_interactions()
 
     def on_unmount(self) -> None:
         self._cancel_open()
         self._cancel_close()
+        self._cancel_dismiss_reset()
         self._restore_focus_callback()
         self._uninstall_interactions()
         super().on_unmount()
@@ -136,12 +139,19 @@ class TooltipBox(PopupBox):
         self._prev_focus_callback = None
         self._focus_callback_wrapper = None
 
+    def _on_closed_externally(self) -> None:
+        if self._is_hovered:
+            self._user_dismissed = True
+
     def _on_hover_change(self, hovered: bool) -> None:
         self._is_hovered = bool(hovered)
         if self._is_hovered:
-            self._schedule_open(self.delay)
+            if not self._user_dismissed:
+                self._schedule_open(self.delay)
             return
         self._schedule_close(self.dismiss_delay)
+        if self._user_dismissed:
+            self._schedule_dismiss_reset()
 
     def _on_focus_change(self, focused: bool, source: FocusSource) -> None:
         if source == FocusSource.POINTER:
@@ -179,7 +189,7 @@ class TooltipBox(PopupBox):
         runtime.clock.schedule_once(_open, delay)
 
     def _schedule_close(self, delay: float) -> None:
-        if self._is_hovered or self._is_focused:
+        if self._is_open.value and (self._is_hovered or self._is_focused):
             return
         self._cancel_open()
         self._cancel_close()
@@ -207,6 +217,25 @@ class TooltipBox(PopupBox):
             return
         self._close_callback = None
         runtime.clock.unschedule(callback)
+
+    def _schedule_dismiss_reset(self) -> None:
+        if self._dismiss_reset_callback is not None:
+            return
+
+        def _reset(_dt: float) -> None:
+            self._dismiss_reset_callback = None
+            if not self._is_hovered:
+                self._user_dismissed = False
+
+        self._dismiss_reset_callback = _reset
+        runtime.clock.schedule_once(_reset, 0.0)
+
+    def _cancel_dismiss_reset(self) -> None:
+        cb = self._dismiss_reset_callback
+        if cb is None:
+            return
+        self._dismiss_reset_callback = None
+        runtime.clock.unschedule(cb)
 
     def _set_open(self, open_state: bool) -> None:
         if self._is_open.value == open_state:

--- a/tests/test_tooltip.py
+++ b/tests/test_tooltip.py
@@ -291,3 +291,112 @@ def test_tooltip_uninstall_stops_hover_after_unmount() -> None:
     anchor.on_pointer_event(enter)
 
     assert result._is_open.value is False
+
+
+def test_schedule_close_cancels_pending_open_when_externally_closed_and_focused_stale() -> None:
+    """Regression: ESC sets _is_open=False externally; mouse-leave must still cancel pending open.
+
+    Bug #138: When _is_focused is stale True (from pointer-click, see #137),
+    the old guard ``if _is_hovered or _is_focused: return`` would short-circuit
+    _cancel_open(), leaving the pending callback alive. After the timer fires,
+    _set_open(True) re-opens the tooltip even though ESC had dismissed it.
+
+    Fix: guard is now ``if _is_open.value and (_is_hovered or _is_focused)``,
+    so an already-closed tooltip always proceeds to _cancel_open().
+    """
+    box = TooltipBox(_FixedWidget(10, 10), _FixedWidget(20, 20), delay=0.5, dismiss_delay=0.0)
+
+    # Hover starts a pending open (delay=0.5 so it stays scheduled).
+    box._on_hover_change(True)
+    assert box._open_callback is not None
+
+    # Simulate pointer-click setting _is_focused=True (#137 bug).
+    box._is_focused = True
+
+    # ESC dismisses the overlay externally — bypasses _set_open().
+    box._is_open.value = False
+
+    # Mouse leaves the button.
+    box._on_hover_change(False)
+
+    # The pending open callback must be cancelled; tooltip must stay closed.
+    assert box._open_callback is None
+    assert box._is_open.value is False
+
+
+def test_tooltip_esc_suppresses_reopen_while_hovered() -> None:
+    """After ESC dismissal, pointer movement within the button must not reopen the tooltip.
+
+    When the pointer crosses internal sub-widget boundaries the InteractionRegion
+    emits a hover=False then hover=True pair within the same dispatch cycle.
+    The tooltip must ignore the hover=True while _user_dismissed is set.
+
+    This test sets state directly to avoid triggering _schedule_dismiss_reset,
+    which uses a background timer that would introduce a threading race condition.
+    The deferred-reset path is covered by test_tooltip_esc_suppression_clears_after_pointer_leaves.
+    """
+    box = TooltipBox(_FixedWidget(10, 10), _FixedWidget(20, 20), delay=0.5, dismiss_delay=0.5)
+
+    # Simulate: tooltip is open while the pointer hovers over the anchor widget.
+    box._is_hovered = True
+    box._is_open.value = True
+
+    # ESC closes externally — mirrors what the handle monitor does.
+    box._on_closed_externally()
+    box._is_open.value = False
+    assert box._user_dismissed is True
+
+    # ENTER fires again (sub-widget crossing; deferred reset has not yet fired).
+    box._on_hover_change(True)
+
+    # No open should be scheduled while _user_dismissed is still set.
+    assert box._open_callback is None
+    assert box._is_open.value is False
+    assert box._user_dismissed is True
+
+
+def test_tooltip_esc_suppression_clears_after_pointer_leaves() -> None:
+    """_user_dismissed resets once the pointer genuinely leaves the button.
+
+    The reset is deferred to the next frame so that a sub-widget crossing does
+    not clear the flag.  When the pointer truly leaves, the deferred callback
+    fires and clears _user_dismissed so the next re-entry reopens normally.
+
+    The observable runtime clock is replaced with a no-op during the test to
+    prevent _ThreadClock from racing the assertions via background threads.
+    """
+    import types
+    from nuiitivet.observable import runtime as _observable_runtime
+
+    box = TooltipBox(_FixedWidget(10, 10), _FixedWidget(20, 20), delay=0.0, dismiss_delay=0.5)
+
+    # Simulate: ESC dismissed while hovered.
+    box._is_hovered = True
+    box._is_open.value = True
+    box._on_closed_externally()
+    box._is_open.value = False
+
+    # Replace clock with a no-op so that schedule_once never fires in the
+    # background, allowing the assertions below to be deterministic.
+    _prev_clock = _observable_runtime.clock
+    _observable_runtime.set_clock(
+        types.SimpleNamespace(
+            schedule_once=lambda fn, d: None,
+            unschedule=lambda fn: None,
+            schedule_interval=lambda fn, i: None,
+        )
+    )
+    try:
+        # Pointer leaves the button with no subsequent hover=True.
+        box._on_hover_change(False)
+        assert box._dismiss_reset_callback is not None
+
+        # Simulate next-frame deferred callback firing.
+        box._dismiss_reset_callback(0.0)
+        assert box._user_dismissed is False
+
+        # Re-entering the button now opens the tooltip normally.
+        box._on_hover_change(True)
+        assert box._is_open.value is True
+    finally:
+        _observable_runtime.set_clock(_prev_clock)


### PR DESCRIPTION
## Summary

Fixes #138: `TooltipBox` re-opens after ESC dismiss when moving the mouse within the button area.

## Root Cause

`dispatch_mouse_motion` performs `hit_test` against individual child widgets. When the pointer crosses sub-widget boundaries (e.g., Icon → Text within a button), LEAVE + ENTER events are fired on the `Clickable`. This toggles `_is_hovered` False → True, which calls `_on_hover_change(True)` and schedules `_schedule_open`, reopening the tooltip even though the user dismissed it with ESC.

## Changes

### `src/nuiitivet/modifiers/popup.py`
- Added `_on_closed_externally()` Template Method hook to `PopupBox`. Called by the handle monitor immediately before setting `_is_open.value = False` when the overlay is closed externally (ESC, light-dismiss). Default is no-op.

### `src/nuiitivet/modifiers/tooltip.py`
- Added `_user_dismissed: bool` flag.
- `TooltipBox` overrides `_on_closed_externally()` to set `_user_dismissed = True` when the pointer is still inside the anchor.
- `_on_hover_change(True)` skips `_schedule_open` while `_user_dismissed` is set.
- `_schedule_dismiss_reset()` defers clearing `_user_dismissed` to the next frame; the flag is only cleared if `_is_hovered` is still `False` at that point, so sub-widget crossings (which restore `_is_hovered = True` synchronously) do not reset suppression prematurely.
- Fixed existing guard in `_schedule_close`: `if _is_hovered or _is_focused` → `if _is_open.value and (_is_hovered or _is_focused)`.

### `tests/test_tooltip.py`
- `test_tooltip_esc_suppresses_reopen_while_hovered`: verifies that `_on_hover_change(True)` with `_user_dismissed=True` does not reopen the tooltip.
- `test_tooltip_esc_suppression_clears_after_pointer_leaves`: verifies that the deferred reset fires correctly on genuine pointer exit and allows normal reopening on re-entry.