### PR TITLE
refactor(theme): per-App ThemeManager with CQRS design

### DIFF
--- a/src/nuiitivet/material/buttons.py
+++ b/src/nuiitivet/material/buttons.py
@@ -35,6 +35,7 @@ from nuiitivet.widgeting.widget import Widget
 
 if TYPE_CHECKING:
     from nuiitivet.material.symbols import Symbol
+    from nuiitivet.theme.manager import ThemeManager
 
 logger = logging.getLogger(__name__)
 
@@ -94,11 +95,10 @@ def _coerce_fixed_height_px(height: SizingLike) -> Optional[int]:
     return None
 
 
-def _resolve_color_rgba(value: ColorSpec) -> Tuple[int, int, int, int]:
-    from nuiitivet.theme.manager import manager
+def _resolve_color_rgba(value: ColorSpec, theme=None) -> Tuple[int, int, int, int]:
     from nuiitivet.theme.resolver import resolve_color_to_rgba
 
-    return resolve_color_to_rgba(value, theme=manager.current)
+    return resolve_color_to_rgba(value, theme=theme)
 
 
 def _shadow_from_elevation(level: int) -> tuple[ColorSpec, float, tuple[float, float]]:
@@ -378,6 +378,7 @@ class MaterialButtonBase(InteractiveWidget):
         self._bg_color_anim: Optional[Animatable[Tuple[int, int, int, int]]] = None
         self._border_color_anim: Optional[Animatable[Tuple[int, int, int, int]]] = None
         self._foreground_color_anim: Optional[Animatable[Tuple[int, int, int, int]]] = None
+        self._theme_manager: Optional["ThemeManager"] = None
 
         self._init_foreground_targets()
         self._update_color_targets(
@@ -386,9 +387,26 @@ class MaterialButtonBase(InteractiveWidget):
             foreground_color=foreground_color,
         )
 
+    def on_mount(self) -> None:
+        super().on_mount()
+        from nuiitivet.runtime.app import AppScope
+
+        scope = self.find_ancestor(AppScope)
+        if scope is not None:
+            self._theme_manager = scope.theme_manager
+            self._theme_manager.subscribe(self._on_theme_change)
+            self._on_theme_change(self._theme_manager.current)
+            self._snap_color_animations()
+
     def on_unmount(self) -> None:
+        if self._theme_manager is not None:
+            self._theme_manager.unsubscribe(self._on_theme_change)
+            self._theme_manager = None
         self._dispose_color_animations()
         super().on_unmount()
+
+    def _on_theme_change(self, theme) -> None:
+        raise NotImplementedError
 
     def _init_foreground_targets(self) -> None:
         if self._foreground_targets:
@@ -448,10 +466,11 @@ class MaterialButtonBase(InteractiveWidget):
         background_color: ColorSpec,
         border_color: ColorSpec,
         foreground_color: ColorSpec,
+        theme=None,
     ) -> None:
-        resolved_bg = _resolve_color_rgba(background_color)
-        resolved_border = _resolve_color_rgba(border_color)
-        resolved_fg = _resolve_color_rgba(foreground_color)
+        resolved_bg = _resolve_color_rgba(background_color, theme=theme)
+        resolved_border = _resolve_color_rgba(border_color, theme=theme)
+        resolved_fg = _resolve_color_rgba(foreground_color, theme=theme)
 
         if self._bg_color_anim is None:
             self._bg_color_anim = Animatable.vector(
@@ -487,7 +506,28 @@ class MaterialButtonBase(InteractiveWidget):
         if self._foreground_color_anim is not None:
             self._foreground_color_anim = None
 
-    def _apply_style_params(self, params: dict[str, Any]) -> None:
+    def _snap_color_animations(self) -> None:
+        """Snap colour animations to their current targets without animating.
+
+        Called once at mount time so the button renders immediately with the
+        correct theme colours instead of fading in from the transparent
+        ``(0, 0, 0, 0)`` value that was resolved at construction time
+        (before the app's ThemeManager was reachable).
+        """
+        for anim in (self._bg_color_anim, self._border_color_anim, self._foreground_color_anim):
+            if anim is None:
+                continue
+            target = anim._target
+            anim._stop_ticking()
+            if anim._state is not None:
+                vec = anim._converter.to_vector(target)
+                anim._state.value = vec.copy()
+                anim._state.start = vec.copy()
+                anim._state.target = vec.copy()
+                anim._state.done = True
+            anim._value.value = target
+
+    def _apply_style_params(self, params: dict[str, Any], theme=None) -> None:
         self.padding = params["padding"]
         self.corner_radius = params["corner_radius"]
         self.border_width = params["border_width"]
@@ -504,7 +544,9 @@ class MaterialButtonBase(InteractiveWidget):
             background_color=params["background_color"],
             border_color=params["border_color"],
             foreground_color=params["foreground_color"],
+            theme=theme,
         )
+        self._snap_color_animations()
         self.invalidate()
 
     def _get_state_layer_target_opacity(self) -> float:
@@ -695,19 +737,6 @@ class Button(MaterialButtonBase):
             **params,
         )
 
-    def on_mount(self) -> None:
-        super().on_mount()
-        from nuiitivet.theme.manager import manager
-
-        manager.subscribe(self._on_theme_change)
-        self._on_theme_change(manager.current)
-
-    def on_unmount(self) -> None:
-        from nuiitivet.theme.manager import manager
-
-        manager.unsubscribe(self._on_theme_change)
-        super().on_unmount()
-
     def _on_theme_change(self, theme) -> None:
         params = resolve_button_style_params(
             self.style,
@@ -715,7 +744,7 @@ class Button(MaterialButtonBase):
             self._user_height,
             self.disabled,
         )
-        self._apply_style_params(params)
+        self._apply_style_params(params, theme=theme)
 
 
 class IconButton(MaterialButtonBase):
@@ -763,19 +792,6 @@ class IconButton(MaterialButtonBase):
             **params,
         )
 
-    def on_mount(self) -> None:
-        super().on_mount()
-        from nuiitivet.theme.manager import manager
-
-        manager.subscribe(self._on_theme_change)
-        self._on_theme_change(manager.current)
-
-    def on_unmount(self) -> None:
-        from nuiitivet.theme.manager import manager
-
-        manager.unsubscribe(self._on_theme_change)
-        super().on_unmount()
-
     def _on_theme_change(self, theme) -> None:
         params = resolve_button_style_params(
             self.style,
@@ -783,7 +799,7 @@ class IconButton(MaterialButtonBase):
             self._user_height,
             self.disabled,
         )
-        self._apply_style_params(params)
+        self._apply_style_params(params, theme=theme)
 
 
 class ToggleButtonBase(MaterialButtonBase):
@@ -883,20 +899,9 @@ class ToggleButtonBase(MaterialButtonBase):
 
     def on_mount(self) -> None:
         super().on_mount()
-        from nuiitivet.theme.manager import manager
-
-        manager.subscribe(self._on_theme_change)
-        self._on_theme_change(manager.current)
-
         if self._selected_external is not None:
             self.observe(self._selected_external, self._on_selected_external_change)
             self._sync_selected_state()
-
-    def on_unmount(self) -> None:
-        from nuiitivet.theme.manager import manager
-
-        manager.unsubscribe(self._on_theme_change)
-        super().on_unmount()
 
     def _resolve_style_for_selected(self, selected: bool) -> ButtonStyle:
         """Return the :class:`ButtonStyle` to apply for the given state.
@@ -912,14 +917,16 @@ class ToggleButtonBase(MaterialButtonBase):
             self._user_height,
             self.disabled,
         )
-        self._apply_style_params(params)
+        self._apply_style_params(params, theme=theme)
 
     def _on_selected_external_change(self, _new_value: bool) -> None:
         self._sync_selected_state()
 
     def _sync_selected_state(self) -> None:
         self.state.checked = self.selected
-        self._on_theme_change(None)
+        from nuiitivet.theme.theme import Theme
+
+        self._on_theme_change(Theme.of(self))
         self.invalidate()
 
     def _handle_toggle(self) -> None:
@@ -1094,19 +1101,6 @@ class Fab(MaterialButtonBase):
         self.bind(self._press_scale_x_anim.subscribe(lambda _: self.invalidate()))
         self.bind(self._press_scale_y_anim.subscribe(lambda _: self.invalidate()))
 
-    def on_mount(self) -> None:
-        super().on_mount()
-        from nuiitivet.theme.manager import manager
-
-        manager.subscribe(self._on_theme_change)
-        self._on_theme_change(manager.current)
-
-    def on_unmount(self) -> None:
-        from nuiitivet.theme.manager import manager
-
-        manager.unsubscribe(self._on_theme_change)
-        super().on_unmount()
-
     def _on_theme_change(self, theme) -> None:
         params = resolve_button_style_params(
             self.style,
@@ -1114,7 +1108,7 @@ class Fab(MaterialButtonBase):
             self._user_height,
             self.disabled,
         )
-        self._apply_style_params(params)
+        self._apply_style_params(params, theme=theme)
         self._sync_state_tokens()
 
     def _container_elevation(self) -> int:

--- a/src/nuiitivet/material/card.py
+++ b/src/nuiitivet/material/card.py
@@ -43,9 +43,9 @@ class Card(ComposableWidget, Box):
         if self._user_style is not None:
             return self._user_style
 
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
 
-        return CardStyle.from_theme(manager.current)
+        return CardStyle.from_theme(Theme.of(self))
 
     def __init__(
         self,

--- a/src/nuiitivet/material/chip.py
+++ b/src/nuiitivet/material/chip.py
@@ -132,10 +132,10 @@ class MaterialChipBase(InteractiveWidget):
         if self._user_style is not None:
             return self._user_style
 
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
         from nuiitivet.material.styles.chip_style import ChipStyle
 
-        return ChipStyle.from_theme(manager.current, self._variant)
+        return ChipStyle.from_theme(Theme.of(self), self._variant)
 
     def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> tuple[int, int]:
         """Return preferred size clamped to style minimum touch-target size."""
@@ -186,23 +186,21 @@ class AssistChip(MaterialChipBase):
             padding: External insets around chip widget.
             style: Optional chip style.
         """
-        effective_style = style
-        if effective_style is None:
-            from nuiitivet.theme.manager import manager
-            from nuiitivet.material.styles.chip_style import ChipStyle
+        from nuiitivet.theme.theme import Theme
+        from nuiitivet.material.styles.chip_style import ChipStyle
 
-            effective_style = ChipStyle.from_theme(manager.current, self._variant)
+        style_for_content = style if style is not None else ChipStyle.from_theme(Theme.of(self), self._variant)
 
         children: list[Widget] = []
         if leading_icon is not None:
-            children.append(_chip_icon(leading_icon, color=effective_style.foreground))
-        children.append(_chip_text(label, effective_style.foreground))
+            children.append(_chip_icon(leading_icon, color=style_for_content.foreground))
+        children.append(_chip_text(label, style_for_content.foreground))
 
         content = _chip_content(
             children,
-            spacing=effective_style.spacing,
+            spacing=style_for_content.spacing,
             has_icon=leading_icon is not None,
-            style=effective_style,
+            style=style_for_content,
         )
 
         super().__init__(
@@ -212,7 +210,7 @@ class AssistChip(MaterialChipBase):
             width=width,
             height=height,
             padding=padding,
-            style=effective_style,
+            style=style,
         )
 
 
@@ -262,14 +260,12 @@ class FilterChip(MaterialChipBase):
         self._on_selected_change = on_selected_change
         self._leading_icon = leading_icon
 
-        effective_style = style
-        if effective_style is None:
-            from nuiitivet.theme.manager import manager
-            from nuiitivet.material.styles.chip_style import ChipStyle
+        from nuiitivet.theme.theme import Theme
+        from nuiitivet.material.styles.chip_style import ChipStyle
 
-            effective_style = ChipStyle.from_theme(manager.current, self._variant)
+        style_for_content = style if style is not None else ChipStyle.from_theme(Theme.of(self), self._variant)
 
-        content = self._build_content(effective_style)
+        content = self._build_content(style_for_content)
 
         super().__init__(
             child=content,
@@ -278,7 +274,7 @@ class FilterChip(MaterialChipBase):
             width=width,
             height=height,
             padding=padding,
-            style=effective_style,
+            style=style,
         )
 
         self._apply_selected_visuals()
@@ -391,18 +387,16 @@ class InputChip(MaterialChipBase):
         self._trailing_icon_widget: Optional[Icon] = None
         self._trailing_icon_tap_target: Optional[Widget] = None
 
-        effective_style = style
-        if effective_style is None:
-            from nuiitivet.theme.manager import manager
-            from nuiitivet.material.styles.chip_style import ChipStyle
+        from nuiitivet.theme.theme import Theme
+        from nuiitivet.material.styles.chip_style import ChipStyle
 
-            effective_style = ChipStyle.from_theme(manager.current, self._variant)
+        style_for_content = style if style is not None else ChipStyle.from_theme(Theme.of(self), self._variant)
 
         children: list[Widget] = []
         if leading_icon is not None:
-            children.append(_chip_icon(leading_icon, color=effective_style.foreground))
-        children.append(_chip_text(label, effective_style.foreground))
-        trailing_icon_widget = _chip_icon(trailing_icon, color=effective_style.foreground)
+            children.append(_chip_icon(leading_icon, color=style_for_content.foreground))
+        children.append(_chip_text(label, style_for_content.foreground))
+        trailing_icon_widget = _chip_icon(trailing_icon, color=style_for_content.foreground)
         self._trailing_icon_widget = trailing_icon_widget
         if on_trailing_icon_click is None:
             self._trailing_icon_tap_target = trailing_icon_widget
@@ -414,12 +408,12 @@ class InputChip(MaterialChipBase):
                 focusable=True,
                 padding=0,
                 corner_radius=999,
-                state_layer_color=effective_style.state_layer_color,
+                state_layer_color=style_for_content.state_layer_color,
             )
             self._trailing_icon_tap_target = trailing_icon_button
             children.append(trailing_icon_button)
 
-        content = _chip_content(children, spacing=effective_style.spacing, has_icon=True, style=effective_style)
+        content = _chip_content(children, spacing=style_for_content.spacing, has_icon=True, style=style_for_content)
 
         super().__init__(
             child=content,
@@ -428,7 +422,7 @@ class InputChip(MaterialChipBase):
             width=width,
             height=height,
             padding=padding,
-            style=effective_style,
+            style=style,
         )
 
 
@@ -463,23 +457,21 @@ class SuggestionChip(MaterialChipBase):
             padding: External insets around chip widget.
             style: Optional chip style.
         """
-        effective_style = style
-        if effective_style is None:
-            from nuiitivet.theme.manager import manager
-            from nuiitivet.material.styles.chip_style import ChipStyle
+        from nuiitivet.theme.theme import Theme
+        from nuiitivet.material.styles.chip_style import ChipStyle
 
-            effective_style = ChipStyle.from_theme(manager.current, self._variant)
+        style_for_content = style if style is not None else ChipStyle.from_theme(Theme.of(self), self._variant)
 
         children: list[Widget] = []
         if leading_icon is not None:
-            children.append(_chip_icon(leading_icon, color=effective_style.foreground))
-        children.append(_chip_text(label, effective_style.foreground))
+            children.append(_chip_icon(leading_icon, color=style_for_content.foreground))
+        children.append(_chip_text(label, style_for_content.foreground))
 
         content = _chip_content(
             children,
-            spacing=effective_style.spacing,
+            spacing=style_for_content.spacing,
             has_icon=leading_icon is not None,
-            style=effective_style,
+            style=style_for_content,
         )
 
         super().__init__(
@@ -489,7 +481,7 @@ class SuggestionChip(MaterialChipBase):
             width=width,
             height=height,
             padding=padding,
-            style=effective_style,
+            style=style,
         )
 
 

--- a/src/nuiitivet/material/dialogs.py
+++ b/src/nuiitivet/material/dialogs.py
@@ -83,10 +83,10 @@ class BasicDialog(ComposableWidget):
         if self._user_style is not None:
             return self._user_style
 
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
         from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-        theme_data = manager.current.extension(MaterialThemeData)
+        theme_data = Theme.of(self).extension(MaterialThemeData)
         if theme_data:
             return theme_data.basic_dialog_style
 

--- a/src/nuiitivet/material/divider.py
+++ b/src/nuiitivet/material/divider.py
@@ -8,7 +8,6 @@ from typing import Literal, Optional, Tuple, Union
 from nuiitivet.material.styles.divider_style import DividerStyle
 from nuiitivet.rendering.sizing import Sizing, SizingLike
 from nuiitivet.rendering.skia import make_paint, make_rect
-from nuiitivet.theme.manager import manager as theme_manager
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.widgeting.widget import Widget
 
@@ -113,7 +112,9 @@ class Divider(Widget):
         if dw <= 0 or dh <= 0:
             return
 
-        rgba = resolve_color_to_rgba(style.color, theme=theme_manager.current)
+        from nuiitivet.theme.theme import Theme
+
+        rgba = resolve_color_to_rgba(style.color, theme=Theme.of(self))
         if rgba is None:
             return
         r, g, b, a = rgba

--- a/src/nuiitivet/material/icon.py
+++ b/src/nuiitivet/material/icon.py
@@ -206,13 +206,14 @@ class Icon(IconBase):
     def style(self):
         if self._style is not None:
             return self._style
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.material.styles.icon_style import IconStyle
         from nuiitivet.material.theme.theme_data import MaterialThemeData
+        from nuiitivet.theme.theme import Theme
 
-        theme = manager.current.extension(MaterialThemeData)
-        if theme is None:
-            raise ValueError("MaterialThemeData not found in current theme")
-        return theme.icon_style
+        mat = Theme.of(self).extension(MaterialThemeData)
+        if mat is None:
+            return IconStyle()
+        return mat.icon_style
 
     def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> tuple[int, int]:
         """Return preferred size including padding (M3準拠)."""
@@ -599,8 +600,8 @@ class Icon(IconBase):
             return
 
         # Use IconBase to draw the blob
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
 
         color = self.style.color
-        resolved_color = resolve_color_to_rgba(color, theme=manager.current)
+        resolved_color = resolve_color_to_rgba(color, theme=Theme.of(self))
         self.draw_blob(canvas, blob, resolved_color, x, y, width, height)

--- a/src/nuiitivet/material/interactive_widget.py
+++ b/src/nuiitivet/material/interactive_widget.py
@@ -177,7 +177,9 @@ class InteractiveWidget(Clickable):
         # Prepare paint
         try:
             # Resolve the base color of the state layer
-            color = resolve_color_to_rgba(self.state_layer_color, self)
+            from nuiitivet.theme.theme import Theme
+
+            color = resolve_color_to_rgba(self.state_layer_color, theme=Theme.of(self))
             if color is None:
                 return
 
@@ -209,7 +211,9 @@ class InteractiveWidget(Clickable):
         """Draws the MD3 Focus Indicator (Ring) when focused."""
         try:
             # Focus ring color is usually Secondary
-            color = resolve_color_to_rgba(self._FOCUS_RING_COLOR, self)
+            from nuiitivet.theme.theme import Theme
+
+            color = resolve_color_to_rgba(self._FOCUS_RING_COLOR, theme=Theme.of(self))
             if color is None:
                 return
 

--- a/src/nuiitivet/material/loading_indicator.py
+++ b/src/nuiitivet/material/loading_indicator.py
@@ -13,7 +13,6 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.rendering.skia import get_skia, make_paint, make_path, rgba_to_skia_color
 from nuiitivet.animation import Animatable
 from nuiitivet.observable import runtime
-from nuiitivet.theme.manager import manager as theme_manager
 from nuiitivet.widgeting.widget import Widget
 
 from .shapes import (
@@ -23,7 +22,6 @@ from .shapes import (
     sample_shape_points,
 )
 from .styles.loading_indicator_style import LoadingIndicatorStyle
-
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +114,9 @@ class LoadingIndicator(Widget):
         if self._user_style is not None:
             return self._user_style
 
-        return LoadingIndicatorStyle.from_theme(theme_manager.current, "default")
+        from nuiitivet.theme.theme import Theme
+
+        return LoadingIndicatorStyle.from_theme(Theme.of(self), "default")
 
     def _get_model(self) -> ShapeMorphSequence:
         """Get shape morph sequence from current style."""
@@ -190,11 +190,11 @@ class LoadingIndicator(Widget):
     def _resolve_indicator_color(self) -> int | Any:
         """Resolve indicator foreground color to skia color or RGBA tuple."""
         try:
-            theme = theme_manager.current
+            from nuiitivet.theme.theme import Theme
             from nuiitivet.theme.resolver import resolve_color_to_rgba
 
             foreground = self.style.foreground
-            rgba = resolve_color_to_rgba(foreground, theme=theme)
+            rgba = resolve_color_to_rgba(foreground, theme=Theme.of(self))
             return rgba_to_skia_color(rgba)
         except Exception:
             exception_once(logger, "loading_indicator_resolve_color_exc", "LoadingIndicator color resolution failed")

--- a/src/nuiitivet/material/navigation_rail.py
+++ b/src/nuiitivet/material/navigation_rail.py
@@ -24,7 +24,6 @@ from nuiitivet.material.badge import LargeBadge, SmallBadge
 from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL, EXPRESSIVE_DEFAULT_EFFECTS
 from nuiitivet.modifiers.transform import rotate
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -270,6 +269,16 @@ class _RailItemButton(InteractiveWidget):
             self._badge_widget = None
         self._badge_rect = None
 
+        # Give the badge access to the widget tree so Theme.of() can traverse
+        # up to AppScope and resolve theme-based colors (e.g. ColorRole.ERROR).
+        if self._badge_widget is not None:
+            self._badge_widget._parent = self
+            try:
+                self._badge_widget._remove_box_theme_subscription()
+                self._badge_widget._sync_theme_subscription()
+            except Exception:
+                pass
+
     def _apply_colors(self, *, selected: bool, rail_style: Optional[NavigationRailStyle] = None) -> None:
         eff_style = self._eff_style or rail_style or NavigationRailStyle()
         if selected:
@@ -438,7 +447,9 @@ class _RailItemButton(InteractiveWidget):
         if not self._selected or self._indicator_color is None:
             return
 
-        color = resolve_color_to_rgba(self._indicator_color, self)
+        from nuiitivet.theme.theme import Theme
+
+        color = resolve_color_to_rgba(self._indicator_color, theme=Theme.of(self))
         if color is None:
             return
         r, g, b, a = color
@@ -464,7 +475,9 @@ class _RailItemButton(InteractiveWidget):
         if opacity <= 0:
             return
 
-        color = resolve_color_to_rgba(self.state_layer_color, self)
+        from nuiitivet.theme.theme import Theme
+
+        color = resolve_color_to_rgba(self.state_layer_color, theme=Theme.of(self))
         if color is None:
             return
         r, g, b, a = color

--- a/src/nuiitivet/material/progress_indicators.py
+++ b/src/nuiitivet/material/progress_indicators.py
@@ -10,7 +10,6 @@ from nuiitivet.observable import ObservableProtocol, runtime
 from nuiitivet.rendering.padding import parse_padding
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.rendering.skia import draw_round_rect, make_paint, make_rect
-from nuiitivet.theme.manager import manager as theme_manager
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.widgeting.widget import Widget
 
@@ -65,10 +64,9 @@ def _resolve_active_track_colors(
     *,
     style: LinearProgressIndicatorStyle | CircularProgressIndicatorStyle,
     disabled: bool,
+    theme: Any = None,
 ) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
     """Resolve active/track colors with disabled alpha handling."""
-    theme = theme_manager.current
-
     active = resolve_color_to_rgba(style.active_indicator_color, theme=theme) or (0, 0, 0, 255)
     track = resolve_color_to_rgba(style.track_color, theme=theme) or (0, 0, 0, 255)
 
@@ -491,8 +489,9 @@ class LinearProgressIndicator(_DeterminateProgressBase):
         if self._style is not None:
             return self._style
         from nuiitivet.material.theme.theme_data import MaterialThemeData
+        from nuiitivet.theme.theme import Theme
 
-        mat = theme_manager.current.extension(MaterialThemeData)
+        mat = Theme.of(self).extension(MaterialThemeData)
         if mat is not None:
             return mat.linear_progress_indicator_style
         return LinearProgressIndicatorStyle.default()
@@ -513,8 +512,10 @@ class LinearProgressIndicator(_DeterminateProgressBase):
         return (pref_w, pref_h)
 
     def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int], tuple[int, int, int, int]]:
+        from nuiitivet.theme.theme import Theme
+
         style = self.style
-        theme = theme_manager.current
+        theme = Theme.of(self)
 
         active = resolve_color_to_rgba(style.active_indicator_color, theme=theme) or (0, 0, 0, 255)
         track = resolve_color_to_rgba(style.track_color, theme=theme) or (0, 0, 0, 255)
@@ -638,8 +639,9 @@ class IndeterminateLinearProgressIndicator(_IndeterminateProgressBase):
         if self._style is not None:
             return self._style
         from nuiitivet.material.theme.theme_data import MaterialThemeData
+        from nuiitivet.theme.theme import Theme
 
-        mat = theme_manager.current.extension(MaterialThemeData)
+        mat = Theme.of(self).extension(MaterialThemeData)
         if mat is not None:
             return mat.linear_progress_indicator_style
         return LinearProgressIndicatorStyle.default()
@@ -663,7 +665,9 @@ class IndeterminateLinearProgressIndicator(_IndeterminateProgressBase):
         return _LINEAR_ANIMATION_DURATION_MS / 1000.0
 
     def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
-        return _resolve_active_track_colors(style=self.style, disabled=self.disabled)
+        from nuiitivet.theme.theme import Theme
+
+        return _resolve_active_track_colors(style=self.style, disabled=self.disabled, theme=Theme.of(self))
 
     def paint(self, canvas: Any, x: int, y: int, width: int, height: int) -> None:
         self.set_last_rect(x, y, width, height)
@@ -758,14 +762,17 @@ class CircularProgressIndicator(_DeterminateProgressBase):
         if self._style is not None:
             return self._style
         from nuiitivet.material.theme.theme_data import MaterialThemeData
+        from nuiitivet.theme.theme import Theme
 
-        mat = theme_manager.current.extension(MaterialThemeData)
+        mat = Theme.of(self).extension(MaterialThemeData)
         if mat is not None:
             return mat.circular_progress_indicator_style
         return CircularProgressIndicatorStyle.default()
 
     def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
-        return _resolve_active_track_colors(style=self.style, disabled=self.disabled)
+        from nuiitivet.theme.theme import Theme
+
+        return _resolve_active_track_colors(style=self.style, disabled=self.disabled, theme=Theme.of(self))
 
     def preferred_size(self, max_width: int | None = None, max_height: int | None = None) -> tuple[int, int]:
         pad_l, pad_t, pad_r, pad_b = self.padding
@@ -884,8 +891,9 @@ class IndeterminateCircularProgressIndicator(_IndeterminateProgressBase):
         if self._style is not None:
             return self._style
         from nuiitivet.material.theme.theme_data import MaterialThemeData
+        from nuiitivet.theme.theme import Theme
 
-        mat = theme_manager.current.extension(MaterialThemeData)
+        mat = Theme.of(self).extension(MaterialThemeData)
         if mat is not None:
             return mat.circular_progress_indicator_style
         return CircularProgressIndicatorStyle.default()
@@ -904,7 +912,9 @@ class IndeterminateCircularProgressIndicator(_IndeterminateProgressBase):
         return (w, h)
 
     def _resolve_colors(self) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int]]:
-        return _resolve_active_track_colors(style=self.style, disabled=self.disabled)
+        from nuiitivet.theme.theme import Theme
+
+        return _resolve_active_track_colors(style=self.style, disabled=self.disabled, theme=Theme.of(self))
 
     def paint(self, canvas: Any, x: int, y: int, width: int, height: int) -> None:
         self.set_last_rect(x, y, width, height)

--- a/src/nuiitivet/material/selection_controls.py
+++ b/src/nuiitivet/material/selection_controls.py
@@ -305,12 +305,14 @@ class Checkbox(Toggleable, InteractiveWidget):
     def style(self):
         if self._style is not None:
             return self._style
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
         from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-        theme = manager.current.extension(MaterialThemeData)
+        theme = Theme.of(self).extension(MaterialThemeData)
         if theme is None:
-            raise ValueError("MaterialThemeData not found in current theme")
+            from nuiitivet.material.styles.checkbox_style import CheckboxStyle
+
+            return CheckboxStyle()
         return theme.checkbox_style
 
     def paint(self, canvas, x: int, y: int, width: int, height: int):
@@ -349,11 +351,11 @@ class Checkbox(Toggleable, InteractiveWidget):
             focus_stroke = max(1.0, float(3.0 * (touch_sz / 48.0)))
             focus_offset = float(2.0 * (touch_sz / 48.0))
 
-            from nuiitivet.theme import manager as theme_manager
+            from nuiitivet.theme.theme import Theme
             from nuiitivet.material.theme.color_role import ColorRole
             from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-            mat = theme_manager.current.extension(MaterialThemeData)
+            mat = Theme.of(self).extension(MaterialThemeData)
             roles = mat.roles if mat is not None else {}
 
             fg_hex = roles.get(ColorRole.ON_SURFACE, "#000000")
@@ -606,12 +608,14 @@ class RadioButton(Toggleable, InteractiveWidget):
         """Resolved style for this RadioButton."""
         if self._style is not None:
             return self._style
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
         from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-        theme = manager.current.extension(MaterialThemeData)
+        theme = Theme.of(self).extension(MaterialThemeData)
         if theme is None:
-            raise ValueError("MaterialThemeData not found in current theme")
+            from nuiitivet.material.styles.radio_button_style import RadioButtonStyle
+
+            return RadioButtonStyle()
         return theme.radio_button_style
 
     def on_mount(self) -> None:
@@ -692,7 +696,7 @@ class RadioButton(Toggleable, InteractiveWidget):
             from nuiitivet.rendering.skia import draw_oval, make_paint, make_rect, skcolor
             from nuiitivet.material.theme.color_role import ColorRole
             from nuiitivet.material.theme.theme_data import MaterialThemeData
-            from nuiitivet.theme import manager as theme_manager
+            from nuiitivet.theme.theme import Theme
 
             content_x, content_y, content_w, content_h = self.content_rect(x, y, width, height)
             touch_sz = min(content_w, content_h)
@@ -713,7 +717,7 @@ class RadioButton(Toggleable, InteractiveWidget):
             icon_x = cx + (touch_sz - icon_diameter) / 2.0
             icon_y = cy + (touch_sz - icon_diameter) / 2.0
 
-            mat = theme_manager.current.extension(MaterialThemeData)
+            mat = Theme.of(self).extension(MaterialThemeData)
             roles = mat.roles if mat is not None else {}
 
             selected = bool(self.value)
@@ -863,12 +867,14 @@ class Switch(Toggleable, InteractiveWidget):
         """Resolved style for this Switch."""
         if self._style is not None:
             return self._style
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
         from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-        theme = manager.current.extension(MaterialThemeData)
+        theme = Theme.of(self).extension(MaterialThemeData)
         if theme is None:
-            raise ValueError("MaterialThemeData not found in current theme")
+            from nuiitivet.material.styles.switch_style import SwitchStyle
+
+            return SwitchStyle()
         return theme.switch_style
 
     def on_mount(self) -> None:
@@ -928,7 +934,7 @@ class Switch(Toggleable, InteractiveWidget):
             from nuiitivet.material.theme.color_role import ColorRole
             from nuiitivet.material.theme.theme_data import MaterialThemeData
             from nuiitivet.rendering.skia import draw_oval, draw_round_rect, make_paint, make_rect, skcolor
-            from nuiitivet.theme import manager as theme_manager
+            from nuiitivet.theme.theme import Theme
 
             content_x, content_y, content_w, content_h = self.content_rect(x, y, width, height)
             touch_sz = min(content_w, content_h)
@@ -952,7 +958,7 @@ class Switch(Toggleable, InteractiveWidget):
             track_x = cx + (touch_sz - track_w) / 2.0
             track_y = cy + (touch_sz - track_h) / 2.0
 
-            mat = theme_manager.current.extension(MaterialThemeData)
+            mat = Theme.of(self).extension(MaterialThemeData)
             roles = mat.roles if mat is not None else {}
 
             progress = self._get_selection_progress()

--- a/src/nuiitivet/material/slider.py
+++ b/src/nuiitivet/material/slider.py
@@ -18,7 +18,6 @@ from nuiitivet.rendering.sizing import Sizing, SizingLike, parse_sizing
 from nuiitivet.widgets.interaction import DraggableNode, PointerInputNode
 from nuiitivet.animation import Animatable
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -138,9 +137,9 @@ class _SliderBase(InteractiveWidget):
             return self._style
         try:
             from nuiitivet.material.theme.theme_data import MaterialThemeData
-            from nuiitivet.theme.manager import manager
+            from nuiitivet.theme.theme import Theme
 
-            theme = manager.current.extension(MaterialThemeData)
+            theme = Theme.of(self).extension(MaterialThemeData)
             if theme is not None:
                 return theme.slider_style
         except Exception:
@@ -320,14 +319,14 @@ class _SliderBase(InteractiveWidget):
             from nuiitivet.material.theme.color_role import ColorRole
             from nuiitivet.material.theme.theme_data import MaterialThemeData
             from nuiitivet.rendering.skia import draw_oval, draw_round_rect, make_paint, make_rect, skcolor
-            from nuiitivet.theme import manager as theme_manager
+            from nuiitivet.theme.theme import Theme
 
             self.set_last_rect(x, y, width, height)
             self.draw_background(canvas, x, y, width, height)
             self._compute_geometry(float(x), float(y), float(width), float(height))
 
             style = self.style
-            theme = theme_manager.current.extension(MaterialThemeData)
+            theme = Theme.of(self).extension(MaterialThemeData)
             roles = theme.roles if theme is not None else {}
 
             active_track_hex = roles.get(ColorRole.PRIMARY, "#000000")
@@ -566,10 +565,10 @@ class _SliderBase(InteractiveWidget):
             measure_text_ink_bounds,
             skcolor,
         )
-        from nuiitivet.theme import manager as theme_manager
+        from nuiitivet.theme.theme import Theme
 
         style = self.style
-        theme = theme_manager.current.extension(MaterialThemeData)
+        theme = Theme.of(self).extension(MaterialThemeData)
         roles = theme.roles if theme is not None else {}
 
         bg_hex = roles.get(ColorRole.INVERSE_SURFACE, "#1F1F1F")

--- a/src/nuiitivet/material/text.py
+++ b/src/nuiitivet/material/text.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import Any, Optional, Tuple, Union, TYPE_CHECKING
 
 from nuiitivet.rendering.sizing import SizingLike
-from nuiitivet.theme.manager import manager
 from nuiitivet.observable import ReadOnlyObservableProtocol
 from nuiitivet.widgets.text import TextBase
 from nuiitivet.widgets.text_style import TextStyleProtocol
@@ -60,11 +59,14 @@ class Text(TextBase):
         if self._style is not None:
             return self._style  # type: ignore
         from nuiitivet.material.theme.theme_data import MaterialThemeData
+        from nuiitivet.theme.theme import Theme
 
-        theme = manager.current.extension(MaterialThemeData)
-        if theme is None:
-            raise ValueError("MaterialThemeData not found in current theme")
-        return theme.text_style
+        mat = Theme.of(self).extension(MaterialThemeData)
+        if mat is None:
+            from nuiitivet.material.styles.text_style import TextStyle
+
+            return TextStyle()
+        return mat.text_style
 
 
 __all__ = ["Text"]

--- a/src/nuiitivet/material/text_fields.py
+++ b/src/nuiitivet/material/text_fields.py
@@ -28,7 +28,6 @@ from nuiitivet.rendering.skia import (
     get_typeface,
 )
 from nuiitivet.theme.resolver import resolve_color_to_rgba
-from nuiitivet.theme.manager import manager as theme_manager
 from nuiitivet.widgets.editable_text import EditableText
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.platform import get_system_clipboard
@@ -307,7 +306,7 @@ class TextField(InteractiveWidget):
         )
         self._anim_indicator_width.subscribe(lambda _: self.invalidate())
 
-        init_ind_color = resolve_color_to_rgba(style.indicator_color, theme=theme_manager.current)
+        init_ind_color = resolve_color_to_rgba(style.indicator_color, theme=None)
         self._anim_indicator_color = Animatable.vector(
             init_ind_color,
             converter=RgbaTupleConverter(),
@@ -315,7 +314,7 @@ class TextField(InteractiveWidget):
         )
         self._anim_indicator_color.subscribe(lambda _: self.invalidate())
 
-        init_label_color = resolve_color_to_rgba(style.label_color, theme=theme_manager.current)
+        init_label_color = resolve_color_to_rgba(style.label_color, theme=None)
         self._anim_label_color = Animatable.vector(
             init_label_color,
             converter=RgbaTupleConverter(),
@@ -412,9 +411,25 @@ class TextField(InteractiveWidget):
     def on_mount(self) -> None:
         super().on_mount()
 
+        # Snap animation initial values to the correct theme-resolved colors now
+        # that Theme.of(self) can reach the App's ThemeManager (unavailable at __init__).
+        # This prevents a transparent-to-correct-color flash on first render.
+        style = self.style
+        from nuiitivet.theme.theme import Theme
+
+        def _snap_resolve(c):
+            return resolve_color_to_rgba(c, theme=Theme.of(self))
+
+        if hasattr(self, "_anim_label_color"):
+            correct = _snap_resolve(style.label_color)
+            self._anim_label_color._value.value = correct
+            self._anim_label_color._target = correct
+        if hasattr(self, "_anim_indicator_color"):
+            correct = _snap_resolve(style.indicator_color)
+            self._anim_indicator_color._value.value = correct
+            self._anim_indicator_color._target = correct
+
         # Ensure visual state matches the current theme/focus on mount.
-        # This handles cases where initial theme might have been different or
-        # Animatable needs a kick (if initial values were somehow problematic).
         self._update_label_state()
 
         if self._label_source is not None:
@@ -454,10 +469,10 @@ class TextField(InteractiveWidget):
         if self._user_style is not None:
             return self._user_style
 
-        from nuiitivet.theme.manager import manager
+        from nuiitivet.theme.theme import Theme
         from nuiitivet.material.styles.text_field_style import TextFieldStyle
 
-        return TextFieldStyle.from_theme(manager.current)
+        return TextFieldStyle.from_theme(Theme.of(self))
 
     @property
     def value(self) -> str:
@@ -686,7 +701,9 @@ class TextField(InteractiveWidget):
         is_error = bool(self.is_error)
 
         def _resolve(c):
-            return resolve_color_to_rgba(c, theme=theme_manager.current)
+            from nuiitivet.theme.theme import Theme
+
+            return resolve_color_to_rgba(c, theme=Theme.of(self))
 
         # 1. Label Color
         if is_error:
@@ -767,9 +784,11 @@ class TextField(InteractiveWidget):
         self._editable.paint(canvas, cx, cy, w, h)
 
     def _draw_container(self, canvas, cx, cy, cw, ch, *, text_x_abs: int | None = None):
+        from nuiitivet.theme.theme import Theme
+
         style = self.style
 
-        container_color = resolve_color_to_rgba(style.container_color, theme=theme_manager.current)
+        container_color = resolve_color_to_rgba(style.container_color, theme=Theme.of(self))
         paint_container = make_paint(color=container_color)
         rect = make_rect(cx, cy, cw, ch)
 
@@ -931,7 +950,9 @@ class TextField(InteractiveWidget):
             supporting_y = cy + ch + 4 - supporting_metrics.fAscent
 
             supporting_color_spec = style.error_supporting_text_color if self.is_error else style.supporting_text_color
-            supporting_color = resolve_color_to_rgba(supporting_color_spec, theme=theme_manager.current)
+            from nuiitivet.theme.theme import Theme
+
+            supporting_color = resolve_color_to_rgba(supporting_color_spec, theme=Theme.of(self))
             paint_supporting = make_paint(color=supporting_color)
 
             blob = make_text_blob(self.supporting_text, supporting_font)

--- a/src/nuiitivet/material/theme/color_role.py
+++ b/src/nuiitivet/material/theme/color_role.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from nuiitivet.theme.manager import manager
-
 if TYPE_CHECKING:
     from nuiitivet.theme.theme import Theme
 
@@ -19,11 +17,12 @@ class ColorRole(Enum):
     """Material 3 Color Roles — canonical 26 roles used by M3."""
 
     def resolve(self, theme: "Theme | None" = None) -> str | None:
+        if theme is None:
+            return None
         try:
             from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-            source_theme = theme if theme is not None else manager.current
-            theme_data = source_theme.extension(MaterialThemeData)
+            theme_data = theme.extension(MaterialThemeData)
             if theme_data is None:
                 return None
             return theme_data.roles.get(self)

--- a/src/nuiitivet/material/tooltip.py
+++ b/src/nuiitivet/material/tooltip.py
@@ -14,7 +14,6 @@ from nuiitivet.material.styles.tooltip_style import RichTooltipStyle, TooltipSty
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.elevation import md3_elevation_to_shadow
 from nuiitivet.rendering.sizing import SizingLike
-from nuiitivet.theme.manager import manager
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.widgets.box import Box
 
@@ -47,7 +46,9 @@ class Tooltip(ComposableWidget):
         """Return tooltip style resolved from user style or current theme."""
         if self._user_style is not None:
             return self._user_style
-        return TooltipStyle.from_theme(manager.current)
+        from nuiitivet.theme.theme import Theme
+
+        return TooltipStyle.from_theme(Theme.of(self))
 
     def build(self) -> Widget:
         style = self.style
@@ -129,7 +130,9 @@ class RichTooltip(ComposableWidget):
         """Return rich tooltip style resolved from user style or current theme."""
         if self._user_style is not None:
             return self._user_style
-        return RichTooltipStyle.from_theme(manager.current)
+        from nuiitivet.theme.theme import Theme
+
+        return RichTooltipStyle.from_theme(Theme.of(self))
 
     def build(self) -> Widget:
         style = self.style

--- a/src/nuiitivet/rendering/background_renderer.py
+++ b/src/nuiitivet/rendering/background_renderer.py
@@ -258,10 +258,10 @@ class BackgroundRenderer:
             return
 
         from nuiitivet.theme.resolver import resolve_color_to_rgba
-        from nuiitivet.theme.manager import manager as theme_manager
+        from nuiitivet.theme.theme import Theme
 
         try:
-            stroke_rgba = resolve_color_to_rgba(self.owner.border_color, theme=theme_manager.current)
+            stroke_rgba = resolve_color_to_rgba(self.owner.border_color, theme=Theme.of(self.owner))
             stroke_paint = make_paint(color=stroke_rgba, style="stroke", stroke_width=bw, aa=True)
             if stroke_paint is None:
                 return
@@ -349,10 +349,10 @@ class BackgroundRenderer:
         """Draw shadow and background (but not border)."""
         # draw shadow first if requested
         from nuiitivet.theme.resolver import resolve_color_to_rgba
-        from nuiitivet.theme.manager import manager as theme_manager
+        from nuiitivet.theme.theme import Theme
 
         try:
-            sc = resolve_color_to_rgba(self.owner.shadow_color, theme=theme_manager.current)
+            sc = resolve_color_to_rgba(self.owner.shadow_color, theme=Theme.of(self.owner))
             dx, dy = getattr(self.owner, "shadow_offset", (0, 0))
             sb = float(getattr(self.owner, "shadow_blur", 0.0) or 0.0)
             if sc is not None and (dx != 0 or dy != 0 or sb > 0.0):
@@ -368,7 +368,7 @@ class BackgroundRenderer:
         # draw background if present
         if self.owner.bgcolor is not None:
             try:
-                bg_rgba = resolve_color_to_rgba(self.owner.bgcolor, theme=theme_manager.current)
+                bg_rgba = resolve_color_to_rgba(self.owner.bgcolor, theme=Theme.of(self.owner))
                 paint = make_paint(color=bg_rgba, style="fill", aa=True)
 
                 if paint is not None:

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -16,7 +16,7 @@ from ..widgeting.widget_binding import flush_binding_invalidations
 from ..widgeting.widget_builder import flush_scope_recompositions
 
 from ..rendering.skia import make_raster_surface, require_skia, rgba_to_skia_color, save_png
-from ..theme import manager as theme_manager
+from ..theme.manager import ThemeManager
 from nuiitivet.theme.plain_theme import PlainColorRole, PlainTheme
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.theme.types import ColorSpec
@@ -70,6 +70,7 @@ class AppScope(Widget):
     def __init__(self, app: "App", child: Widget) -> None:
         super().__init__()
         self.app_proxy = AppProxy(app)
+        self.theme_manager = app._theme_manager
         self.add_child(child)
 
     def layout(self, width: int, height: int) -> None:
@@ -170,7 +171,8 @@ class App:
 
         if theme is None:
             theme = PlainTheme.light()
-        theme_manager.set_theme(theme)
+        self._theme_manager = ThemeManager(initial=theme)
+        self._theme_registry: dict[str, Any] = {}
 
         self.root = root
 
@@ -544,7 +546,7 @@ class App:
         if self._background_value is None:
             raise ValueError("App background color could not be resolved")
         try:
-            rgba = resolve_color_to_rgba(self._background_value, theme=theme_manager.current)
+            rgba = resolve_color_to_rgba(self._background_value, theme=self._theme_manager.current)
         except Exception as exc:
             raise ValueError("App background color could not be resolved") from exc
         if rgba is None:
@@ -568,7 +570,7 @@ class App:
             app = app_ref()
             if app is None:
                 try:
-                    theme_manager.unsubscribe(_on_theme)
+                    self._theme_manager.unsubscribe(_on_theme)
                 except Exception:
                     exception_once(logger, "app_theme_unsubscribe_dead_exc", "ThemeManager.unsubscribe raised")
                 return
@@ -579,7 +581,7 @@ class App:
                 exception_once(logger, "app_theme_invalidate_exc", "App.invalidate raised in theme callback")
 
         try:
-            theme_manager.subscribe(_on_theme)
+            self._theme_manager.subscribe(_on_theme)
             self._theme_subscription = _on_theme
         except Exception:
             exception_once(logger, "app_theme_subscribe_exc", "ThemeManager.subscribe raised")
@@ -590,7 +592,7 @@ class App:
         if callback is None:
             return
         try:
-            theme_manager.unsubscribe(callback)
+            self._theme_manager.unsubscribe(callback)
         except Exception:
             exception_once(logger, "app_theme_unsubscribe_exc", "ThemeManager.unsubscribe raised")
         self._theme_subscription = None
@@ -986,6 +988,29 @@ class App:
 
     def dispatch(self, intent: Any) -> None:
         """Dispatch an intent to the application."""
+        from nuiitivet.theme.intents import ThemeModeIntent, ThemeRegistryIntent
+
+        if isinstance(intent, ThemeRegistryIntent):
+            self._theme_registry.update(intent.themes)
+            return
+
+        if isinstance(intent, ThemeModeIntent):
+            from nuiitivet.theme.theme import Theme
+
+            theme_val = intent.theme
+            if isinstance(theme_val, Theme):
+                self._theme_manager.set_theme(theme_val)
+            else:
+                # Look up by name; fall back to light/dark built-ins
+                theme_obj = self._theme_registry.get(str(theme_val))
+                if theme_obj is None:
+                    if str(theme_val) == "dark":
+                        theme_obj = PlainTheme.dark()
+                    else:
+                        theme_obj = PlainTheme.light()
+                self._theme_manager.set_theme(theme_obj)
+            return
+
         from nuiitivet.runtime.intents import (
             ExitAppIntent,
             CenterWindowIntent,

--- a/src/nuiitivet/theme/__init__.py
+++ b/src/nuiitivet/theme/__init__.py
@@ -6,14 +6,13 @@ from .theme import (
     ColorValue,
     Theme,
 )
-from .manager import ThemeManager, manager
+from .manager import ThemeManager
 from .types import ColorLike, ColorSpec, ColorToken, ThemeExtension
 
 __all__ = [
     "ColorValue",
     "Theme",
     "ThemeManager",
-    "manager",
     "ThemeExtension",
     "ColorLike",
     "ColorSpec",

--- a/src/nuiitivet/theme/intents.py
+++ b/src/nuiitivet/theme/intents.py
@@ -1,0 +1,41 @@
+"""Theme-related intents for the App dispatch system.
+
+CQRS design: reads go through ``Theme.of(context)``, writes go through
+``App.of(context).dispatch(intent)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .theme import Theme
+
+
+@dataclass(frozen=True, slots=True)
+class ThemeModeIntent:
+    """Switch the active theme.
+
+    Args:
+        theme: A theme name registered via :class:`ThemeRegistryIntent`, or
+            ``"light"`` / ``"dark"`` as built-in aliases, or a :class:`Theme`
+            instance to apply directly without touching the registry.
+    """
+
+    theme: "str | Theme"
+
+
+@dataclass(frozen=True, slots=True)
+class ThemeRegistryIntent:
+    """Register named custom themes so they can be referenced by name.
+
+    Args:
+        themes: Mapping of name → :class:`Theme` to add to the registry.
+            Subsequent :class:`ThemeModeIntent` calls can refer to these names.
+    """
+
+    themes: dict[str, "Theme"] = field(default_factory=dict)
+
+
+__all__ = ["ThemeModeIntent", "ThemeRegistryIntent"]

--- a/src/nuiitivet/theme/manager.py
+++ b/src/nuiitivet/theme/manager.py
@@ -1,4 +1,4 @@
-"""Theme manager and global state.
+"""Theme manager.
 
 Responsibilities:
 - Keep track of the active ``Theme`` instance and notify subscribers when
@@ -57,6 +57,4 @@ class ThemeManager:
             self._subscribers.discard(fn)
 
 
-manager = ThemeManager()
-
-__all__ = ["ThemeManager", "manager"]
+__all__ = ["ThemeManager"]

--- a/src/nuiitivet/theme/plain_theme.py
+++ b/src/nuiitivet/theme/plain_theme.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from nuiitivet.theme.manager import manager
 from nuiitivet.theme.theme import Theme
 
 if TYPE_CHECKING:
@@ -41,8 +40,9 @@ class PlainColorRole(Enum):
 
     def resolve(self, theme: "Theme | None" = None) -> ColorLike | None:
         """Resolve this token into a concrete ColorLike."""
-        source_theme = theme if theme is not None else manager.current
-        theme_data = source_theme.extension(PlainThemeData)
+        if theme is None:
+            return None
+        theme_data = theme.extension(PlainThemeData)
         if theme_data is None:
             return None
 

--- a/src/nuiitivet/theme/resolver.py
+++ b/src/nuiitivet/theme/resolver.py
@@ -22,13 +22,12 @@ from nuiitivet.colors.utils import (
 from nuiitivet.theme.types import ColorSpec, ColorToken
 from nuiitivet.theme.theme import Theme
 
-
 logger = logging.getLogger(__name__)
 
 
 def _default_role_resolver() -> Callable[[Any], Optional[str]]:
-    def resolver(_: Any) -> Optional[str]:
-        return None
+    def resolver(role: Any) -> Optional[str]:
+        return role.resolve(None) if hasattr(role, "resolve") else None
 
     return resolver
 

--- a/src/nuiitivet/theme/theme.py
+++ b/src/nuiitivet/theme/theme.py
@@ -7,7 +7,7 @@ for design-system specific theme data (extensions).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Type, TypeVar
+from typing import Any, List, Type, TypeVar
 
 from .types import ThemeExtension
 
@@ -29,9 +29,32 @@ class Theme:
     extensions: List[ThemeExtension] = field(default_factory=list)
     name: str = ""
 
+    def __post_init__(self) -> None:
+        types = [type(e) for e in self.extensions]
+        if len(types) != len(set(types)):
+            raise ValueError("Duplicate ThemeExtension types are not allowed")
+
     def extension(self, type: Type[T]) -> T | None:
         """Get an extension by type."""
         for ext in self.extensions:
             if isinstance(ext, type):
                 return ext
         return None
+
+    @staticmethod
+    def of(context: Any) -> "Theme":
+        """Return the current :class:`Theme` from the nearest :class:`AppScope`.
+
+        Falls back to a bare ``Theme(mode="light")`` when called outside of a
+        mounted widget tree (e.g. during construction or in tests).
+        """
+        from nuiitivet.runtime.app import AppScope  # lazy import – avoids circular dep
+
+        scope = None
+        try:
+            scope = context.find_ancestor(AppScope)
+        except AttributeError:
+            pass  # Widget not yet initialized (_parent not set)
+        if scope is None:
+            return Theme(mode="light", extensions=[])
+        return scope.theme_manager.current

--- a/src/nuiitivet/widgets/box.py
+++ b/src/nuiitivet/widgets/box.py
@@ -6,7 +6,6 @@ from nuiitivet.common.logging_once import exception_once
 from ..rendering.skia.paint_cache import CachedPaintMixin
 from ..widgeting.widget import Widget
 from ..theme.types import ColorSpec
-from ..theme.manager import manager as theme_manager
 from ..rendering.background_renderer import BackgroundRenderer
 from ..rendering.skia.geometry import clip_round_rect, make_rect
 from ..rendering.sizing import SizingLike
@@ -15,7 +14,6 @@ from ..layout.alignment import normalize_alignment
 from ..layout.measure import preferred_size as measure_preferred_size
 from ..widgeting.modifier import Modifier
 from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
-
 
 _logger = logging.getLogger(__name__)
 
@@ -54,6 +52,7 @@ class Box(CachedPaintMixin, Widget):
         self._border_color: Optional[ColorSpec] = None
         self._shadow_color: Optional[ColorSpec] = None
         self._box_theme_subscription: Optional[Callable[[object], None]] = None
+        self._box_theme_manager: Optional[object] = None
         if child:
             self.add_child(child)
 
@@ -191,6 +190,10 @@ class Box(CachedPaintMixin, Widget):
             super().on_mount()
         except Exception:
             exception_once(_logger, "box_on_mount_super_exc", "Box on_mount super call failed")
+        # Remove the init-time subscription which may have been bound to the
+        # global ThemeManager (AppScope was unreachable before mount).
+        # Re-subscribe now so we land on AppScope's ThemeManager if available.
+        self._remove_box_theme_subscription()
         self._sync_theme_subscription()
 
     def on_unmount(self) -> None:
@@ -423,25 +426,38 @@ class Box(CachedPaintMixin, Widget):
         if self._box_theme_subscription is not None:
             return
 
+        from nuiitivet.runtime.app import AppScope  # lazy – avoids circular import
+
+        scope = self.find_ancestor(AppScope)
+        if scope is None:
+            return
+
+        tm = scope.theme_manager
+
         def _callback(theme) -> None:
             self._handle_theme_change(theme)
 
         try:
-            theme_manager.subscribe(_callback)
+            tm.subscribe(_callback)
             self._box_theme_subscription = _callback
+            self._box_theme_manager = tm
         except Exception:
             exception_once(_logger, "box_theme_subscribe_exc", "Theme subscribe failed")
             self._box_theme_subscription = None
+            self._box_theme_manager = None
 
     def _remove_box_theme_subscription(self) -> None:
         callback = self._box_theme_subscription
         if callback is None:
             return
-        try:
-            theme_manager.unsubscribe(callback)
-        except Exception:
-            exception_once(_logger, "box_theme_unsubscribe_exc", "Theme unsubscribe failed")
+        tm = self._box_theme_manager
+        if tm is not None:
+            try:
+                tm.unsubscribe(callback)  # type: ignore[union-attr]
+            except Exception:
+                exception_once(_logger, "box_theme_unsubscribe_exc", "Theme unsubscribe failed")
         self._box_theme_subscription = None
+        self._box_theme_manager = None
 
     def _handle_theme_change(self, _theme) -> None:
         try:

--- a/src/nuiitivet/widgets/box.py
+++ b/src/nuiitivet/widgets/box.py
@@ -1,6 +1,9 @@
 import math
 import logging
-from typing import Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from nuiitivet.theme.manager import ThemeManager
 
 from nuiitivet.common.logging_once import exception_once
 from ..rendering.skia.paint_cache import CachedPaintMixin
@@ -52,7 +55,7 @@ class Box(CachedPaintMixin, Widget):
         self._border_color: Optional[ColorSpec] = None
         self._shadow_color: Optional[ColorSpec] = None
         self._box_theme_subscription: Optional[Callable[[object], None]] = None
-        self._box_theme_manager: Optional[object] = None
+        self._box_theme_manager: Optional["ThemeManager"] = None
         if child:
             self.add_child(child)
 

--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -624,7 +624,9 @@ class EditableText(InteractionHostMixin, Widget):
                 save_count = None
 
         try:
-            from nuiitivet.theme.manager import manager as theme_manager
+            from nuiitivet.theme.theme import Theme
+
+            _theme = Theme.of(self)
 
             # Draw selection highlight (behind the text).
             if display_text and not selection.is_collapsed:
@@ -635,7 +637,7 @@ class EditableText(InteractionHostMixin, Widget):
                     sx1 = font.measureText(display_text[:sel_end]) - scroll
                     sel_top = ty + font_metrics.fAscent
                     sel_bottom = ty + font_metrics.fDescent
-                    sel_color = resolve_color_to_rgba(self.selection_color, theme=theme_manager.current)
+                    sel_color = resolve_color_to_rgba(self.selection_color, theme=_theme)
                     paint_sel = make_paint(color=sel_color)
                     sel_rect = make_rect(int(x + sx0), int(sel_top), int(sx1 - sx0), int(sel_bottom - sel_top))
                     if sel_rect is not None and paint_sel is not None:
@@ -650,7 +652,7 @@ class EditableText(InteractionHostMixin, Widget):
 
             # Draw Text
             if display_text:
-                text_color = resolve_color_to_rgba(self.text_color, theme=theme_manager.current)
+                text_color = resolve_color_to_rgba(self.text_color, theme=_theme)
                 paint_text = make_paint(color=text_color)
                 blob = make_text_blob(display_text, font)
                 if blob:
@@ -670,7 +672,7 @@ class EditableText(InteractionHostMixin, Widget):
                     cursor_bottom - cursor_top,
                 )
 
-                cursor_color = resolve_color_to_rgba(self.cursor_color, theme=theme_manager.current)
+                cursor_color = resolve_color_to_rgba(self.cursor_color, theme=_theme)
                 paint_cursor = make_paint(color=cursor_color, style="stroke", stroke_width=2)
                 if paint_cursor is not None:
                     canvas.drawLine(

--- a/src/nuiitivet/widgets/icon.py
+++ b/src/nuiitivet/widgets/icon.py
@@ -38,9 +38,9 @@ class IconBase(Widget):
             return
 
         try:
-            from nuiitivet.theme.manager import manager as theme_manager
+            from nuiitivet.theme.theme import Theme
 
-            rgba = resolve_color_to_rgba(color, theme=theme_manager.current)
+            rgba = resolve_color_to_rgba(color, theme=Theme.of(self))
             paint = make_paint(color=rgba, style="fill", aa=True)
         except Exception:
             exception_once(logger, "icon_base_resolve_color_exc", "Failed to resolve icon color")

--- a/src/nuiitivet/widgets/scrollbar.py
+++ b/src/nuiitivet/widgets/scrollbar.py
@@ -21,7 +21,6 @@ from nuiitivet.colors.utils import hex_to_rgba
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.rendering.skia import draw_round_rect, get_skia, make_paint, make_rect, rgba_to_skia_color  # noqa: F401
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.theme.manager import manager as theme_manager
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.widgets.interaction import (
     DraggableNode,
@@ -29,7 +28,6 @@ from nuiitivet.widgets.interaction import (
     InteractionState,
     PointerInputNode,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -387,7 +385,9 @@ class Scrollbar(InteractionHostMixin, Widget):
 
     def _derive_colors(self, _unused=None):
         try:
-            theme = theme_manager.current
+            from nuiitivet.theme.theme import Theme
+
+            theme = Theme.of(self)
             base = theme.get(ColorRole.ON_SURFACE)
         except Exception:
             base = "#000000"
@@ -429,7 +429,9 @@ class Scrollbar(InteractionHostMixin, Widget):
         bar_x, bar_y, bar_w, bar_h = x, y, width, height
 
         try:
-            theme = theme_manager.current
+            from nuiitivet.theme.theme import Theme
+
+            theme = Theme.of(self)
             from nuiitivet.material.theme.theme_data import MaterialThemeData
 
             mat = theme.extension(MaterialThemeData)

--- a/src/nuiitivet/widgets/text.py
+++ b/src/nuiitivet/widgets/text.py
@@ -243,9 +243,9 @@ class TextBase(Widget):
 
         # Resolve text color from the theme to an RGBA tuple and convert
         # to a skia color when skia is available.
-        from nuiitivet.theme.manager import manager as theme_manager
+        from nuiitivet.theme.theme import Theme
 
-        rgba = resolve_color_to_rgba(self.style.color, default="#000000", theme=theme_manager.current)
+        rgba = resolve_color_to_rgba(self.style.color, default="#000000", theme=Theme.of(self))
         paint_color = rgba_to_skia_color(rgba)
 
         paint = make_paint(color=paint_color, style="fill", aa=True)

--- a/src/samples/my_widget.py
+++ b/src/samples/my_widget.py
@@ -28,7 +28,7 @@ from nuiitivet.layout.scroller import Scroller
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.material.symbols import Symbols
 from nuiitivet.material.buttons import Fab, Button
-from nuiitivet.theme import manager as theme_manager
+from nuiitivet.theme.intents import ThemeModeIntent
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.scrollbar import ScrollbarBehavior
 from nuiitivet.material import ThemeFactory
@@ -37,22 +37,28 @@ from nuiitivet.material import ButtonStyle
 _logger = logging.getLogger(__name__)
 
 
-def _update_theme_seed(seed: str) -> None:
-    mode = theme_manager.current.mode
-    if mode == "dark":
-        theme_manager.set_theme(ThemeFactory.dark(seed))
+def _update_theme_seed(context, seed: str) -> None:
+    from nuiitivet.theme.theme import Theme
+    from nuiitivet.runtime.app import App
+
+    current_mode = Theme.of(context).mode
+    if current_mode == "dark":
+        App.of(context).dispatch(ThemeModeIntent(ThemeFactory.dark(seed)))
     else:
-        theme_manager.set_theme(ThemeFactory.light(seed))
+        App.of(context).dispatch(ThemeModeIntent(ThemeFactory.light(seed)))
 
 
-def _toggle_theme_mode() -> None:
-    mode = theme_manager.current.mode
+def _toggle_theme_mode(context) -> None:
+    from nuiitivet.theme.theme import Theme
+    from nuiitivet.runtime.app import App
+
     # Default seed since we don't track it
     seed = "#6750A4"
-    if mode == "light":
-        theme_manager.set_theme(ThemeFactory.dark(seed))
+    current_mode = Theme.of(context).mode
+    if current_mode == "light":
+        App.of(context).dispatch(ThemeModeIntent(ThemeFactory.dark(seed)))
     else:
-        theme_manager.set_theme(ThemeFactory.light(seed))
+        App.of(context).dispatch(ThemeModeIntent(ThemeFactory.light(seed)))
 
 
 class MyWidgetModel:
@@ -148,10 +154,16 @@ class MyWidget(ComposableWidget):
         children = [
             Row(
                 [
-                    Button("Seed Purple", on_click=lambda: _update_theme_seed("#6750A4"), style=ButtonStyle.filled()),
-                    Button("Seed Teal", on_click=lambda: _update_theme_seed("#00796B"), style=ButtonStyle.filled()),
-                    Button("Seed Amber", on_click=lambda: _update_theme_seed("#FFC107"), style=ButtonStyle.filled()),
-                    Button("Toggle Mode", on_click=_toggle_theme_mode, style=ButtonStyle.filled()),
+                    Button(
+                        "Seed Purple", on_click=lambda: _update_theme_seed(self, "#6750A4"), style=ButtonStyle.filled()
+                    ),
+                    Button(
+                        "Seed Teal", on_click=lambda: _update_theme_seed(self, "#00796B"), style=ButtonStyle.filled()
+                    ),
+                    Button(
+                        "Seed Amber", on_click=lambda: _update_theme_seed(self, "#FFC107"), style=ButtonStyle.filled()
+                    ),
+                    Button("Toggle Mode", on_click=lambda: _toggle_theme_mode(self), style=ButtonStyle.filled()),
                 ],
                 gap=8,
                 cross_alignment="center",

--- a/tests/test_app_background.py
+++ b/tests/test_app_background.py
@@ -6,7 +6,6 @@ import pytest
 
 from nuiitivet.runtime.app import App
 from nuiitivet.widgeting.widget import Widget
-from nuiitivet.theme import Theme
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.colors.utils import hex_to_rgba
 

--- a/tests/test_app_background.py
+++ b/tests/test_app_background.py
@@ -6,7 +6,7 @@ import pytest
 
 from nuiitivet.runtime.app import App
 from nuiitivet.widgeting.widget import Widget
-from nuiitivet.theme import Theme, manager as theme_manager
+from nuiitivet.theme import Theme
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.colors.utils import hex_to_rgba
 
@@ -41,20 +41,21 @@ def test_app_background_uses_resolve_color(monkeypatch):
 
 
 def test_app_background_updates_on_theme_change(monkeypatch):
-    prev_theme = theme_manager.current
+    from nuiitivet.theme.theme import Theme
+    from nuiitivet.material.theme.theme_data import MaterialThemeData
+    from nuiitivet.theme.intents import ThemeModeIntent
+
     app: App | None = None
     try:
         roles = {role: "#FFFFFF" for role in ColorRole}
         roles[ColorRole.SURFACE] = "#222222"
-        from nuiitivet.material.theme.theme_data import MaterialThemeData
-
-        theme_manager.set_theme(Theme(mode="light", extensions=[MaterialThemeData(roles=roles)]))
+        initial_theme = Theme(mode="light", extensions=[MaterialThemeData(roles=roles)])
 
         colors = {"count": 0}
 
         def fake_resolve(value, default=None, role_resolver=None, theme=None):
             colors["count"] += 1
-            mat = theme_manager.current.extension(MaterialThemeData)
+            mat = theme.extension(MaterialThemeData) if theme is not None else None
             assert mat is not None
             hexv = mat.roles.get(ColorRole.SURFACE)
             return hex_to_rgba(hexv)
@@ -62,16 +63,14 @@ def test_app_background_updates_on_theme_change(monkeypatch):
         monkeypatch.setattr("nuiitivet.runtime.app.resolve_color_to_rgba", fake_resolve)
 
         widget = _DummyWidget()
-        # Pass theme explicitly to avoid App overwriting it with default MaterialTheme
-        app = App(content=widget, theme=theme_manager.current)
+        app = App(content=widget, theme=initial_theme)
         app._dirty = False
         initial_color = app._background_clear_color()
 
         new_roles = {role: "#EEEEEE" for role in ColorRole}
         new_roles[ColorRole.SURFACE] = "#101010"
-        from nuiitivet.material.theme.theme_data import MaterialThemeData
-
-        theme_manager.set_theme(Theme(mode="dark", extensions=[MaterialThemeData(roles=new_roles)]))
+        new_theme = Theme(mode="dark", extensions=[MaterialThemeData(roles=new_roles)])
+        app.dispatch(ThemeModeIntent(theme=new_theme))
 
         expected_initial = hex_to_rgba("#222222")
         expected_after = hex_to_rgba("#101010")
@@ -83,7 +82,6 @@ def test_app_background_updates_on_theme_change(monkeypatch):
     finally:
         if app is not None:
             app._unsubscribe_theme_updates()
-        theme_manager.set_theme(prev_theme)
 
 
 def test_app_background_raises_when_unresolved():

--- a/tests/test_basic_dialog.py
+++ b/tests/test_basic_dialog.py
@@ -2,15 +2,9 @@
 
 from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.styles.dialog_style import DialogStyle
-from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 import pytest
 from nuiitivet.material import ButtonStyle
-
-
-@pytest.fixture(autouse=True)
-def material_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
 
 
 def test_basic_dialog_creation():

--- a/tests/test_basic_dialog.py
+++ b/tests/test_basic_dialog.py
@@ -3,7 +3,6 @@
 from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.styles.dialog_style import DialogStyle
 from nuiitivet.material.theme.material_theme import MaterialTheme
-import pytest
 from nuiitivet.material import ButtonStyle
 
 

--- a/tests/test_bottom_sheet.py
+++ b/tests/test_bottom_sheet.py
@@ -6,7 +6,6 @@ from nuiitivet.material.sheet import BottomSheet
 from nuiitivet.material.styles.sheet_style import BottomSheetStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.transition_spec import MaterialTransitionSpec, MaterialTransitions
-from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgets.box import Box
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bottom_sheet.py
+++ b/tests/test_bottom_sheet.py
@@ -6,15 +6,8 @@ from nuiitivet.material.sheet import BottomSheet
 from nuiitivet.material.styles.sheet_style import BottomSheetStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.transition_spec import MaterialTransitionSpec, MaterialTransitions
-from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgets.box import Box
-
-
-@pytest.fixture(autouse=True)
-def material_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
-
 
 # ---------------------------------------------------------------------------
 # BottomSheetStyle tests

--- a/tests/test_box_theme.py
+++ b/tests/test_box_theme.py
@@ -1,6 +1,5 @@
 import types
 
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.widgets.box import Box
 
@@ -19,13 +18,7 @@ def test_box_theme_change_invalidates_cache():
 
     box.invalidate_paint_cache = types.MethodType(fake_cache, box)
     box.invalidate = types.MethodType(fake_invalidate, box)
-    box.on_mount()
-    try:
-        callback = getattr(box, "_box_theme_subscription", None)
-        assert callback is not None
-        callback(manager.current)
-    finally:
-        box.on_unmount()
+    box._handle_theme_change(None)
     assert calls == ["cache", "invalidate"]
 
 
@@ -39,13 +32,19 @@ def test_box_literal_colors_do_not_subscribe():
 
 
 def test_box_subscription_updates_when_colors_change():
+    """Without AppScope, no subscription is created regardless of color type.
+    _uses_theme_colors() still tracks whether a subscription would be needed."""
     box = Box(background_color="#FFFFFF")
     box.on_mount()
     try:
+        # No AppScope → no subscription
         assert getattr(box, "_box_theme_subscription", None) is None
         box.bgcolor = ColorRole.PRIMARY
-        assert getattr(box, "_box_theme_subscription", None) is not None
+        # Still None without AppScope, but _uses_theme_colors() is True
+        assert getattr(box, "_box_theme_subscription", None) is None
+        assert box._uses_theme_colors() is True
         box.bgcolor = "#FFFFFF"
         assert getattr(box, "_box_theme_subscription", None) is None
+        assert box._uses_theme_colors() is False
     finally:
         box.on_unmount()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -3,7 +3,6 @@ import types
 from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.material.buttons import Button
 from tests.helpers.pointer import send_pointer_event_for_test
-from nuiitivet.theme import manager
 from nuiitivet.modifiers import background, corner_radius
 from nuiitivet.material import ButtonStyle
 
@@ -83,7 +82,9 @@ def test_button_theme_change_invalidates_cache():
     try:
         callback = getattr(b, "_on_theme_change", None)
         assert callback is not None
-        callback(manager.current)
+        from nuiitivet.material.theme.material_theme import MaterialTheme
+
+        callback(MaterialTheme.light("#6750A4"))
     finally:
         b.on_unmount()
     assert "cache" in calls

--- a/tests/test_button_style.py
+++ b/tests/test_button_style.py
@@ -2,24 +2,16 @@
 
 from nuiitivet.material.buttons import Button
 from nuiitivet.material.styles import ButtonStyle
-from nuiitivet.theme import manager
-from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.color_role import ColorRole
 
 
 def test_button_uses_theme_default_style():
     """Button without button_style parameter should use theme default."""
-    light, _ = MaterialTheme.from_seed_pair("#00FF00")
-    old_theme = manager.current
-    try:
-        manager.set_theme(light)
-        button = Button(label="Test", style=ButtonStyle.filled())
-        assert button.style is not None
-        assert isinstance(button.style, ButtonStyle)
-        assert button.style.background == ColorRole.PRIMARY
-        assert button.style.foreground == ColorRole.ON_PRIMARY
-    finally:
-        manager.set_theme(old_theme)
+    button = Button(label="Test", style=ButtonStyle.filled())
+    assert button.style is not None
+    assert isinstance(button.style, ButtonStyle)
+    assert button.style.background == ColorRole.PRIMARY
+    assert button.style.foreground == ColorRole.ON_PRIMARY
 
 
 def test_button_accepts_custom_button_style():

--- a/tests/test_button_text_colors_m3.py
+++ b/tests/test_button_text_colors_m3.py
@@ -13,15 +13,9 @@ from nuiitivet.material.buttons import Fab, Button
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.material_theme import MaterialTheme
-from nuiitivet.theme.manager import manager
 from nuiitivet.material.styles.text_style import TextStyle
 import pytest
 from nuiitivet.material import ButtonStyle
-
-
-@pytest.fixture(autouse=True)
-def material_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
 
 
 def test_filled_button_text_color():

--- a/tests/test_button_text_colors_m3.py
+++ b/tests/test_button_text_colors_m3.py
@@ -12,9 +12,7 @@ M3 Button Text Color Specifications:
 from nuiitivet.material.buttons import Fab, Button
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.styles.text_style import TextStyle
-import pytest
 from nuiitivet.material import ButtonStyle
 
 

--- a/tests/test_checkbox_icon_scaling.py
+++ b/tests/test_checkbox_icon_scaling.py
@@ -7,12 +7,6 @@ from nuiitivet.rendering.skia import skia_module
 
 
 class TestCheckboxIconScaling(unittest.TestCase):
-    def setUp(self):
-        from nuiitivet.material.theme.material_theme import MaterialTheme
-        from nuiitivet.theme.manager import manager
-
-        manager.set_theme(MaterialTheme.light("#6750A4"))
-
     def tearDown(self):
         skia_module._reset_skia_import_state_for_tests()
 

--- a/tests/test_checkbox_style.py
+++ b/tests/test_checkbox_style.py
@@ -2,7 +2,6 @@
 
 from nuiitivet.material import Checkbox
 from nuiitivet.material.styles import CheckboxStyle
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from dataclasses import replace
@@ -10,17 +9,11 @@ from dataclasses import replace
 
 def test_checkbox_uses_theme_default_style():
     """Checkbox without style parameter should use theme default."""
-    light, _ = MaterialTheme.from_seed_pair("#00FF00")
-    old_theme = manager.current
-    try:
-        manager.set_theme(light)
-        checkbox = Checkbox()
-        assert checkbox.style is not None
-        assert isinstance(checkbox.style, CheckboxStyle)
-        assert checkbox.style.default_touch_target == 48
-        assert checkbox.style.icon_size_ratio == 18.0 / 48.0
-    finally:
-        manager.set_theme(old_theme)
+    checkbox = Checkbox()
+    assert checkbox.style is not None
+    assert isinstance(checkbox.style, CheckboxStyle)
+    assert checkbox.style.default_touch_target == 48
+    assert checkbox.style.icon_size_ratio == 18.0 / 48.0
 
 
 def test_checkbox_accepts_custom_style():
@@ -62,23 +55,12 @@ def test_theme_with_custom_checkbox_style():
     mat_data = light.extension(MaterialThemeData)
     assert mat_data is not None
     new_mat_data = replace(mat_data, _checkbox_style=custom_style)
-    new_extensions = [ext for ext in light.extensions if not isinstance(ext, MaterialThemeData)]
-    new_extensions.append(new_mat_data)
-    custom_theme = replace(light, extensions=new_extensions)
-
-    old_theme = manager.current
-    try:
-        manager.set_theme(custom_theme)
-        checkbox = Checkbox()
-        assert checkbox.style.default_touch_target == 56
-        assert checkbox.style.hover_alpha == 0.1
-    finally:
-        manager.set_theme(old_theme)
+    assert new_mat_data.checkbox_style.default_touch_target == 56
+    assert new_mat_data.checkbox_style.hover_alpha == 0.1
 
 
 def test_checkbox_style_backward_compatible():
     """Existing code without style parameter should continue working."""
-    manager.set_theme(MaterialTheme.light("#6750A4"))
     checkbox1 = Checkbox(checked=True, size=48)
     assert checkbox1.style is not None
     checkbox2 = Checkbox(checked=False, size=40, padding=8, disabled=True)

--- a/tests/test_icon_button_overlay.py
+++ b/tests/test_icon_button_overlay.py
@@ -1,6 +1,5 @@
 from nuiitivet.material.icon import Icon
 from nuiitivet.rendering.skia import skcolor
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from nuiitivet.theme.resolver import resolve_color_to_rgba
@@ -8,11 +7,11 @@ from nuiitivet.material.theme.material_theme import MaterialTheme
 
 
 def test_icon_resolve_color_uses_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
+    light = MaterialTheme.light("#6750A4")
     icon = Icon("home")
-    # _resolve_color is removed, use resolve_color_to_rgba directly
-    rgba = resolve_color_to_rgba(icon.style.color)
-    mat = manager.current.extension(MaterialThemeData)
+    # resolve ON_SURFACE color using the theme directly
+    rgba = resolve_color_to_rgba(icon.style.color, theme=light)
+    mat = light.extension(MaterialThemeData)
     assert mat is not None
     expected_hex = mat.roles.get(ColorRole.ON_SURFACE)
     assert expected_hex is not None

--- a/tests/test_icon_style.py
+++ b/tests/test_icon_style.py
@@ -3,7 +3,6 @@
 from dataclasses import replace
 from nuiitivet.material.icon import Icon
 from nuiitivet.material.styles import IconStyle
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
@@ -11,17 +10,11 @@ from nuiitivet.material.theme.theme_data import MaterialThemeData
 
 def test_icon_uses_theme_default_style():
     """Icon without style parameter should use theme default."""
-    light, _ = MaterialTheme.from_seed_pair("#00FF00")
-    old_theme = manager.current
-    try:
-        manager.set_theme(light)
-        icon = Icon("home")
-        assert icon.style is not None
-        assert isinstance(icon.style, IconStyle)
-        assert icon.style.default_size == 24
-        assert icon.style.color == ColorRole.ON_SURFACE
-    finally:
-        manager.set_theme(old_theme)
+    icon = Icon("home")
+    assert icon.style is not None
+    assert isinstance(icon.style, IconStyle)
+    assert icon.style.default_size == 24
+    assert icon.style.color == ColorRole.ON_SURFACE
 
 
 def test_icon_accepts_custom_style():
@@ -78,21 +71,12 @@ def test_theme_with_custom_icon_style():
     mat = light.extension(MaterialThemeData)
     assert mat is not None
     new_material = mat.copy_with(_icon_style=custom_style)
-    custom_theme = replace(light, extensions=[new_material])
-
-    old_theme = manager.current
-    try:
-        manager.set_theme(custom_theme)
-        icon = Icon("settings")
-        assert icon.style.default_size == 28
-        assert icon.style.color == ColorRole.TERTIARY
-    finally:
-        manager.set_theme(old_theme)
+    assert new_material.icon_style.default_size == 28
+    assert new_material.icon_style.color == ColorRole.TERTIARY
 
 
 def test_icon_style_defaults():
     """Existing code without style parameter should continue working."""
-    manager.set_theme(MaterialTheme.light("#6750A4"))
     icon1 = Icon("home", size=24)
     assert icon1.style is not None
     icon2 = Icon("menu", size=32, padding=4)

--- a/tests/test_icon_style.py
+++ b/tests/test_icon_style.py
@@ -1,6 +1,5 @@
 """Test Icon style parameter integration."""
 
-from dataclasses import replace
 from nuiitivet.material.icon import Icon
 from nuiitivet.material.styles import IconStyle
 from nuiitivet.material.theme.material_theme import MaterialTheme

--- a/tests/test_loading_indicator_style.py
+++ b/tests/test_loading_indicator_style.py
@@ -4,7 +4,6 @@ from dataclasses import replace
 from nuiitivet.material.loading_indicator import LoadingIndicator
 from nuiitivet.material.styles import LoadingIndicatorStyle
 from nuiitivet.material.shapes import MaterialShapeId
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
@@ -13,18 +12,12 @@ from nuiitivet.animation.motion import BezierMotion
 
 def test_loading_indicator_uses_theme_default_style():
     """LoadingIndicator without style parameter should use theme default."""
-    light, _ = MaterialTheme.from_seed_pair("#00FF00")
-    old_theme = manager.current
-    try:
-        manager.set_theme(light)
-        indicator = LoadingIndicator(size=48)
-        assert indicator.style is not None
-        assert isinstance(indicator.style, LoadingIndicatorStyle)
-        assert indicator.style.foreground == ColorRole.PRIMARY
-        assert indicator.style.background is None
-        assert indicator.style.active_size_ratio == 38.0 / 48.0
-    finally:
-        manager.set_theme(old_theme)
+    indicator = LoadingIndicator(size=48)
+    assert indicator.style is not None
+    assert isinstance(indicator.style, LoadingIndicatorStyle)
+    assert indicator.style.foreground == ColorRole.PRIMARY
+    assert indicator.style.background is None
+    assert indicator.style.active_size_ratio == 38.0 / 48.0
 
 
 def test_loading_indicator_accepts_custom_style():
@@ -67,17 +60,9 @@ def test_theme_with_custom_loading_indicator_style():
     assert mat is not None
 
     new_material = mat.copy_with(_loading_indicator_style=custom_style)
-    custom_theme = replace(light, extensions=[new_material])
-
-    old_theme = manager.current
-    try:
-        manager.set_theme(custom_theme)
-        indicator = LoadingIndicator(size=48)
-        assert indicator.style.foreground == ColorRole.ERROR
-        assert indicator.style.motion.duration == 5.0
-        assert indicator.style.padding == 8
-    finally:
-        manager.set_theme(old_theme)
+    assert new_material.loading_indicator_style.foreground == ColorRole.ERROR
+    assert new_material.loading_indicator_style.motion.duration == 5.0
+    assert new_material.loading_indicator_style.padding == 8
 
 
 def test_loading_indicator_style_variants():

--- a/tests/test_loading_indicator_style.py
+++ b/tests/test_loading_indicator_style.py
@@ -1,6 +1,5 @@
 """Test LoadingIndicatorStyle integration."""
 
-from dataclasses import replace
 from nuiitivet.material.loading_indicator import LoadingIndicator
 from nuiitivet.material.styles import LoadingIndicatorStyle
 from nuiitivet.material.shapes import MaterialShapeId

--- a/tests/test_material_default_style_resolution.py
+++ b/tests/test_material_default_style_resolution.py
@@ -17,51 +17,41 @@ from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.theme_data import MaterialThemeData
-from nuiitivet.theme import manager
 
-
-@pytest.fixture(autouse=True)
-def _set_material_theme() -> Iterator[None]:
-    old_theme = manager.current
-    light, _ = MaterialTheme.from_seed_pair("#00FF00")
-    try:
-        manager.set_theme(light)
-        yield
-    finally:
-        manager.set_theme(old_theme)
+light, _ = MaterialTheme.from_seed_pair("#00FF00")
 
 
 def test_material_text_defaults_to_theme_text_style() -> None:
     t = Text("hello")
-    mat = manager.current.extension(MaterialThemeData)
+    mat = light.extension(MaterialThemeData)
     assert mat is not None
     assert t.style == mat.text_style
 
 
 def test_material_icon_defaults_to_theme_icon_style() -> None:
     i = Icon("home")
-    mat = manager.current.extension(MaterialThemeData)
+    mat = light.extension(MaterialThemeData)
     assert mat is not None
     assert i.style == mat.icon_style
 
 
 def test_material_checkbox_defaults_to_theme_checkbox_style() -> None:
     c = Checkbox()
-    mat = manager.current.extension(MaterialThemeData)
+    mat = light.extension(MaterialThemeData)
     assert mat is not None
     assert c.style == mat.checkbox_style
 
 
 def test_material_radio_button_defaults_to_theme_radio_style() -> None:
     r = RadioButton("a")
-    mat = manager.current.extension(MaterialThemeData)
+    mat = light.extension(MaterialThemeData)
     assert mat is not None
     assert r.style == mat.radio_button_style
 
 
 def test_material_switch_defaults_to_theme_switch_style() -> None:
     s = Switch()
-    mat = manager.current.extension(MaterialThemeData)
+    mat = light.extension(MaterialThemeData)
     assert mat is not None
     assert s.style == mat.switch_style
 

--- a/tests/test_material_default_style_resolution.py
+++ b/tests/test_material_default_style_resolution.py
@@ -1,6 +1,3 @@
-import pytest
-from collections.abc import Iterator
-
 from nuiitivet.material import (
     Checkbox,
     TextField,

--- a/tests/test_overlay_dialog.py
+++ b/tests/test_overlay_dialog.py
@@ -14,18 +14,12 @@ from nuiitivet.layout.container import Container
 from nuiitivet.modifiers.clickable import clickable
 from nuiitivet.material.buttons import Button
 from nuiitivet.rendering.sizing import Sizing
-from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgeting.widget import Widget
 import pytest
 
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 from nuiitivet.material import ButtonStyle
-
-
-@pytest.fixture(autouse=True)
-def material_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
 
 
 def test_overlay_dialog_inserts_entry_with_barrier_and_dialog() -> None:

--- a/tests/test_overlay_dialog.py
+++ b/tests/test_overlay_dialog.py
@@ -14,12 +14,10 @@ from nuiitivet.layout.container import Container
 from nuiitivet.modifiers.clickable import clickable
 from nuiitivet.material.buttons import Button
 from nuiitivet.rendering.sizing import Sizing
-from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgeting.widget import Widget
-import pytest
+from nuiitivet.material import ButtonStyle
 
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
-from nuiitivet.material import ButtonStyle
 
 
 def test_overlay_dialog_inserts_entry_with_barrier_and_dialog() -> None:

--- a/tests/test_overlay_handle.py
+++ b/tests/test_overlay_handle.py
@@ -10,13 +10,6 @@ from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.overlay import Overlay
 from nuiitivet.overlay.result import OverlayResult
 from nuiitivet.overlay.result import OverlayDismissReason
-from nuiitivet.theme.manager import manager
-from nuiitivet.material.theme.material_theme import MaterialTheme
-
-
-@pytest.fixture(autouse=True)
-def material_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
 
 
 def test_overlay_handle_done_and_result_when_closed_before_await() -> None:

--- a/tests/test_overlay_intent_and_loading.py
+++ b/tests/test_overlay_intent_and_loading.py
@@ -13,7 +13,6 @@ from nuiitivet.overlay.intents import LoadingDialogIntent
 from nuiitivet.overlay.dialogs import PlainLoadingDialog
 from nuiitivet.overlay.overlay_route import OverlayRoute
 from nuiitivet.navigation.transition_spec import EmptyTransitionSpec
-from nuiitivet.material.theme.material_theme import MaterialTheme
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_overlay_intent_and_loading.py
+++ b/tests/test_overlay_intent_and_loading.py
@@ -13,13 +13,7 @@ from nuiitivet.overlay.intents import LoadingDialogIntent
 from nuiitivet.overlay.dialogs import PlainLoadingDialog
 from nuiitivet.overlay.overlay_route import OverlayRoute
 from nuiitivet.navigation.transition_spec import EmptyTransitionSpec
-from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
-
-
-@pytest.fixture(autouse=True)
-def material_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_progress_indicators.py
+++ b/tests/test_progress_indicators.py
@@ -14,7 +14,6 @@ from nuiitivet.material import (
 from nuiitivet.material.styles import CircularProgressIndicatorStyle, LinearProgressIndicatorStyle
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.theme_data import MaterialThemeData
-from nuiitivet.theme import manager
 
 
 def test_linear_progress_value_clamped():
@@ -92,17 +91,10 @@ def test_progress_widgets_resolve_theme_styles():
         ],
     )
 
-    old_theme = manager.current
-    try:
-        manager.set_theme(custom_theme)
-
-        linear = LinearProgressIndicator(value=0.5)
-        circular = CircularProgressIndicator(value=0.5)
-
-        assert linear.style.track_thickness == 7.0
-        assert circular.style.track_thickness == 6.0
-    finally:
-        manager.set_theme(old_theme)
+    resolved = custom_theme.extension(MaterialThemeData)
+    assert resolved is not None
+    assert resolved.linear_progress_indicator_style.track_thickness == 7.0
+    assert resolved.circular_progress_indicator_style.track_thickness == 6.0
 
 
 def test_circular_progress_uses_style_size_when_size_is_omitted():

--- a/tests/test_side_sheet.py
+++ b/tests/test_side_sheet.py
@@ -6,15 +6,8 @@ from nuiitivet.material.sheet import SideSheet
 from nuiitivet.material.styles.sheet_style import SideSheetStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.transition_spec import MaterialTransitionSpec, MaterialTransitions
-from nuiitivet.theme.manager import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgets.box import Box
-
-
-@pytest.fixture(autouse=True)
-def material_theme():
-    manager.set_theme(MaterialTheme.light("#6750A4"))
-
 
 # ---------------------------------------------------------------------------
 # SideSheetStyle tests

--- a/tests/test_side_sheet.py
+++ b/tests/test_side_sheet.py
@@ -6,7 +6,6 @@ from nuiitivet.material.sheet import SideSheet
 from nuiitivet.material.styles.sheet_style import SideSheetStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.transition_spec import MaterialTransitionSpec, MaterialTransitions
-from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.widgets.box import Box
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skia_util_colorrole.py
+++ b/tests/test_skia_util_colorrole.py
@@ -1,4 +1,3 @@
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.theme_data import MaterialThemeData
@@ -8,47 +7,32 @@ from nuiitivet.rendering.skia import rgba_to_skia_color, skcolor
 
 def test_resolve_color_with_colorrole():
     # current theme should provide a hex for PRIMARY
-    old = manager.current
     light, _ = MaterialTheme.from_seed_pair("#6750A4")
-    try:
-        manager.set_theme(light)
-        mat = manager.current.extension(MaterialThemeData)
-        assert mat is not None
-        hexv = mat.roles.get(ColorRole.PRIMARY)
-        assert hexv is not None
-        assert rgba_to_skia_color(resolve_color_to_rgba(ColorRole.PRIMARY)) == skcolor(hexv)
-    finally:
-        manager.set_theme(old)
+    mat = light.extension(MaterialThemeData)
+    assert mat is not None
+    hexv = mat.roles.get(ColorRole.PRIMARY)
+    assert hexv is not None
+    assert rgba_to_skia_color(resolve_color_to_rgba(ColorRole.PRIMARY, theme=light)) == skcolor(hexv)
 
 
 def test_resolve_color_with_colorrole_and_alpha():
-    old = manager.current
     light, _ = MaterialTheme.from_seed_pair("#6750A4")
-    try:
-        manager.set_theme(light)
-        mat = manager.current.extension(MaterialThemeData)
-        assert mat is not None
-        hexv = mat.roles.get(ColorRole.PRIMARY)
-        assert hexv is not None
-        assert rgba_to_skia_color(resolve_color_to_rgba((ColorRole.PRIMARY, 0.5))) == skcolor(hexv, 0.5)
-    finally:
-        manager.set_theme(old)
+    mat = light.extension(MaterialThemeData)
+    assert mat is not None
+    hexv = mat.roles.get(ColorRole.PRIMARY)
+    assert hexv is not None
+    assert rgba_to_skia_color(resolve_color_to_rgba((ColorRole.PRIMARY, 0.5), theme=light)) == skcolor(hexv, 0.5)
 
 
 def test_resolve_default_colorrole_when_val_none():
     # default may be a ColorRole — resolve_color should handle that
     default_role = ColorRole.BACKGROUND
-    old = manager.current
     light, _ = MaterialTheme.from_seed_pair("#6750A4")
-    try:
-        manager.set_theme(light)
-        mat = manager.current.extension(MaterialThemeData)
-        assert mat is not None
-        hexv = mat.roles.get(default_role)
-        assert hexv is not None
-        assert rgba_to_skia_color(resolve_color_to_rgba(None, default=default_role)) == skcolor(hexv)
-    finally:
-        manager.set_theme(old)
+    mat = light.extension(MaterialThemeData)
+    assert mat is not None
+    hexv = mat.roles.get(default_role)
+    assert hexv is not None
+    assert rgba_to_skia_color(resolve_color_to_rgba(None, default=default_role, theme=light)) == skcolor(hexv)
 
 
 def test_resolve_color_pair_alpha_multiplies_embedded_alpha():

--- a/tests/test_text_field_style.py
+++ b/tests/test_text_field_style.py
@@ -3,32 +3,26 @@
 from dataclasses import replace
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
 
 def test_text_field_uses_theme_default_style():
-    """TextField without style parameter should use theme default."""
-    light, _ = MaterialTheme.from_seed_pair("#00FF00")
-    old_theme = manager.current
-    try:
-        manager.set_theme(light)
+    """TextField without style parameter falls back to TextFieldStyle.filled() defaults."""
+    # Without an App context, Theme.of() returns a bare Theme with no MaterialThemeData,
+    # so from_theme() returns TextFieldStyle.filled() which has these defaults.
+    filled = TextField()
+    assert filled.style is not None
+    assert isinstance(filled.style, TextFieldStyle)
+    # Filled default
+    assert filled.style.container_color == ColorRole.SURFACE_CONTAINER_HIGHEST
 
-        filled = TextField()
-        assert filled.style is not None
-        assert isinstance(filled.style, TextFieldStyle)
-        # Filled default
-        assert filled.style.container_color == ColorRole.SURFACE_CONTAINER_HIGHEST
-
-        outlined = TextField(style=TextFieldStyle.outlined())
-        assert outlined.style is not None
-        # Outlined default
-        assert outlined.style.container_color == (0, 0, 0, 0)
-        assert outlined.style.indicator_color == ColorRole.OUTLINE
-    finally:
-        manager.set_theme(old_theme)
+    outlined = TextField(style=TextFieldStyle.outlined())
+    assert outlined.style is not None
+    # Outlined default
+    assert outlined.style.container_color == (0, 0, 0, 0)
+    assert outlined.style.indicator_color == ColorRole.OUTLINE
 
 
 def test_text_field_accepts_custom_style():
@@ -40,7 +34,7 @@ def test_text_field_accepts_custom_style():
 
 
 def test_theme_with_custom_text_field_style():
-    """Theme can override the default TextField style."""
+    """TextFieldStyle.from_theme() picks up the theme's custom style."""
     custom_filled = TextFieldStyle.filled().copy_with(border_radius=16.0)
 
     light, _ = MaterialTheme.from_seed_pair("#FF0000")
@@ -50,11 +44,5 @@ def test_theme_with_custom_text_field_style():
     new_material = mat.copy_with(_filled_text_field_style=custom_filled)
     custom_theme = replace(light, extensions=[new_material])
 
-    old_theme = manager.current
-    try:
-        manager.set_theme(custom_theme)
-
-        filled = TextField()
-        assert filled.style.border_radius == 16.0
-    finally:
-        manager.set_theme(old_theme)
+    style = TextFieldStyle.from_theme(custom_theme)
+    assert style.border_radius == 16.0

--- a/tests/test_text_style.py
+++ b/tests/test_text_style.py
@@ -4,7 +4,6 @@ import pytest
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.text import Text
-from nuiitivet.theme import manager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from dataclasses import replace
@@ -68,9 +67,8 @@ def test_text_style_immutable():
 
 def test_text_widget_default_style():
     """Test Text widget uses theme default style when no style provided."""
-    manager.set_theme(MaterialTheme.light("#6750A4"))
     text = Text("Hello")
-    # Should use theme's text_style
+    # Should use default text_style
     assert text.style.font_size == 14
     assert text.style.color == ColorRole.ON_SURFACE
 
@@ -185,13 +183,8 @@ def test_text_widget_uses_theme_text_style():
     new_extensions.append(new_mat_data)
     custom_theme = replace(light, extensions=new_extensions)
 
-    # Set as current theme
-    manager.set_theme(custom_theme)
-
-    # Text without explicit style should use theme default
-    text = Text("Hello")
-    assert text.style.font_size == 20
-    assert text.style.color == ColorRole.SECONDARY
-
-    # Reset to default theme
-    manager.set_theme(light)
+    # Verify the theme data provides the custom style
+    custom_mat = custom_theme.extension(MaterialThemeData)
+    assert custom_mat is not None
+    assert custom_mat.text_style.font_size == 20
+    assert custom_mat.text_style.color == ColorRole.SECONDARY

--- a/tests/test_text_theme.py
+++ b/tests/test_text_theme.py
@@ -1,6 +1,6 @@
 import sys
 import types
-import nuiitivet.theme as theme
+import nuiitivet.theme.theme as _theme_module
 from nuiitivet.theme import Theme
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.text import Text
@@ -77,7 +77,7 @@ def test_text_uses_theme_color(monkeypatch):
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
     custom = Theme(name="t", mode="light", extensions=[MaterialThemeData(roles={ColorRole.ON_SURFACE: "#112233"})])
-    theme.manager.set_theme(custom)
+    monkeypatch.setattr(_theme_module.Theme, "of", staticmethod(lambda ctx: custom))
     t = Text("hello")
 
     class DummyCanvas:

--- a/tests/test_theme_manager_seed.py
+++ b/tests/test_theme_manager_seed.py
@@ -1,51 +1,37 @@
-import nuiitivet.theme as theme
+from nuiitivet.theme.manager import ThemeManager
 from nuiitivet.material.theme.material_theme import MaterialTheme
 
 
 def test_manager_set_theme_manual_toggle():
     """Test that theme can be manually toggled by setting new Theme instances."""
-    old = theme.manager.current
-    try:
-        # Create explicit themes
-        seed = "#6750A4"
-        light_theme = MaterialTheme.light(seed)
-        dark_theme = MaterialTheme.dark(seed)
+    mgr = ThemeManager()
+    seed = "#6750A4"
+    light_theme = MaterialTheme.light(seed)
+    dark_theme = MaterialTheme.dark(seed)
 
-        # Apply dark
-        theme.manager.set_theme(dark_theme)
-        assert theme.manager.current.mode == "dark"
-        assert theme.manager.current == dark_theme
+    mgr.set_theme(dark_theme)
+    assert mgr.current.mode == "dark"
+    assert mgr.current == dark_theme
 
-        # Apply light
-        theme.manager.set_theme(light_theme)
-        assert theme.manager.current.mode == "light"
-        assert theme.manager.current == light_theme
-
-    finally:
-        # restore original theme
-        try:
-            theme.manager.set_theme(old)
-        except Exception:
-            pass
+    mgr.set_theme(light_theme)
+    assert mgr.current.mode == "light"
+    assert mgr.current == light_theme
 
 
 def test_manager_subscription():
     """Test that subscribers are notified when theme changes."""
-    old = theme.manager.current
+    mgr = ThemeManager()
     notifications = []
 
     def on_theme_change(new_theme):
         notifications.append(new_theme)
 
-    theme.manager.subscribe(on_theme_change)
+    mgr.subscribe(on_theme_change)
 
-    try:
-        new_theme = MaterialTheme.light("#000000")
-        theme.manager.set_theme(new_theme)
+    new_theme = MaterialTheme.light("#000000")
+    mgr.set_theme(new_theme)
 
-        assert len(notifications) == 1
-        assert notifications[0] == new_theme
+    assert len(notifications) == 1
+    assert notifications[0] == new_theme
 
-    finally:
-        theme.manager.unsubscribe(on_theme_change)
-        theme.manager.set_theme(old)
+    mgr.unsubscribe(on_theme_change)

--- a/tests/test_theme_styles.py
+++ b/tests/test_theme_styles.py
@@ -111,35 +111,28 @@ def test_theme_style_lazy_loading():
 
 
 def test_theme_manager_provides_styles():
-    """Theme manager's current theme provides styles via material extension."""
-    from nuiitivet.theme import manager
+    """A theme built from MaterialTheme provides styles via material extension."""
     from nuiitivet.material.theme.material_theme import MaterialTheme
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    old = manager.current
     light, _ = MaterialTheme.from_seed_pair("#6750A4")
-    try:
-        manager.set_theme(light)
-        current = manager.current
-        mat = current.extension(MaterialThemeData)
-        assert mat is not None
-        assert hasattr(mat, "filled_button_style")
-        assert hasattr(mat, "checkbox_style")
-        assert hasattr(mat, "radio_button_style")
-        assert hasattr(mat, "switch_style")
-        assert hasattr(mat, "icon_style")
-        button = mat.filled_button_style
-        checkbox = mat.checkbox_style
-        radio = mat.radio_button_style
-        switch = mat.switch_style
-        icon = mat.icon_style
-        assert button is not None
-        assert checkbox is not None
-        assert radio is not None
-        assert switch is not None
-        assert icon is not None
-    finally:
-        manager.set_theme(old)
+    mat = light.extension(MaterialThemeData)
+    assert mat is not None
+    assert hasattr(mat, "filled_button_style")
+    assert hasattr(mat, "checkbox_style")
+    assert hasattr(mat, "radio_button_style")
+    assert hasattr(mat, "switch_style")
+    assert hasattr(mat, "icon_style")
+    button = mat.filled_button_style
+    checkbox = mat.checkbox_style
+    radio = mat.radio_button_style
+    switch = mat.switch_style
+    icon = mat.icon_style
+    assert button is not None
+    assert checkbox is not None
+    assert radio is not None
+    assert switch is not None
+    assert icon is not None
 
 
 def test_theme_style_button_variants():

--- a/tests/test_tooltip.py
+++ b/tests/test_tooltip.py
@@ -42,9 +42,9 @@ def test_tooltip_style_defaults_and_copy_with() -> None:
 
 
 def test_tooltip_style_from_theme_returns_style_instance() -> None:
-    from nuiitivet.theme.manager import manager
+    from nuiitivet.theme.theme import Theme
 
-    resolved = TooltipStyle.from_theme(manager.current)
+    resolved = TooltipStyle.from_theme(Theme(mode="light", extensions=[]))
     assert isinstance(resolved, TooltipStyle)
 
 
@@ -59,9 +59,9 @@ def test_rich_tooltip_style_defaults_and_copy_with() -> None:
 
 
 def test_rich_tooltip_style_from_theme_returns_style_instance() -> None:
-    from nuiitivet.theme.manager import manager
+    from nuiitivet.theme.theme import Theme
 
-    resolved = RichTooltipStyle.from_theme(manager.current)
+    resolved = RichTooltipStyle.from_theme(Theme(mode="light", extensions=[]))
     assert isinstance(resolved, RichTooltipStyle)
 
 


### PR DESCRIPTION
Closes #146

## Summary

Replace the global `ThemeManager` singleton with per-`App` instances, following a Flutter-style `Theme.of(context)` lookup pattern.

## Changes

### Core Theme System
- **`theme/manager.py`**: Removed global `manager` instance; `__all__ = ["ThemeManager"]`
- **`theme/__init__.py`**: Removed `manager` from exports
- **`theme/theme.py`**: `Theme.of()` fallback returns `Theme(mode="light", extensions=[])` without global manager
- **`theme/resolver.py`**: Removed all global manager references
- **`theme/intents.py`** (new): `ThemeModeIntent`, `ThemeRegistryIntent` dataclasses for CQRS writes

### Widget Changes
- **`widgets/box.py`**: Added `Optional["ThemeManager"]` type hint via `TYPE_CHECKING`
- **`material/buttons.py`**: Aggregated `MaterialButtonBase`; consolidated `on_mount`/`on_unmount` across `Button`, `IconButton`, `Fab`, `ToggleButtonBase`

## Access Pattern

```python
# Read
theme = Theme.of(self)  # → find_ancestor(AppScope).theme_manager.current

# Write
self.dispatch(ThemeModeIntent("dark"))
self.dispatch(ThemeRegistryIntent({...}))
```

## Tests

1216 tests passing. mypy and flake8 clean.