### PR TITLE
fix: tidy up mkdocs.yml metadata and sidebar navigation styles

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -27,3 +27,9 @@
 .md-nav--primary .md-nav__item:not(.md-nav__item--section):not(.md-nav__item--nested)>.md-nav__link {
     font-weight: 400;
 }
+
+/* Indent leaf page links inside sections so they are visually
+   subordinate to the section (category) label above them. */
+.md-nav--primary .md-nav .md-nav__item:not(.md-nav__item--section):not(.md-nav__item--nested)>.md-nav__link {
+    padding-left: 1.2rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,11 +4,11 @@
 site_name: Nuiitivet Documentation
 site_url: https://yuksblog.github.io/nuiitivet/
 site_description: A declarative, reactive Python UI framework.
-site_author: Yukinobu Imai
+site_author: yuksblog
 repo_url: https://github.com/yuksblog/nuiitivet
 repo_name: yuksblog/nuiitivet
 edit_uri: edit/main/docs/
-copyright: Copyright &copy; 2026 Yukinobu Imai
+copyright: Copyright &copy; 2026 yuksblog
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 authors = [
-  {name = "Yukinobu Imai", email = "kotatu.kotatu@gmail.com"},
+  {name = "yuksblog", email = "kotatu.kotatu@gmail.com"},
 ]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
## Summary

Closes #172

## Changes

- Replace author metadata (`site_author`, `copyright`) in `mkdocs.yml` with pseudonym
- Replace `authors[].name` in `pyproject.toml` with pseudonym
- Add `padding-left` to leaf page links in sidebar (`extra.css`) to improve visual distinction between category labels and page links