### PR TITLE
feat(material): expose MaterialNavigator as Navigator in nuiitivet.material

### DIFF
--- a/docs/guide/navigation.md
+++ b/docs/guide/navigation.md
@@ -21,8 +21,7 @@ To navigate to a new screen, you use the `push()` method. This adds a new route 
 ```python
 import nuiitivet as nv
 
-from nuiitivet.navigation import Navigator
-from nuiitivet.material import Text, Button
+from nuiitivet.material import Navigator, Text, Button
 from nuiitivet.layout.column import Column
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box

--- a/docs/guide/navigation_intent.md
+++ b/docs/guide/navigation_intent.md
@@ -25,9 +25,7 @@ import nuiitivet as nv
 
 from dataclasses import dataclass
 
-from nuiitivet.material import App, Text, Button
-from nuiitivet.layout.column import Column
-from nuiitivet.navigation import Navigator
+from nuiitivet.material import App, Text, Button, Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle
@@ -92,8 +90,7 @@ app = App(
 Once configured, you can navigate by pushing an Intent object to the `Navigator`. The `Navigator` will automatically resolve the Intent to the correct route using the mapping you provided.
 
 ```python
-from nuiitivet.navigation import Navigator
-from nuiitivet.material import Button
+from nuiitivet.material import Navigator, Button
 from nuiitivet.material import ButtonStyle
 
 def go_to_details():
@@ -113,7 +110,7 @@ Intent-based navigation is highly recommended, especially when navigating from a
 Here is an example of how a ViewModel can trigger navigation using `Navigator` and Intents. You can pass `Navigator.root()` to your ViewModel:
 
 ```python
-from nuiitivet.navigation import Navigator
+from nuiitivet.material import Navigator
 
 class ItemViewModel:
     def __init__(self, item_id: int, navigator: Navigator):

--- a/docs/guide/navigation_route.md
+++ b/docs/guide/navigation_route.md
@@ -13,7 +13,8 @@ Nuiitivet provides built-in transition effects such as `FadeIn`, `FadeOut`, `Sca
 ```python
 import nuiitivet as nv
 
-from nuiitivet.navigation import Navigator, Route
+from nuiitivet.material import Navigator
+from nuiitivet.navigation import Route
 from nuiitivet.material import (Text, MaterialTransitions, FadeIn, SlideInVertically, FadeOut, SlideOutVertically, Button)
 from nuiitivet.layout.column import Column
 from nuiitivet.widgeting.widget import ComposableWidget
@@ -57,7 +58,8 @@ If you want to transition to a new screen instantly without any animation, you c
 ```python
 import nuiitivet as nv
 
-from nuiitivet.navigation import Navigator, Route, Transitions
+from nuiitivet.material import Navigator
+from nuiitivet.navigation import Route, Transitions
 from nuiitivet.material import Text, Button
 from nuiitivet.layout.column import Column
 from nuiitivet.widgeting.widget import ComposableWidget

--- a/docs/guide/navigation_sub.md
+++ b/docs/guide/navigation_sub.md
@@ -11,12 +11,12 @@ You can create a nested navigation area by placing a `MaterialNavigator` widget 
 ```python
 import nuiitivet as nv
 
-from nuiitivet.material import Text, Button
+from nuiitivet.material import Text, Button, Navigator
 from nuiitivet.material.navigator import MaterialNavigator
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.layout.container import Container
-from nuiitivet.navigation import Navigator, Route
+from nuiitivet.navigation import Route
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from .text_fields import TextField
     from .styles.text_field_style import TextFieldStyle
     from .text import Text
+    from .navigator import MaterialNavigator as Navigator
     from .overlay import MaterialOverlay
     from .overlay import MaterialOverlay as Overlay
     from .overlay import WhileLoading
@@ -103,6 +104,7 @@ __all__ = [
     "TextFieldStyle",
     "NavigationRail",
     "RailItem",
+    "Navigator",
     "MaterialOverlay",
     "Overlay",
     "WhileLoading",
@@ -185,6 +187,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "TextFieldStyle": ("styles.text_field_style", "TextFieldStyle"),
     "NavigationRail": ("navigation_rail", "NavigationRail"),
     "RailItem": ("navigation_rail", "RailItem"),
+    "Navigator": ("navigator", "MaterialNavigator"),
     "MaterialOverlay": ("overlay", "MaterialOverlay"),
     "Overlay": ("overlay", "MaterialOverlay"),
     "LoadingScope": ("overlay", "LoadingScope"),

--- a/src/nuiitivet/navigation/__init__.py
+++ b/src/nuiitivet/navigation/__init__.py
@@ -3,7 +3,7 @@
 This package provides a minimal Navigator/Route API.
 """
 
-from nuiitivet.navigation.navigator import Navigator
+from nuiitivet.navigation.navigator import Navigator  # noqa: F401
 from nuiitivet.navigation.layer_composer import (
     NavigationLayerComposer,
     NavigationLayerCompositionContext,

--- a/src/nuiitivet/navigation/__init__.py
+++ b/src/nuiitivet/navigation/__init__.py
@@ -21,7 +21,6 @@ from nuiitivet.navigation.transition_spec import (
 )
 
 __all__ = [
-    "Navigator",
     "NavigationLayerComposer",
     "NavigationLayerCompositionContext",
     "NavigationTransitionKind",

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -4,10 +4,10 @@ import nuiitivet as nv
 import nuiitivet.material as md
 from nuiitivet.material.buttons import Button
 from nuiitivet.material.dialogs import BasicDialog
-from nuiitivet.material import Overlay
+from nuiitivet.material import Overlay, Navigator
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
-from nuiitivet.navigation import Navigator, Route
+from nuiitivet.navigation import Route
 from nuiitivet.observable import Observable
 from nuiitivet.material import ButtonStyle
 

--- a/src/samples/navigation/basic.py
+++ b/src/samples/navigation/basic.py
@@ -1,8 +1,7 @@
 import nuiitivet as nv
 
-from nuiitivet.material import App, Text, Button
+from nuiitivet.material import App, Text, Button, Navigator
 from nuiitivet.layout.column import Column
-from nuiitivet.navigation import Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle

--- a/src/samples/navigation/intent.py
+++ b/src/samples/navigation/intent.py
@@ -2,9 +2,8 @@ import nuiitivet as nv
 
 from dataclasses import dataclass
 
-from nuiitivet.material import App, Text, Button
+from nuiitivet.material import App, Text, Button, Navigator
 from nuiitivet.layout.column import Column
-from nuiitivet.navigation import Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle

--- a/src/samples/navigation/route.py
+++ b/src/samples/navigation/route.py
@@ -11,7 +11,8 @@ from nuiitivet.material import (
     Button,
 )
 from nuiitivet.layout.column import Column
-from nuiitivet.navigation import Navigator, Route, Transitions
+from nuiitivet.material import Navigator
+from nuiitivet.navigation import Route, Transitions
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle

--- a/src/samples/navigation/sub.py
+++ b/src/samples/navigation/sub.py
@@ -1,11 +1,10 @@
 import nuiitivet as nv
 
-from nuiitivet.material import App, Text, Button
+from nuiitivet.material import App, Text, Button, Navigator
 from nuiitivet.material.navigator import MaterialNavigator
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
-from nuiitivet.navigation import Navigator
 from nuiitivet.widgeting.widget import ComposableWidget
 from nuiitivet.widgets.box import Box
 from nuiitivet.material import ButtonStyle

--- a/src/samples/overlay_navigator_demo.py
+++ b/src/samples/overlay_navigator_demo.py
@@ -15,7 +15,8 @@ from dataclasses import dataclass
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.modifiers import background
-from nuiitivet.navigation import Navigator, Route
+from nuiitivet.material import Navigator
+from nuiitivet.navigation import Route
 from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material import App
 from nuiitivet.material import Overlay


### PR DESCRIPTION
## Summary

Closes #167

Unifies the three Material app entry points under a single import module by
exposing `MaterialNavigator` as `Navigator` in `nuiitivet.material`, consistent
with `App` (= `MaterialApp`) and `Overlay` (= `MaterialOverlay`).

## Changes

### `nuiitivet/material/__init__.py`
- Added `Navigator` alias (resolves to `MaterialNavigator`) to `TYPE_CHECKING`
  block, `__all__`, and `_EXPORTS`.

### `nuiitivet/navigation/__init__.py`
- Removed `Navigator` from `__all__` to steer IDE auto-complete away from
  direct application imports. The class remains importable at runtime for
  internal use and tests.

### Sample scripts (`src/samples/`)
- Updated all navigation samples to use `from nuiitivet.material import Navigator`
  instead of `from nuiitivet.navigation import Navigator`.

### Guide docs (`docs/guide/`)
- Updated `navigation.md`, `navigation_intent.md`, `navigation_route.md`, and
  `navigation_sub.md` code blocks to follow the new import convention.

## Migration

```python
# Before
from nuiitivet.navigation import Navigator

# After
from nuiitivet.material import Navigator
```

`nuiitivet.navigation.Navigator` (the base class) remains importable and is
unchanged. Only application-level import convention is updated.