### PR TITLE
refactor(theme): rename MaterialTheme to MaterialThemeFactory

### DIFF
--- a/docs/guide/material_app.md
+++ b/docs/guide/material_app.md
@@ -83,12 +83,12 @@ See [Title Bar](window_title_bar.md) for detailed usage.
 
 ## Theme
 
-Pass a `MaterialTheme` to change the seed color or switch to dark mode:
+Pass a `ThemeFactory` to change the seed color or switch to dark mode:
 
 ```python
-from nuiitivet.material import App, MaterialTheme
+from nuiitivet.material import App, ThemeFactory
 
-App(HomeScreen(), theme=MaterialTheme.dark("#00639B")).run()
+App(HomeScreen(), theme=ThemeFactory.dark("#00639B")).run()
 ```
 
 See [Material Theme](material_theme.md) for detailed usage.

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -44,8 +44,7 @@ if TYPE_CHECKING:
     from .overlay import MaterialOverlay
     from .overlay import MaterialOverlay as Overlay
     from .overlay import WhileLoading
-    from .theme.material_theme import MaterialTheme
-    from .theme.material_theme import MaterialTheme as ThemeFactory
+    from .theme.material_theme import MaterialThemeFactory as ThemeFactory
     from .toolbar import DockedToolbar, FloatingToolbar, ToolbarOrientation
     from .tooltip import Tooltip, RichTooltip
     from .styles.sheet_style import SideSheetStyle, BottomSheetStyle
@@ -65,7 +64,6 @@ if TYPE_CHECKING:
 __all__ = [
     "MaterialApp",
     "App",
-    "MaterialTheme",
     "ThemeFactory",
     "SmallBadge",
     "LargeBadge",
@@ -148,8 +146,7 @@ __all__ = [
 _EXPORTS: dict[str, tuple[str, str]] = {
     "MaterialApp": ("app", "MaterialApp"),
     "App": ("app", "MaterialApp"),
-    "MaterialTheme": ("theme", "MaterialTheme"),
-    "ThemeFactory": ("theme", "MaterialTheme"),
+    "ThemeFactory": ("theme", "MaterialThemeFactory"),
     "SmallBadge": ("badge", "SmallBadge"),
     "LargeBadge": ("badge", "LargeBadge"),
     "Divider": ("divider", "Divider"),

--- a/src/nuiitivet/material/app.py
+++ b/src/nuiitivet/material/app.py
@@ -8,7 +8,7 @@ from nuiitivet.material.navigation_visual_state import MaterialNavigationLayerCo
 from nuiitivet.material.navigator import MaterialNavigator
 from nuiitivet.material.overlay import MaterialOverlay
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.navigation.navigator import Navigator
 from nuiitivet.navigation.route import Route
 from nuiitivet.runtime.app import App
@@ -62,13 +62,13 @@ class MaterialApp(App):
             width: Window width specification ("auto", fixed integer, etc.).
             height: Window height specification.
             background: Background color of the window. Defaults to Material Surface color.
-            theme: The MaterialTheme to use. Defaults to Light theme.
+            theme: The MaterialThemeFactory to use. Defaults to Light theme.
             title_bar: Custom window title bar.
             window_position: Initial window position.
             resizable: Whether the window can be resized. Defaults to True.
         """
         if theme is None:
-            theme = MaterialTheme.light("#6750A4")
+            theme = MaterialThemeFactory.light("#6750A4")
 
         def _overlay_factory() -> MaterialOverlay:
             return MaterialOverlay(intents=overlay_routes)

--- a/src/nuiitivet/material/theme/__init__.py
+++ b/src/nuiitivet/material/theme/__init__.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from .color_role import ColorRole
 from .theme_data import MaterialThemeData
-from .material_theme import MaterialTheme
+from .material_theme import MaterialThemeFactory
 
 __all__ = [
     "ColorRole",
     "MaterialThemeData",
-    "MaterialTheme",
+    "MaterialThemeFactory",
 ]

--- a/src/nuiitivet/material/theme/material_theme.py
+++ b/src/nuiitivet/material/theme/material_theme.py
@@ -9,7 +9,7 @@ from nuiitivet.material.theme.theme_data import MaterialThemeData
 from nuiitivet.material.theme.palette import from_seed
 
 
-class MaterialTheme:
+class MaterialThemeFactory:
     """Factory for creating Themes with Material Design configuration."""
 
     @staticmethod
@@ -23,16 +23,16 @@ class MaterialTheme:
 
     @staticmethod
     def light(seed_color: str) -> Theme:
-        return MaterialTheme.from_seed(seed_color, mode="light")
+        return MaterialThemeFactory.from_seed(seed_color, mode="light")
 
     @staticmethod
     def dark(seed_color: str) -> Theme:
-        return MaterialTheme.from_seed(seed_color, mode="dark")
+        return MaterialThemeFactory.from_seed(seed_color, mode="dark")
 
     @staticmethod
     def from_seed_pair(seed_color: str, name: str = "") -> Tuple[Theme, Theme]:
         """Create light and dark themes from a seed color."""
         return (
-            MaterialTheme.from_seed(seed_color, mode="light", name=name),
-            MaterialTheme.from_seed(seed_color, mode="dark", name=name),
+            MaterialThemeFactory.from_seed(seed_color, mode="light", name=name),
+            MaterialThemeFactory.from_seed(seed_color, mode="dark", name=name),
         )

--- a/src/samples/material_theme/no_theme.py
+++ b/src/samples/material_theme/no_theme.py
@@ -1,7 +1,7 @@
 """Material Theme - No Theme (default).
 
 Demonstrates the default appearance when no theme is passed to App.
-MaterialApp defaults to MaterialTheme.light("#6750A4").
+MaterialApp defaults to MaterialThemeFactory.light("#6750A4").
 """
 
 from __future__ import annotations

--- a/src/samples/readme/readme_hero_showcase.py
+++ b/src/samples/readme/readme_hero_showcase.py
@@ -1,7 +1,7 @@
 """Hero showcase sample for README  E"Pulse" music app.
 
 Visual goals (intended for a hero GIF):
-    * MD3 Expressive look powered by ``MaterialTheme.from_seed``
+    * MD3 Expressive look powered by ``MaterialThemeFactory.from_seed``
     * Persistent ``NavigationRail`` on the left that auto-cycles through
       sections to demonstrate ``Deck``-based navigation
     * Eye-catching "Now Playing" hero card with a continuously rotating
@@ -44,7 +44,7 @@ from nuiitivet.material.styles.progress_indicator_style import (
 )
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.modifiers import background, clip, corner_radius, rotate, scale, shadow
 from nuiitivet.observable import runtime as observable_runtime
 from nuiitivet.observable.value import _ObservableValue
@@ -776,14 +776,14 @@ def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Pulse  EREADME hero showcase")
     p.add_argument("--png", type=str, default="", help="Render a single frame to PNG and exit")
     p.add_argument("--no-autoplay", action="store_true", help="Disable section auto-cycling")
-    p.add_argument("--seed", type=str, default="#5B5BFF", help="MaterialTheme seed color")
+    p.add_argument("--seed", type=str, default="#5B5BFF", help="MaterialThemeFactory seed color")
     p.add_argument("--dark", action="store_true", help="Use dark theme")
     return p.parse_args()
 
 
 def main() -> None:
     args = _parse_args()
-    theme = MaterialTheme.from_seed(args.seed, mode="dark" if args.dark else "light")
+    theme = MaterialThemeFactory.from_seed(args.seed, mode="dark" if args.dark else "light")
 
     app = md.App(
         content=PulseApp(autoplay=not args.no_autoplay),

--- a/tests/test_basic_dialog.py
+++ b/tests/test_basic_dialog.py
@@ -2,7 +2,7 @@
 
 from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material.styles.dialog_style import DialogStyle
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material import ButtonStyle
 
 
@@ -154,11 +154,11 @@ def test_color_role_includes_md3_surface_containers():
 
 
 def test_material_theme_resolves_surface_container_high():
-    """A MaterialTheme resolves SURFACE_CONTAINER_HIGH to a concrete color."""
+    """A MaterialThemeFactory resolves SURFACE_CONTAINER_HIGH to a concrete color."""
     from nuiitivet.material.theme.color_role import ColorRole
     from nuiitivet.theme.resolver import resolve_color_to_rgba
 
-    theme = MaterialTheme.light("#6750A4")
+    theme = MaterialThemeFactory.light("#6750A4")
     rgba = resolve_color_to_rgba(ColorRole.SURFACE_CONTAINER_HIGH, theme=theme)
     assert isinstance(rgba, tuple)
     assert len(rgba) == 4

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -82,9 +82,9 @@ def test_button_theme_change_invalidates_cache():
     try:
         callback = getattr(b, "_on_theme_change", None)
         assert callback is not None
-        from nuiitivet.material.theme.material_theme import MaterialTheme
+        from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 
-        callback(MaterialTheme.light("#6750A4"))
+        callback(MaterialThemeFactory.light("#6750A4"))
     finally:
         b.on_unmount()
     assert "cache" in calls

--- a/tests/test_checkbox_style.py
+++ b/tests/test_checkbox_style.py
@@ -2,7 +2,7 @@
 
 from nuiitivet.material import Checkbox
 from nuiitivet.material.styles import CheckboxStyle
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from dataclasses import replace
 
@@ -50,7 +50,7 @@ def test_checkbox_style_copy_with():
 def test_theme_with_custom_checkbox_style():
     """Theme can provide custom checkbox style."""
     custom_style = CheckboxStyle(default_touch_target=56, hover_alpha=0.1)
-    light, _ = MaterialTheme.from_seed_pair("#FF0000")
+    light, _ = MaterialThemeFactory.from_seed_pair("#FF0000")
 
     mat_data = light.extension(MaterialThemeData)
     assert mat_data is not None

--- a/tests/test_color_utils.py
+++ b/tests/test_color_utils.py
@@ -28,12 +28,12 @@ def test_theme_sample_contrasts():
     # smoke test: ensure the ratio function returns sensible floats and
     # the sample primary/on_primary in the light theme passes AA for large
     # text (3.0) and ideally AA normal (4.5) depending on palette.
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.theme.theme_data import MaterialThemeData
     from nuiitivet.material.theme.color_role import ColorRole
 
     DEFAULT_SEED = "#6750A4"
-    default_theme, _ = MaterialTheme.from_seed_pair(DEFAULT_SEED, name="test-color-utils")
+    default_theme, _ = MaterialThemeFactory.from_seed_pair(DEFAULT_SEED, name="test-color-utils")
 
     mat = default_theme.extension(MaterialThemeData)
     assert mat is not None

--- a/tests/test_icon_button_overlay.py
+++ b/tests/test_icon_button_overlay.py
@@ -3,11 +3,11 @@ from nuiitivet.rendering.skia import skcolor
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from nuiitivet.theme.resolver import resolve_color_to_rgba
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 
 
 def test_icon_resolve_color_uses_theme():
-    light = MaterialTheme.light("#6750A4")
+    light = MaterialThemeFactory.light("#6750A4")
     icon = Icon("home")
     # resolve ON_SURFACE color using the theme directly
     rgba = resolve_color_to_rgba(icon.style.color, theme=light)

--- a/tests/test_icon_style.py
+++ b/tests/test_icon_style.py
@@ -2,7 +2,7 @@
 
 from nuiitivet.material.icon import Icon
 from nuiitivet.material.styles import IconStyle
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
@@ -65,7 +65,7 @@ def test_theme_with_custom_icon_style():
         default_size=28,
         color=ColorRole.TERTIARY,
     )
-    light, _ = MaterialTheme.from_seed_pair("#FF0000")
+    light, _ = MaterialThemeFactory.from_seed_pair("#FF0000")
 
     mat = light.extension(MaterialThemeData)
     assert mat is not None

--- a/tests/test_loading_indicator_style.py
+++ b/tests/test_loading_indicator_style.py
@@ -3,7 +3,7 @@
 from nuiitivet.material.loading_indicator import LoadingIndicator
 from nuiitivet.material.styles import LoadingIndicatorStyle
 from nuiitivet.material.shapes import MaterialShapeId
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from nuiitivet.animation.motion import BezierMotion
@@ -48,7 +48,7 @@ def test_loading_indicator_style_copy_with():
 
 def test_theme_with_custom_loading_indicator_style():
     """Theme can provide custom loading indicator style."""
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     custom_style = LoadingIndicatorStyle(
         foreground=ColorRole.ERROR,
         motion=BezierMotion(0.34, 0.80, 0.34, 1.00, duration=5.0),
@@ -80,7 +80,7 @@ def test_loading_indicator_style_variants():
 
 def test_loading_indicator_style_from_theme():
     """LoadingIndicatorStyle.from_theme returns appropriate variant."""
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
 
     default = LoadingIndicatorStyle.from_theme(light, "default")
     contained = LoadingIndicatorStyle.from_theme(light, "contained")

--- a/tests/test_material_default_style_resolution.py
+++ b/tests/test_material_default_style_resolution.py
@@ -12,10 +12,10 @@ from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-light, _ = MaterialTheme.from_seed_pair("#00FF00")
+light, _ = MaterialThemeFactory.from_seed_pair("#00FF00")
 
 
 def test_material_text_defaults_to_theme_text_style() -> None:

--- a/tests/test_material_namespace_aliases.py
+++ b/tests/test_material_namespace_aliases.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import nuiitivet
 from nuiitivet import material
-from nuiitivet.material import App, MaterialApp, MaterialOverlay, MaterialTheme, Overlay, ThemeFactory
+from nuiitivet.material import App, MaterialApp, MaterialOverlay, Overlay, ThemeFactory
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 
 
 def test_app_alias_is_material_app() -> None:
@@ -18,8 +19,8 @@ def test_overlay_alias_is_material_overlay() -> None:
     assert Overlay is MaterialOverlay
 
 
-def test_theme_factory_alias_is_material_theme() -> None:
-    assert ThemeFactory is MaterialTheme
+def test_theme_factory_alias_is_material_theme_factory() -> None:
+    assert ThemeFactory is MaterialThemeFactory
 
 
 def test_aliases_in_all() -> None:
@@ -31,7 +32,6 @@ def test_aliases_in_all() -> None:
 def test_original_names_still_exported() -> None:
     assert "MaterialApp" in material.__all__
     assert "MaterialOverlay" in material.__all__
-    assert "MaterialTheme" in material.__all__
 
 
 def test_top_level_does_not_expose_app() -> None:

--- a/tests/test_palette_contrast.py
+++ b/tests/test_palette_contrast.py
@@ -1,5 +1,5 @@
 from nuiitivet.theme import Theme
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from nuiitivet.colors.utils import passes_wcag
@@ -24,6 +24,6 @@ def _check_theme_contrast(theme: Theme) -> None:
 def test_several_seeds_meet_contrast():
     seeds = ["#6750A4", "#FF0000", "#00FF00", "#0000FF", "#808080"]
     for seed in seeds:
-        light, dark = MaterialTheme.from_seed_pair(seed)
+        light, dark = MaterialThemeFactory.from_seed_pair(seed)
         _check_theme_contrast(light)
         _check_theme_contrast(dark)

--- a/tests/test_palette_integration.py
+++ b/tests/test_palette_integration.py
@@ -1,9 +1,9 @@
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
 
 def test_theme_from_seed_generates_both_modes():
-    light, dark = MaterialTheme.from_seed_pair("#6750A4")
+    light, dark = MaterialThemeFactory.from_seed_pair("#6750A4")
     # basic checks
     assert light.mode == "light"
     assert dark.mode == "dark"

--- a/tests/test_progress_indicator_style.py
+++ b/tests/test_progress_indicator_style.py
@@ -8,7 +8,7 @@ from nuiitivet.material.styles import (
     ProgressIndicatorStyle,
 )
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
 
@@ -57,7 +57,7 @@ def test_progress_style_copy_with():
 
 
 def test_theme_with_custom_progress_styles():
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
 
@@ -81,7 +81,7 @@ def test_theme_with_custom_progress_styles():
 
 
 def test_progress_style_from_theme_variants():
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
 
     linear_default = LinearProgressIndicatorStyle.from_theme(light)
     linear_flat = LinearProgressIndicatorStyle.from_theme(light, "flat")

--- a/tests/test_progress_indicators.py
+++ b/tests/test_progress_indicators.py
@@ -12,7 +12,7 @@ from nuiitivet.material import (
     LinearProgressIndicator,
 )
 from nuiitivet.material.styles import CircularProgressIndicatorStyle, LinearProgressIndicatorStyle
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
 
@@ -74,7 +74,7 @@ def test_indeterminate_api_has_no_value_parameter():
 
 
 def test_progress_widgets_resolve_theme_styles():
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
 

--- a/tests/test_skia_util_colorrole.py
+++ b/tests/test_skia_util_colorrole.py
@@ -1,5 +1,5 @@
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from nuiitivet.theme.resolver import resolve_color_to_rgba
 from nuiitivet.rendering.skia import rgba_to_skia_color, skcolor
@@ -7,7 +7,7 @@ from nuiitivet.rendering.skia import rgba_to_skia_color, skcolor
 
 def test_resolve_color_with_colorrole():
     # current theme should provide a hex for PRIMARY
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
     hexv = mat.roles.get(ColorRole.PRIMARY)
@@ -16,7 +16,7 @@ def test_resolve_color_with_colorrole():
 
 
 def test_resolve_color_with_colorrole_and_alpha():
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
     hexv = mat.roles.get(ColorRole.PRIMARY)
@@ -27,7 +27,7 @@ def test_resolve_color_with_colorrole_and_alpha():
 def test_resolve_default_colorrole_when_val_none():
     # default may be a ColorRole — resolve_color should handle that
     default_role = ColorRole.BACKGROUND
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
     hexv = mat.roles.get(default_role)

--- a/tests/test_text_field_style.py
+++ b/tests/test_text_field_style.py
@@ -3,7 +3,7 @@
 from dataclasses import replace
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 
@@ -37,7 +37,7 @@ def test_theme_with_custom_text_field_style():
     """TextFieldStyle.from_theme() picks up the theme's custom style."""
     custom_filled = TextFieldStyle.filled().copy_with(border_radius=16.0)
 
-    light, _ = MaterialTheme.from_seed_pair("#FF0000")
+    light, _ = MaterialThemeFactory.from_seed_pair("#FF0000")
 
     mat = light.extension(MaterialThemeData)
     assert mat is not None

--- a/tests/test_text_style.py
+++ b/tests/test_text_style.py
@@ -4,7 +4,7 @@ import pytest
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.text import Text
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from dataclasses import replace
 
@@ -127,7 +127,7 @@ def test_text_widget_style_overflow():
 
 def test_theme_default_text_style():
     """Test Theme provides default TextStyle."""
-    light, dark = MaterialTheme.from_seed_pair("#6750A4")
+    light, dark = MaterialThemeFactory.from_seed_pair("#6750A4")
 
     light_mat = light.extension(MaterialThemeData)
     dark_mat = dark.extension(MaterialThemeData)
@@ -145,7 +145,7 @@ def test_theme_default_text_style():
 
 def test_theme_with_custom_text_style():
     """Test Theme.with_styles() with custom TextStyle."""
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
 
     custom_text_style = TextStyle(
         font_size=16,
@@ -173,7 +173,7 @@ def test_theme_with_custom_text_style():
 def test_text_widget_uses_theme_text_style():
     """Test Text widget picks up custom text_style from theme."""
     # Create custom theme with large font
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     custom_style = TextStyle(font_size=20, color=ColorRole.SECONDARY)
 
     mat_data = light.extension(MaterialThemeData)

--- a/tests/test_theme_manager_seed.py
+++ b/tests/test_theme_manager_seed.py
@@ -1,13 +1,13 @@
 from nuiitivet.theme.manager import ThemeManager
-from nuiitivet.material.theme.material_theme import MaterialTheme
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 
 
 def test_manager_set_theme_manual_toggle():
     """Test that theme can be manually toggled by setting new Theme instances."""
     mgr = ThemeManager()
     seed = "#6750A4"
-    light_theme = MaterialTheme.light(seed)
-    dark_theme = MaterialTheme.dark(seed)
+    light_theme = MaterialThemeFactory.light(seed)
+    dark_theme = MaterialThemeFactory.dark(seed)
 
     mgr.set_theme(dark_theme)
     assert mgr.current.mode == "dark"
@@ -28,7 +28,7 @@ def test_manager_subscription():
 
     mgr.subscribe(on_theme_change)
 
-    new_theme = MaterialTheme.light("#000000")
+    new_theme = MaterialThemeFactory.light("#000000")
     mgr.set_theme(new_theme)
 
     assert len(notifications) == 1

--- a/tests/test_theme_styles.py
+++ b/tests/test_theme_styles.py
@@ -5,10 +5,10 @@ from dataclasses import replace
 
 def test_theme_has_style_properties():
     """Theme has button_style, checkbox_style, icon_style properties via material extension."""
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    light, dark = MaterialTheme.from_seed_pair("#6750A4", name="test")
+    light, dark = MaterialThemeFactory.from_seed_pair("#6750A4", name="test")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
     assert hasattr(mat, "filled_button_style")
@@ -29,8 +29,8 @@ def test_theme_has_style_properties():
 
 
 def test_theme_default_styles():
-    """MaterialTheme.from_seed() creates themes with default M3 styles."""
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    """MaterialThemeFactory.from_seed() creates themes with default M3 styles."""
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.styles.button_style import ButtonStyle
     from nuiitivet.material.styles.checkbox_style import CheckboxStyle
     from nuiitivet.material.styles.icon_style import IconStyle
@@ -38,7 +38,7 @@ def test_theme_default_styles():
     from nuiitivet.material.styles.switch_style import SwitchStyle
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    light, dark = MaterialTheme.from_seed_pair("#6750A4")
+    light, dark = MaterialThemeFactory.from_seed_pair("#6750A4")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
     button = mat.filled_button_style
@@ -63,12 +63,12 @@ def test_theme_default_styles():
 
 def test_theme_with_styles():
     """Theme styles can be customized via copy_with on MaterialThemeData."""
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.styles.button_style import ButtonStyle
     from nuiitivet.material.styles.checkbox_style import CheckboxStyle
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     custom_button = ButtonStyle.outlined()
     custom_checkbox = CheckboxStyle().copy_with(default_touch_target=56)
 
@@ -111,11 +111,11 @@ def test_theme_style_lazy_loading():
 
 
 def test_theme_manager_provides_styles():
-    """A theme built from MaterialTheme provides styles via material extension."""
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    """A theme built from MaterialThemeFactory provides styles via material extension."""
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     mat = light.extension(MaterialThemeData)
     assert mat is not None
     assert hasattr(mat, "filled_button_style")
@@ -137,11 +137,11 @@ def test_theme_manager_provides_styles():
 
 def test_theme_style_button_variants():
     """Theme can hold different button style variants."""
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.styles.button_style import ButtonStyle
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     filled = ButtonStyle.filled()
     outlined = ButtonStyle.outlined()
     text = ButtonStyle.text()
@@ -164,10 +164,10 @@ def test_theme_style_button_variants():
 
 def test_theme_immutability_preserved():
     """Theme remains immutable after adding style fields."""
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    light, _ = MaterialTheme.from_seed_pair("#6750A4")
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
     try:
         light.mode = "dark"
         assert False, "Should not be able to modify frozen theme"
@@ -184,10 +184,10 @@ def test_theme_immutability_preserved():
 
 def test_theme_styles_independent_of_mode():
     """Light and dark themes share same style instances by default."""
-    from nuiitivet.material.theme.material_theme import MaterialTheme
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
     from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-    light, dark = MaterialTheme.from_seed_pair("#6750A4")
+    light, dark = MaterialThemeFactory.from_seed_pair("#6750A4")
     light_mat = light.extension(MaterialThemeData)
     dark_mat = dark.extension(MaterialThemeData)
     assert light_mat is not None


### PR DESCRIPTION
## Summary

Renames `MaterialTheme` to `MaterialThemeFactory` to accurately reflect its role as a pure static factory class. The public-facing alias `ThemeFactory` in `nuiitivet.material` remains the recommended import.

## Changes

- Rename class `MaterialTheme` → `MaterialThemeFactory` in `material_theme.py`
- Export `MaterialThemeFactory` as `ThemeFactory` from `nuiitivet.material`; `MaterialThemeFactory` itself is **not** re-exported (alias-only pattern, consistent with `App` / `Overlay`)
- Remove `MaterialTheme` from all exports and internal references
- Update all import sites across `src/`, `tests/`, `docs/`, and `scripts/`

## Breaking Change

`MaterialTheme` is no longer available. Use `ThemeFactory` (preferred) or `nuiitivet.material.theme.MaterialThemeFactory` directly.

Closes #168