### PR TITLE
refactor(material): remove MaterialApp and MaterialOverlay from public API

### DIFF
--- a/docs/guide/material_app.md
+++ b/docs/guide/material_app.md
@@ -113,4 +113,4 @@ See [Material Overlay](material_overlay.md) for detailed usage.
 
 ---
 
-[API Reference](../api/material.md#nuiitivet.material.MaterialApp)
+[API Reference](../api/material.md#nuiitivet.material.App)

--- a/docs/guide/material_navigator.md
+++ b/docs/guide/material_navigator.md
@@ -5,12 +5,12 @@
 The only difference from the base `Navigator` is the default transition: when you push a plain `Widget`, `MaterialNavigator` wraps it in a `Route` pre-configured with the MD3 page transition. Pushing an explicit `Route` bypasses this default and uses whatever `transition_spec` you provide.
 
 !!! note "Import convention"
-    `MaterialApp` and `MaterialNavigator` are exported from `nuiitivet.material` under shorter aliases.
-    Import and use them by their aliases throughout your code.
+    `App` and `Navigator` are the public names exported from `nuiitivet.material` for these classes.
+    Import and use them by these names throughout your code.
 
     ```python
-    from nuiitivet.material import App       # MaterialApp aliased as App
-    from nuiitivet.material import Navigator # MaterialNavigator aliased as Navigator
+    from nuiitivet.material import App       # MaterialApp
+    from nuiitivet.material import Navigator # MaterialNavigator
     ```
 
     The rest of this guide follows this convention.

--- a/docs/guide/material_overlay.md
+++ b/docs/guide/material_overlay.md
@@ -3,12 +3,11 @@
 `MaterialOverlay` is a Material Design 3-flavored subclass of `Overlay` — the framework's system for displaying content above the main widget tree. It is automatically configured by `App`.
 
 !!! note "Import convention"
-    `MaterialApp` and `MaterialOverlay` are exported from `nuiitivet.material` under shorter aliases.
-    Import and use them by their aliases throughout your code.
+    Import `App` and `Overlay` from `nuiitivet.material`.
 
     ```python
-    from nuiitivet.material import App      # MaterialApp aliased as App
-    from nuiitivet.material import Overlay  # MaterialOverlay aliased as Overlay
+    from nuiitivet.material import App
+    from nuiitivet.material import Overlay
     ```
 
     The rest of this guide follows this convention.

--- a/docs/guide/material_theme.md
+++ b/docs/guide/material_theme.md
@@ -3,12 +3,12 @@
 `MaterialThemeFactory` is a factory that creates `Theme` objects pre-configured with Material Design 3 color roles derived from a seed color.
 
 !!! note "Import convention"
-     `MaterialApp` and `MaterialThemeFactory` is exported from `nuiitivet.material` under the shorter alias `ThemeFactory`.
-    Import and use them by their aliases throughout your code.
+    `App` and `ThemeFactory` are the public names exported from `nuiitivet.material` for these classes.
+    Import and use them by these names throughout your code.
 
     ```python
-    from nuiitivet.material import App      # MaterialApp aliased as App
-    from nuiitivet.material import ThemeFactory  # MaterialThemeFactory aliased as ThemeFactory
+    from nuiitivet.material import App          # MaterialApp
+    from nuiitivet.material import ThemeFactory  # MaterialThemeFactory
     ```
 
     The rest of this guide follows this convention.

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .badge import LargeBadge, SmallBadge
-    from .app import MaterialApp
     from .app import MaterialApp as App
     from .divider import Divider
     from .buttons import (
@@ -41,7 +40,6 @@ if TYPE_CHECKING:
     from .styles.text_field_style import TextFieldStyle
     from .text import Text
     from .navigator import MaterialNavigator as Navigator
-    from .overlay import MaterialOverlay
     from .overlay import MaterialOverlay as Overlay
     from .overlay import WhileLoading
     from .theme.material_theme import MaterialThemeFactory as ThemeFactory
@@ -62,7 +60,6 @@ if TYPE_CHECKING:
     from .transition_spec import MaterialTransitionSpec
 
 __all__ = [
-    "MaterialApp",
     "App",
     "ThemeFactory",
     "SmallBadge",
@@ -103,7 +100,6 @@ __all__ = [
     "NavigationRail",
     "RailItem",
     "Navigator",
-    "MaterialOverlay",
     "Overlay",
     "WhileLoading",
     "BasicDialog",
@@ -144,7 +140,6 @@ __all__ = [
 
 
 _EXPORTS: dict[str, tuple[str, str]] = {
-    "MaterialApp": ("app", "MaterialApp"),
     "App": ("app", "MaterialApp"),
     "ThemeFactory": ("theme", "MaterialThemeFactory"),
     "SmallBadge": ("badge", "SmallBadge"),
@@ -185,7 +180,6 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "NavigationRail": ("navigation_rail", "NavigationRail"),
     "RailItem": ("navigation_rail", "RailItem"),
     "Navigator": ("navigator", "MaterialNavigator"),
-    "MaterialOverlay": ("overlay", "MaterialOverlay"),
     "Overlay": ("overlay", "MaterialOverlay"),
     "LoadingScope": ("overlay", "LoadingScope"),
     "BasicDialog": ("dialogs", "BasicDialog"),

--- a/tests/test_material_namespace_aliases.py
+++ b/tests/test_material_namespace_aliases.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import nuiitivet
 from nuiitivet import material
-from nuiitivet.material import App, MaterialApp, MaterialOverlay, Overlay, ThemeFactory
+from nuiitivet.material import App, Overlay, ThemeFactory
+from nuiitivet.material.app import MaterialApp
+from nuiitivet.material.overlay import MaterialOverlay
 from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 
 
@@ -29,9 +31,9 @@ def test_aliases_in_all() -> None:
     assert "ThemeFactory" in material.__all__
 
 
-def test_original_names_still_exported() -> None:
-    assert "MaterialApp" in material.__all__
-    assert "MaterialOverlay" in material.__all__
+def test_original_names_not_exported() -> None:
+    assert "MaterialApp" not in material.__all__
+    assert "MaterialOverlay" not in material.__all__
 
 
 def test_top_level_does_not_expose_app() -> None:


### PR DESCRIPTION
## Summary

Removes `MaterialApp` and `MaterialOverlay` from the `nuiitivet.material` public API.
Application code must now use the short aliases `App` and `Overlay` instead.

Closes #171

## Changes

### `src/nuiitivet/material/__init__.py`
- Remove `MaterialApp` from `TYPE_CHECKING`, `__all__`, and `_EXPORTS`
- Remove `MaterialOverlay` from `TYPE_CHECKING`, `__all__`, and `_EXPORTS`
- `App` and `Overlay` aliases are untouched

### `tests/test_material_namespace_aliases.py`
- Import `MaterialApp` / `MaterialOverlay` from internal modules (not from public API) for alias identity tests
- Rename `test_original_names_still_exported` → `test_original_names_not_exported` (asserts removal)

### Docs
- `docs/guide/material_overlay.md`: update import convention note
- `docs/guide/material_app.md`: update API reference anchor to `#nuiitivet.material.App`
- `docs/guide/material_navigator.md`: update import convention note
- `docs/guide/material_theme.md`: update import convention note

## Breaking Change

`from nuiitivet.material import MaterialApp` and `from nuiitivet.material import MaterialOverlay` will raise `AttributeError`.
Use `App` and `Overlay` instead.