### PR TITLE
feat(chrome): redesign window decoration API

### DIFF
--- a/scripts/docs/render_layout_images.py
+++ b/scripts/docs/render_layout_images.py
@@ -132,10 +132,14 @@ def load_module_from_path(path: Path):
 
 
 def extract_title(source_path: Path) -> str:
-    """Extract title from DefaultTitleBar(title="...") in source code."""
+    """Extract window title from the source code.
+
+    Looks for ``App``/``MaterialApp`` ``title=`` keyword argument first,
+    then falls back to a human-readable form of the filename.
+    """
     try:
         content = source_path.read_text(encoding="utf-8")
-        match = re.search(r'DefaultTitleBar\(.*title=["\']([^"\']+)["\']', content)
+        match = re.search(r'\btitle=["\']([^"\']+)["\']', content)
         if match:
             return match.group(1)
     except Exception:

--- a/scripts/investigation/inspect_grid_overlap.py
+++ b/scripts/investigation/inspect_grid_overlap.py
@@ -38,9 +38,8 @@ def inspect_for_n(n):
     items = [f"GItem {i+1}" for i in range(n)]
     model.grid_items.set(items)
     widget = MyWidget(model)
-    from nuiitivet.runtime.title_bar import DefaultTitleBar
 
-    app = App(root=widget, width=480, height=600, title_bar=DefaultTitleBar(top_padding=16))
+    app = App(widget, width=480, height=600)
 
     # Normalize root as App.run would
     built = app.root.evaluate_build()

--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -25,7 +25,7 @@ from nuiitivet.observable import Observable, batch
 
 # Configuration
 from nuiitivet.rendering.skia.font import set_default_font_family
-from nuiitivet.runtime.title_bar import DefaultTitleBar, CustomTitleBar
+from nuiitivet.runtime.chrome import OSChrome, CustomChrome, Border
 
 __all__: list[str] = [
     "Column",
@@ -38,8 +38,9 @@ __all__: list[str] = [
     "GridItem",
     "Spacer",
     "CrossAligned",
-    "DefaultTitleBar",
-    "CustomTitleBar",
+    "OSChrome",
+    "CustomChrome",
+    "Border",
     "Deck",
     "Sizing",
     "Widget",

--- a/src/nuiitivet/backends/pyglet/gpu_frame.py
+++ b/src/nuiitivet/backends/pyglet/gpu_frame.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from nuiitivet.common.logging_once import debug_once, exception_once
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -75,23 +74,81 @@ def draw_gpu_frame(app: Any, gr_context: Any, GL: Any, skia: Any) -> bool:
         except Exception:
             exception_once(logger, "gpu_frame_clear_color_convert_exc", "Failed to convert clear color")
             bg_color = getattr(skia, "ColorWHITE", 0)
-    canvas.clear(bg_color)
+    # Detect CustomChrome properties needed for rendering
+    chrome = getattr(app, "chrome", None)
+    chrome_corner_radius = 0.0
+    chrome_border = None
+    if chrome is not None and type(chrome).__name__ == "CustomChrome":
+        chrome_corner_radius = float(getattr(chrome, "corner_radius", 0.0))
+        chrome_border = getattr(chrome, "border", None)
+
+    if chrome_corner_radius > 0:
+        # Clear to transparent so pixels outside the rounded rect are invisible
+        canvas.clear(skia.Color(0, 0, 0, 0))
+    else:
+        canvas.clear(bg_color)
 
     if app.root:
         content_height = max(0, app.height)
+        w = app.width
 
         layout_fn = getattr(app.root, "layout", None)
         clear_needs_layout_fn = getattr(app.root, "clear_needs_layout", None)
         if callable(layout_fn):
             needs_layout = getattr(app.root, "needs_layout", True)
             last_size = getattr(app, "_last_layout_size", None)
-            current_size = (app.width, content_height)
+            current_size = (w, content_height)
             if needs_layout or last_size != current_size:
-                layout_fn(app.width, content_height)
+                layout_fn(w, content_height)
                 app._last_layout_size = current_size
                 if callable(clear_needs_layout_fn):
                     clear_needs_layout_fn()
-        app.root.paint(canvas, 0, 0, app.width, content_height)
+
+        if chrome_corner_radius > 0:
+            rrect = skia.RRect.MakeRectXY(
+                skia.Rect.MakeWH(float(w), float(content_height)),
+                chrome_corner_radius,
+                chrome_corner_radius,
+            )
+            canvas.save()
+            canvas.clipRRect(rrect, doAntiAlias=True)
+            bg_fill = skia.Paint(AntiAlias=True)
+            bg_fill.setColor(bg_color)
+            canvas.drawRRect(rrect, bg_fill)
+
+        app.root.paint(canvas, 0, 0, w, content_height)
+
+        if chrome_corner_radius > 0:
+            canvas.restore()
+
+        if chrome_border is not None:
+            try:
+                from nuiitivet.theme.resolver import resolve_color_to_rgba
+                from nuiitivet.rendering.skia.color import rgba_to_skia_color
+
+                theme = getattr(getattr(app, "_theme_manager", None), "current", None)
+                border_rgba = resolve_color_to_rgba(chrome_border.color, theme=theme)
+                raw = tuple(int(x) for x in border_rgba)
+                border_color = rgba_to_skia_color((raw[0], raw[1], raw[2], raw[3]))
+                border_width = float(chrome_border.width)
+                border_paint = skia.Paint(AntiAlias=True)
+                border_paint.setStyle(skia.Paint.kStroke_Style)
+                border_paint.setStrokeWidth(border_width)
+                border_paint.setColor(border_color)
+                half = border_width / 2.0
+                inset = skia.Rect.MakeXYWH(
+                    half,
+                    half,
+                    float(w) - border_width,
+                    float(content_height) - border_width,
+                )
+                r = max(0.0, chrome_corner_radius - half)
+                if r > 0:
+                    canvas.drawRRect(skia.RRect.MakeRectXY(inset, r, r), border_paint)
+                else:
+                    canvas.drawRect(inset, border_paint)
+            except Exception:
+                exception_once(logger, "gpu_frame_chrome_border_exc", "Failed to draw CustomChrome border")
 
     try:
         gr_context.flush()

--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -112,14 +112,39 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
     caption = None
     style = None
     try:
-        title_bar = getattr(app, "title_bar", None)
-        if title_bar:
-            if hasattr(title_bar, "title") and title_bar.title:
-                caption = str(title_bar.title)
-            if type(title_bar).__name__ == "CustomTitleBar":
-                style = pyglet.window.Window.WINDOW_STYLE_BORDERLESS
+        title_val = getattr(app, "_title_value", None)
+        if isinstance(title_val, str):
+            caption = title_val
+        elif title_val is not None and hasattr(title_val, "value"):
+            v = title_val.value
+            if v is not None:
+                caption = str(v)
     except Exception:
         exception_once(logger, "pyglet_get_title_exc", "Failed to get window title")
+
+    try:
+        chrome = getattr(app, "chrome", None)
+        if chrome is None:
+            # chrome=None → bare borderless
+            style = pyglet.window.Window.WINDOW_STYLE_BORDERLESS
+        else:
+            chrome_type = type(chrome).__name__
+            if chrome_type == "OSChrome":
+                variant = getattr(chrome, "variant", "default")
+                _variant_map = {
+                    "dialog": pyglet.window.Window.WINDOW_STYLE_DIALOG,
+                    "tool": pyglet.window.Window.WINDOW_STYLE_TOOL,
+                    "borderless": pyglet.window.Window.WINDOW_STYLE_BORDERLESS,
+                    "transparent": pyglet.window.Window.WINDOW_STYLE_TRANSPARENT,
+                }
+                style = _variant_map.get(variant)  # None → OS default
+            elif chrome_type == "CustomChrome":
+                # Always borderless for custom chrome — WINDOW_STYLE_TRANSPARENT
+                # restores OS decorations on macOS and is not needed here.
+                # Corner rounding is applied in the render layer (gpu_frame.py).
+                style = pyglet.window.Window.WINDOW_STYLE_BORDERLESS
+    except Exception:
+        exception_once(logger, "pyglet_get_chrome_exc", "Failed to determine window style from chrome")
 
     window = pyglet.window.Window(
         width=getattr(app, "width", 0),
@@ -147,6 +172,15 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
         exception_once(logger, "pyglet_initial_resize_exc", "Failed to adjust initial window size for HiDPI")
 
     setattr(app, "_window", window)
+
+    # Apply Observable title now that the window exists
+    try:
+        title_val = getattr(app, "_title_value", None)
+        if title_val is not None and hasattr(title_val, "value"):
+            v = title_val.value
+            window.set_caption(str(v) if v is not None else "")
+    except Exception:
+        exception_once(logger, "pyglet_apply_obs_title_exc", "Failed to apply Observable title to window")
 
     # Initial window positioning.
     try:

--- a/src/nuiitivet/material/app.py
+++ b/src/nuiitivet/material/app.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
 
 from nuiitivet.material.navigation_visual_state import MaterialNavigationLayerComposer
 from nuiitivet.material.navigator import MaterialNavigator
@@ -11,11 +11,14 @@ from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.navigation.navigator import Navigator
 from nuiitivet.navigation.route import Route
-from nuiitivet.runtime.app import App
-from nuiitivet.runtime.title_bar import TitleBar
+from nuiitivet.runtime.app import App, _UNSET
 from nuiitivet.runtime.window import WindowPosition, WindowSizingLike
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.widgeting.widget import Widget
+
+if TYPE_CHECKING:
+    from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+    from nuiitivet.runtime.chrome import CustomChrome, OSChrome
 
 
 class MaterialApp(App):
@@ -47,7 +50,8 @@ class MaterialApp(App):
         height: WindowSizingLike = "auto",
         background: ColorSpec = ColorRole.SURFACE,
         theme: Optional[Any] = None,
-        title_bar: Optional[TitleBar] = None,
+        title: str | None | ReadOnlyObservableProtocol[str | None] = None,
+        chrome: OSChrome | CustomChrome | None = _UNSET,  # type: ignore[assignment]
         window_position: WindowPosition | None = None,
         resizable: bool = True,
     ) -> None:
@@ -63,7 +67,9 @@ class MaterialApp(App):
             height: Window height specification.
             background: Background color of the window. Defaults to Material Surface color.
             theme: The MaterialThemeFactory to use. Defaults to Light theme.
-            title_bar: Custom window title bar.
+            title: OS window title.
+            chrome: Window decoration (``OSChrome``, ``CustomChrome``, or
+                ``None`` for bare borderless). Omitting defaults to ``OSChrome()``.
             window_position: Initial window position.
             resizable: Whether the window can be resized. Defaults to True.
         """
@@ -77,7 +83,8 @@ class MaterialApp(App):
             content=content,
             width=width,
             height=height,
-            title_bar=title_bar,
+            title=title,
+            chrome=chrome,
             background=background,
             theme=theme,
             overlay_factory=_overlay_factory,

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -28,7 +28,9 @@ from .app_events import (
     dispatch_mouse_release as _dispatch_mouse_release_fn,
     dispatch_mouse_scroll as _dispatch_mouse_scroll_fn,
 )
-from .title_bar import TitleBar, DefaultTitleBar, CustomTitleBar, WindowDragArea
+from .chrome import OSChrome, CustomChrome
+from .title_bar import WindowDragArea
+from nuiitivet.observable.protocols import Disposable, ReadOnlyObservableProtocol
 from .window import WindowSizingLike, WindowPosition, parse_window_sizing
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -39,6 +41,8 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+_UNSET = object()
 
 
 # NOTE: compatibility wrapper removed. Use `resolve_color_to_rgba` from
@@ -159,7 +163,8 @@ class App:
         root: Widget,
         width: WindowSizingLike,
         height: WindowSizingLike,
-        title_bar: Optional[TitleBar],
+        title: "str | None | ReadOnlyObservableProtocol[str | None]",
+        chrome: "OSChrome | CustomChrome | None",
         background: ColorSpec,
         theme: Optional[Any] = None,
         window_position: WindowPosition | None = None,
@@ -203,9 +208,9 @@ class App:
                 except Exception:
                     pass
 
-        # Include custom title bar preferred height for auto sizing.
-        if isinstance(title_bar, CustomTitleBar) and needs_auto_size:
-            title_target: Widget = title_bar.content
+        # Include custom chrome header preferred height for auto sizing.
+        if isinstance(chrome, CustomChrome) and needs_auto_size:
+            title_target: Widget = chrome.header
             built_title_target: Widget | None = None
             if isinstance(title_target, ComposableWidget):
                 try:
@@ -214,7 +219,7 @@ class App:
                         title_target = built
                         built_title_target = built
                 except Exception:
-                    title_target = title_bar.content
+                    title_target = chrome.header
             try:
                 tw, th = title_target.preferred_size()
             except Exception:
@@ -233,12 +238,9 @@ class App:
         self.window_position = window_position
         self.resizable = resizable
 
-        if title_bar is None:
-            title_bar = DefaultTitleBar()
+        self.chrome: OSChrome | CustomChrome | None = chrome
 
-        self.title_bar = title_bar
-
-        if isinstance(self.title_bar, CustomTitleBar):
+        if isinstance(self.chrome, CustomChrome):
             # We need a reference to the drag area to notify it of window moves
             self._window_drag_area: Optional[WindowDragArea] = None
 
@@ -255,10 +257,10 @@ class App:
                         if self._window_drag_area:
                             self._window_drag_area.notify_window_moved(dx, dy)
                     except Exception:
-                        exception_once(logger, "app_custom_title_bar_drag_exc", "Failed to move window")
+                        exception_once(logger, "app_custom_chrome_drag_exc", "Failed to move window")
 
             self._window_drag_area = WindowDragArea(
-                child=self.title_bar.content,
+                child=self.chrome.header,
                 on_drag=on_drag,
                 width="100%",
             )
@@ -274,6 +276,9 @@ class App:
 
         # Wrap the root widget with AppScope to provide access to the App instance
         self.root = AppScope(app=self, child=self.root)
+
+        self._title_value: str | None | ReadOnlyObservableProtocol[str | None] = title
+        self._title_disposable: Optional[Disposable] = None
 
         self._scale = 1.0
         self._dirty = False
@@ -291,6 +296,7 @@ class App:
         self._theme_subscription: Optional[Callable[[Any], None]] = None
         self._update_background_color()
         self._subscribe_theme_updates()
+        self._subscribe_title_updates()
         self._last_layout_size: Optional[tuple[int, int]] = None
         self._saved_window_rect: Optional[tuple[int, int, int, int]] = None
 
@@ -417,7 +423,8 @@ class App:
         width: WindowSizingLike = "auto",
         height: WindowSizingLike = "auto",
         *,
-        title_bar: Optional[TitleBar] = None,
+        title: "str | None | ReadOnlyObservableProtocol[str | None]" = None,
+        chrome: "OSChrome | CustomChrome | None" = _UNSET,  # type: ignore[assignment]
         background: ColorSpec = PlainColorRole.SURFACE,
         overlay_factory: Callable[[], "Overlay"] | None = None,
         theme: Optional[Any] = None,
@@ -436,7 +443,15 @@ class App:
                   out of the box.
             width: Window width specification.
             height: Window height specification.
-            title_bar: Custom window title bar.
+            title: OS window title. Accepts a plain string or a
+                :class:`~nuiitivet.observable.protocols.ReadOnlyObservableProtocol`
+                for dynamic updates (e.g. ``Observable("Untitled")``). Pass
+                ``None`` for no title.
+            chrome: Window decoration. Pass an :class:`OSChrome` instance to
+                use OS-managed decorations with an optional style variant,
+                :class:`CustomChrome` for an app-drawn header, or ``None`` for
+                a bare borderless window. Omitting this parameter (the default)
+                is equivalent to ``OSChrome()``.
             background: Window background color.
             overlay_factory: Optional overlay factory.
             theme: Theme to install.
@@ -457,11 +472,13 @@ class App:
             navigator=navigator,
             overlay_factory=overlay_factory,
         )
+        resolved_chrome: OSChrome | CustomChrome | None = OSChrome() if chrome is _UNSET else chrome
         self._init_common(
             root=root_widget,
             width=width,
             height=height,
-            title_bar=title_bar,
+            title=title,
+            chrome=resolved_chrome,
             background=background,
             theme=theme,
             window_position=window_position,
@@ -527,6 +544,10 @@ class App:
             self._unsubscribe_theme_updates()
         except Exception:
             exception_once(logger, "app_del_unsubscribe_theme_exc", "_unsubscribe_theme_updates raised in __del__")
+        try:
+            self._unsubscribe_title_updates()
+        except Exception:
+            exception_once(logger, "app_del_unsubscribe_title_exc", "_unsubscribe_title_updates raised in __del__")
 
     def render_to_png(self, path: str):
         img = self._render_snapshot(scale=1.0)
@@ -596,6 +617,39 @@ class App:
         except Exception:
             exception_once(logger, "app_theme_unsubscribe_exc", "ThemeManager.unsubscribe raised")
         self._theme_subscription = None
+
+    def _subscribe_title_updates(self) -> None:
+        if not isinstance(self._title_value, ReadOnlyObservableProtocol):
+            return
+        app_ref = weakref.ref(self)
+
+        def _on_title(new_title: "str | None") -> None:
+            app = app_ref()
+            if app is not None:
+                app._apply_window_title(new_title)
+
+        try:
+            self._title_disposable = self._title_value.subscribe(_on_title)
+        except Exception:
+            exception_once(logger, "app_title_subscribe_exc", "Observable title subscribe raised")
+
+    def _apply_window_title(self, title: "str | None") -> None:
+        window = getattr(self, "_window", None)
+        if window is not None:
+            try:
+                window.set_caption(str(title) if title is not None else "")
+            except Exception:
+                exception_once(logger, "app_title_set_caption_exc", "window.set_caption raised")
+
+    def _unsubscribe_title_updates(self) -> None:
+        disp = getattr(self, "_title_disposable", None)
+        if disp is None:
+            return
+        try:
+            disp.dispose()
+        except Exception:
+            exception_once(logger, "app_title_unsubscribe_exc", "title disposable.dispose raised")
+        self._title_disposable = None
 
     def _mount_paint_unmount(self, canvas, x: int, y: int, w: int, h: int) -> None:
         """Temporarily mount the root widget, paint it, then unmount.

--- a/src/nuiitivet/runtime/chrome.py
+++ b/src/nuiitivet/runtime/chrome.py
@@ -1,0 +1,71 @@
+"""Window chrome configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Optional
+
+if TYPE_CHECKING:
+    from nuiitivet.widgeting.widget import Widget
+    from nuiitivet.theme.types import ColorSpec
+
+OSChromeVariant = Literal["default", "dialog", "tool", "borderless", "transparent"]
+
+_VARIANT_DOC = (
+    '"default": standard OS window, '
+    '"dialog": no minimize/maximize, '
+    '"tool": small title bar, '
+    '"borderless": no OS decoration, '
+    '"transparent": transparent background'
+)
+
+
+@dataclass
+class Border:
+    """Border specification for CustomChrome.
+
+    Attributes:
+        color: Border color (any ColorSpec accepted by the theme system).
+        width: Border width in logical pixels.
+    """
+
+    color: "ColorSpec"
+    width: float = 1.0
+
+
+@dataclass
+class OSChrome:
+    """OS-managed window decoration.
+
+    Maps *variant* directly to ``pyglet.window.Window.WINDOW_STYLE_*``.
+
+    Args:
+        variant: Window style. One of: "default", "dialog", "tool",
+            "borderless", "transparent".
+    """
+
+    variant: OSChromeVariant = "default"
+
+
+@dataclass
+class CustomChrome:
+    """Custom (app-drawn) window decoration.
+
+    Always uses a borderless OS window (no OS title bar).
+    Wraps *header* in :class:`~nuiitivet.runtime.title_bar.WindowDragArea`
+    so the user can drag the window by the header.
+
+    Args:
+        header: Widget rendered as the window's title-bar area.
+        corner_radius: Corner radius in logical pixels applied by the render
+            layer. Content is clipped to a rounded rectangle; pixels outside
+            the rounded corners are cleared to transparent. Note that true
+            desktop-transparency in the corners requires platform-level window
+            compositing support.
+        border: Optional border drawn around the window edge inside the
+            rounded-corner boundary.
+    """
+
+    header: "Widget"
+    corner_radius: float = 0.0
+    border: Optional[Border] = None

--- a/src/nuiitivet/runtime/title_bar.py
+++ b/src/nuiitivet/runtime/title_bar.py
@@ -1,6 +1,6 @@
-"""Title bar configuration for the application."""
+"""Internal window drag-area widget."""
 
-from typing import TYPE_CHECKING, Optional, Callable
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from nuiitivet.widgeting.widget import Widget
@@ -9,47 +9,6 @@ from nuiitivet.widgets.interaction import InteractionRegion, DraggableNode
 
 
 from nuiitivet.rendering.sizing import SizingLike
-
-
-class TitleBar:
-    """Base class for title bar configuration."""
-
-    def __init__(self, title: Optional[str] = None):
-        self.title = title
-
-
-class DefaultTitleBar(TitleBar):
-    """Configuration for the default OS title bar.
-
-    Attributes:
-        title: The window title.
-        icon: Path to the window icon.
-    """
-
-    def __init__(
-        self,
-        title: Optional[str] = None,
-        icon: Optional[str] = None,
-    ):
-        super().__init__(title)
-        self.icon = icon
-
-    def __repr__(self) -> str:
-        return f"DefaultTitleBar(title={self.title!r}, icon={self.icon!r})"
-
-
-class CustomTitleBar(TitleBar):
-    """Configuration for a custom title bar."""
-
-    def __init__(self, content: "Widget", title: Optional[str] = None):
-        """Initialize with custom content.
-
-        Args:
-            content: The widget to render as the title bar.
-            title: The window title (used for taskbar/dock, but not rendered by OS).
-        """
-        super().__init__(title)
-        self.content = content
 
 
 class WindowDragArea(InteractionRegion):

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -748,6 +748,15 @@ class InteractionRegion(InteractionHostMixin, Widget):
     # InteractionHostMixin provides add_node, get_node, state property, controller property,
     # enable_hover, enable_click, request_focus_from_pointer, on_pointer_event.
 
+    def layout(self, width: int, height: int) -> None:
+        super().layout(width, height)
+        if not self.children:
+            return
+        l, t, r, b = self.padding
+        cw = max(0, width - l - r)
+        ch = max(0, height - t - b)
+        self.children[0].layout(cw, ch)
+
     def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
 
         self.set_last_rect(x, y, width, height)

--- a/src/samples/custom_title_bar_demo.py
+++ b/src/samples/custom_title_bar_demo.py
@@ -37,7 +37,14 @@ def main():
         ),
         width=600,
         height=400,
-        title_bar=nv.CustomTitleBar(content=title_bar_content),
+        chrome=nv.CustomChrome(
+            header=title_bar_content,
+            corner_radius=8,
+            border=nv.Border(
+                color="#37474f",
+                width=4,
+            ),
+        ),
         background="#ffffff",
     )
     app.run()

--- a/src/samples/japanese_text_demo.py
+++ b/src/samples/japanese_text_demo.py
@@ -3,7 +3,6 @@ from nuiitivet.material import App
 from nuiitivet.material.text import Text
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.layout.column import Column
-import nuiitivet as nv
 from nuiitivet.material.text_fields import TextField
 
 
@@ -36,7 +35,7 @@ def main():
         content=column,
         width=600,
         height=400,
-        title_bar=nv.DefaultTitleBar(title="Japanese Text Demo"),
+        title="Japanese Text Demo",
     )
 
     app.run()

--- a/src/samples/layout_alignment/column_alignment.py
+++ b/src/samples/layout_alignment/column_alignment.py
@@ -59,7 +59,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="nv.Column main_alignment"),
+        title="nv.Column main_alignment",
         width="auto",
         height="auto",
     )

--- a/src/samples/layout_alignment/column_cross_alignment.py
+++ b/src/samples/layout_alignment/column_cross_alignment.py
@@ -57,7 +57,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="nv.Column cross_alignment"),
+        title="nv.Column cross_alignment",
         width="auto",
         height="auto",
     )

--- a/src/samples/layout_alignment/container_alignment.py
+++ b/src/samples/layout_alignment/container_alignment.py
@@ -36,7 +36,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=root,
-        title_bar=nv.DefaultTitleBar(title="nv.Container Alignment"),
+        title="nv.Container Alignment",
         width="auto",
         height="auto",
     )

--- a/src/samples/layout_alignment/row_alignment.py
+++ b/src/samples/layout_alignment/row_alignment.py
@@ -54,7 +54,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="nv.Row main_alignment"),
+        title="nv.Row main_alignment",
         width="auto",
         height="auto",
     )

--- a/src/samples/layout_alignment/row_cross_alignment.py
+++ b/src/samples/layout_alignment/row_cross_alignment.py
@@ -51,7 +51,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="nv.Row cross_alignment"),
+        title="nv.Row cross_alignment",
         width="auto",
         height="auto",
     )

--- a/src/samples/layout_basics/basic_column.py
+++ b/src/samples/layout_basics/basic_column.py
@@ -13,7 +13,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Basic nv.Column"), width=400)
+    app = md.App(content=content, title="Basic nv.Column", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_basics/basic_row.py
+++ b/src/samples/layout_basics/basic_row.py
@@ -12,7 +12,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=actions, title_bar=nv.DefaultTitleBar(title="Basic nv.Row"), width=400)
+    app = md.App(content=actions, title="Basic nv.Row", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_basics/row_column_combination.py
+++ b/src/samples/layout_basics/row_column_combination.py
@@ -32,7 +32,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=form,
-        title_bar=nv.DefaultTitleBar(title="nv.Row/nv.Column Combination"),
+        title="nv.Row/nv.Column Combination",
         width="auto",
     )
     if png:

--- a/src/samples/layout_extras/container_demo.py
+++ b/src/samples/layout_extras/container_demo.py
@@ -11,7 +11,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="nv.Container Demo"))
+    app = md.App(content=widget, title="nv.Container Demo")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/deck_demo.py
+++ b/src/samples/layout_extras/deck_demo.py
@@ -60,7 +60,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=DeckDemo(),
-        title_bar=nv.DefaultTitleBar(title="nv.Deck Demo"),
+        title="nv.Deck Demo",
         width=520,
         height=300,
     )

--- a/src/samples/layout_extras/flow_demo.py
+++ b/src/samples/layout_extras/flow_demo.py
@@ -26,7 +26,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.Flow Demo"))
+    app = md.App(content=root, title="nv.Flow Demo")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/flow_minimal_demo.py
+++ b/src/samples/layout_extras/flow_minimal_demo.py
@@ -26,7 +26,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.Flow Demo"))
+    app = md.App(content=root, title="nv.Flow Demo")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/spacer_flex_demo.py
+++ b/src/samples/layout_extras/spacer_flex_demo.py
@@ -15,7 +15,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="nv.Spacer Flex Demo"))
+    app = md.App(content=widget, title="nv.Spacer Flex Demo")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/stack_demo.py
+++ b/src/samples/layout_extras/stack_demo.py
@@ -36,7 +36,7 @@ def main(png: str = ""):
         style=CardStyle(background=None, border_radius=0),
     )
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.Stack Demo"))
+    app = md.App(content=root, title="nv.Stack Demo")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_extras/uniform_flow_minimal_demo.py
+++ b/src/samples/layout_extras/uniform_flow_minimal_demo.py
@@ -19,7 +19,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="nv.UniformFlow Demo"))
+    app = md.App(content=root, title="nv.UniformFlow Demo")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_grid/app_layout_grid.py
+++ b/src/samples/layout_grid/app_layout_grid.py
@@ -36,7 +36,7 @@ def main(png: str = ""):
     # title_bar argument included so render_layout_images.py can extract the title string
     app = md.App(
         content=widget,
-        title_bar=nv.DefaultTitleBar(title="nv.Grid Layout"),
+        title="nv.Grid Layout",
         width=400,
         height=400,
     )

--- a/src/samples/layout_grid/basic_grid.py
+++ b/src/samples/layout_grid/basic_grid.py
@@ -33,7 +33,7 @@ def main(png: str = ""):
         ],
     )
 
-    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="Basic nv.Grid"))
+    app = md.App(content=widget, title="Basic nv.Grid")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_grid/expanded_cell.py
+++ b/src/samples/layout_grid/expanded_cell.py
@@ -24,7 +24,7 @@ def main(png: str = ""):
 
     root = nv.Container(padding=50, child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Expanded Cell"))
+    app = md.App(content=root, title="Expanded Cell")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_grid/named_areas_grid.py
+++ b/src/samples/layout_grid/named_areas_grid.py
@@ -38,7 +38,7 @@ def main(png: str = ""):
     )
 
     app = md.App(
-        content=widget, title_bar=nv.DefaultTitleBar(title="nv.Grid Layout (Named Areas)"), width=400, height=400
+        content=widget, title="nv.Grid Layout (Named Areas)", width=400, height=400
     )
     if png:
         app.render_to_png(png)

--- a/src/samples/layout_grid/step1_grid.py
+++ b/src/samples/layout_grid/step1_grid.py
@@ -41,7 +41,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=widget,
-        title_bar=nv.DefaultTitleBar(title="Step 1: Simple nv.Grid"),
+        title="Step 1: Simple nv.Grid",
         width=400,
         height=400,
     )

--- a/src/samples/layout_grid/step2_span.py
+++ b/src/samples/layout_grid/step2_span.py
@@ -36,7 +36,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=widget,
-        title_bar=nv.DefaultTitleBar(title="Step 2: Spanning"),
+        title="Step 2: Spanning",
         width=400,
         height=400,
     )

--- a/src/samples/layout_grid/step3_sizing.py
+++ b/src/samples/layout_grid/step3_sizing.py
@@ -35,7 +35,7 @@ def main(png: str = ""):
     )
 
     app = md.App(
-        content=widget, title_bar=nv.DefaultTitleBar(title="Step 3: nv.Sizing Strategies"), width=400, height=400
+        content=widget, title="Step 3: nv.Sizing Strategies", width=400, height=400
     )
     if png:
         app.render_to_png(png)

--- a/src/samples/layout_grid/step4_expand.py
+++ b/src/samples/layout_grid/step4_expand.py
@@ -47,7 +47,7 @@ def main(png: str = ""):
 
     app = md.App(
         content=widget,
-        title_bar=nv.DefaultTitleBar(title="Step 4: Expansion"),
+        title="Step 4: Expansion",
         width=400,
         height=400,
     )

--- a/src/samples/layout_overflow/clipped_content.py
+++ b/src/samples/layout_overflow/clipped_content.py
@@ -20,7 +20,7 @@ def main(png: str = ""):
 
     root = nv.Container(padding=100, child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Clipped Content"), width=400)
+    app = md.App(content=root, title="Clipped Content", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_overflow/default_overflow.py
+++ b/src/samples/layout_overflow/default_overflow.py
@@ -20,7 +20,7 @@ def main(png: str = ""):
     # Center it so we can see the overflow clearly
     root = nv.Container(padding=100, child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Default Overflow"), width=400)
+    app = md.App(content=root, title="Default Overflow", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_overflow/scrollable_list.py
+++ b/src/samples/layout_overflow/scrollable_list.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
         ).modifier(mod.scrollable(axis="y", show_scrollbar=True)),
     )
 
-    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="Scrollable List"), width=400)
+    app = md.App(content=widget, title="Scrollable List", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_sizing/auto_size.py
+++ b/src/samples/layout_sizing/auto_size.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
 
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Auto Size"), width=400)
+    app = md.App(content=root, title="Auto Size", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_sizing/fixed_size.py
+++ b/src/samples/layout_sizing/fixed_size.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
     # Wrap in center container for better visibility
     root = nv.Container(alignment="center", child=widget)
 
-    app = md.App(content=root, title_bar=nv.DefaultTitleBar(title="Fixed Size"), width=400)
+    app = md.App(content=root, title="Fixed Size", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_sizing/flex_width.py
+++ b/src/samples/layout_sizing/flex_width.py
@@ -1,5 +1,4 @@
 import nuiitivet.material as md
-import nuiitivet as nv
 
 
 def main(png: str = ""):
@@ -10,7 +9,7 @@ def main(png: str = ""):
         alignment="center",
     )
 
-    app = md.App(content=widget, title_bar=nv.DefaultTitleBar(title="Full Width Box"), width=400)
+    app = md.App(content=widget, title="Full Width Box", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/container_margin.py
+++ b/src/samples/layout_spacing/container_margin.py
@@ -17,7 +17,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="nv.Container Margin"), width=400)
+    app = md.App(content=content, title="nv.Container Margin", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/gap_demo.py
+++ b/src/samples/layout_spacing/gap_demo.py
@@ -14,7 +14,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Gap Demo"), width=400)
+    app = md.App(content=content, title="Gap Demo", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/padding_demo.py
+++ b/src/samples/layout_spacing/padding_demo.py
@@ -13,7 +13,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Padding Demo"), width=400)
+    app = md.App(content=content, title="Padding Demo", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/layout_spacing/spacer_demo.py
+++ b/src/samples/layout_spacing/spacer_demo.py
@@ -16,7 +16,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="nv.Spacer Demo"), width=400)
+    app = md.App(content=content, title="nv.Spacer Demo", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/material_app/basic_usage.py
+++ b/src/samples/material_app/basic_usage.py
@@ -1,6 +1,5 @@
 """Material App - Basic Usage."""
 
-import nuiitivet as nv
 from nuiitivet.material import App, Button, Text
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.layout.column import Column
@@ -27,7 +26,7 @@ class HomeScreen(ComposableWidget):
 def main(png_path: str = "") -> None:
     app = App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="Material App"),
+        title="Material App",
         width=400,
         height=240,
     )

--- a/src/samples/material_theme/dark_mode.py
+++ b/src/samples/material_theme/dark_mode.py
@@ -5,7 +5,6 @@ Demonstrates dark mode using the same seed color as the light theme.
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Button, Text, ThemeFactory
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.layout.column import Column
@@ -33,7 +32,7 @@ class HomeScreen(ComposableWidget):
 def main(png_path: str = "") -> None:
     app = App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="Dark Mode"),
+        title="Dark Mode",
         theme=ThemeFactory.dark("#00639B"),
         width=400,
         height=280,

--- a/src/samples/material_theme/light_dark_toggle.py
+++ b/src/samples/material_theme/light_dark_toggle.py
@@ -6,7 +6,6 @@ Click the toggle button to switch between light and dark mode.
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Button, Text, ThemeFactory
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.layout.column import Column
@@ -48,7 +47,7 @@ class HomeScreen(ComposableWidget):
 def main() -> None:
     App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="Light / Dark Toggle"),
+        title="Light / Dark Toggle",
         theme=light,
         width=400,
         height=320,

--- a/src/samples/material_theme/multiple_themes.py
+++ b/src/samples/material_theme/multiple_themes.py
@@ -6,7 +6,6 @@ and ThemeModeIntent. Themes are registered on mount and switched by string key.
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Button, Text, ThemeFactory
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.layout.column import Column
@@ -43,7 +42,7 @@ class HomeScreen(ComposableWidget):
 def main() -> None:
     app = App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="Multiple Themes"),
+        title="Multiple Themes",
         theme=ocean_light,
         width=400,
         height=340,

--- a/src/samples/material_theme/no_theme.py
+++ b/src/samples/material_theme/no_theme.py
@@ -6,7 +6,6 @@ MaterialApp defaults to MaterialThemeFactory.light("#6750A4").
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Button, Text
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.layout.column import Column
@@ -34,7 +33,7 @@ class HomeScreen(ComposableWidget):
 def main(png_path: str = "") -> None:
     app = App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="No Theme"),
+        title="No Theme",
         width=400,
         height=280,
     )

--- a/src/samples/material_theme/seed_color.py
+++ b/src/samples/material_theme/seed_color.py
@@ -5,7 +5,6 @@ Demonstrates how passing a custom seed color generates a distinct M3 palette.
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Button, Text, ThemeFactory
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.layout.column import Column
@@ -33,7 +32,7 @@ class HomeScreen(ComposableWidget):
 def main(png_path: str = "") -> None:
     app = App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="Seed Color"),
+        title="Seed Color",
         theme=ThemeFactory.light("#00639B"),
         width=400,
         height=280,

--- a/src/samples/material_widgets/badge.py
+++ b/src/samples/material_widgets/badge.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Icon, LargeBadge, SmallBadge, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -30,7 +29,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Badge"),
+        title="Badge",
         width=520,
         height=200,
     )

--- a/src/samples/material_widgets/button.py
+++ b/src/samples/material_widgets/button.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Button
 from nuiitivet.material.styles.button_style import ButtonStyle
 from nuiitivet.layout.column import Column
@@ -44,7 +43,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Button"),
+        title="Button",
         width=560,
         height=260,
     )

--- a/src/samples/material_widgets/button_group.py
+++ b/src/samples/material_widgets/button_group.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import (
     App,
     ConnectedButtonGroup,
@@ -56,7 +55,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="ButtonGroup"),
+        title="ButtonGroup",
         width=520,
         height=360,
     )

--- a/src/samples/material_widgets/card.py
+++ b/src/samples/material_widgets/card.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Card, CardStyle, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -33,7 +32,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Card"),
+        title="Card",
         width=600,
         height=220,
     )

--- a/src/samples/material_widgets/chip.py
+++ b/src/samples/material_widgets/chip.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, AssistChip, FilterChip, InputChip, SuggestionChip, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -38,7 +37,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Chip"),
+        title="Chip",
         width=560,
         height=240,
     )

--- a/src/samples/material_widgets/divider.py
+++ b/src/samples/material_widgets/divider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Divider, Text
 from nuiitivet.material.styles.divider_style import DividerStyle
 from nuiitivet.layout.column import Column
@@ -49,7 +48,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Divider"),
+        title="Divider",
         width=440,
         height=360,
     )

--- a/src/samples/material_widgets/fab.py
+++ b/src/samples/material_widgets/fab.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Fab, FabStyle, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -41,7 +40,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Fab"),
+        title="Fab",
         width=440,
         height=320,
     )

--- a/src/samples/material_widgets/icon.py
+++ b/src/samples/material_widgets/icon.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Icon, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -49,7 +48,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Icon"),
+        title="Icon",
         width=560,
         height=280,
     )

--- a/src/samples/material_widgets/icon_button.py
+++ b/src/samples/material_widgets/icon_button.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, IconButton, IconToggleButton, Text
 from nuiitivet.material.styles import IconButtonStyle, IconToggleButtonStyle
 from nuiitivet.layout.column import Column
@@ -43,7 +42,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="IconButton"),
+        title="IconButton",
         width=520,
         height=260,
     )

--- a/src/samples/material_widgets/menu.py
+++ b/src/samples/material_widgets/menu.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Menu, MenuDivider, MenuItem, SubMenuItem
 from nuiitivet.layout.container import Container
 
@@ -26,7 +25,7 @@ def main(png_path: str = "") -> None:
 
     app = App(
         content=Container(padding=24, child=menu),
-        title_bar=nv.DefaultTitleBar(title="Menu"),
+        title="Menu",
         width=360,
         height=380,
     )

--- a/src/samples/material_widgets/navigation_rail.py
+++ b/src/samples/material_widgets/navigation_rail.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Card, CardStyle, NavigationRail, RailItem, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
@@ -39,7 +38,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=Row([rail, body], width=Sizing.flex(1), height=Sizing.flex(1)),
-        title_bar=nv.DefaultTitleBar(title="NavigationRail"),
+        title="NavigationRail",
         width=560,
         height=320,
     )

--- a/src/samples/material_widgets/progress.py
+++ b/src/samples/material_widgets/progress.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import (
     App,
     CircularProgressIndicator,
@@ -43,7 +42,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Progress Indicators"),
+        title="Progress Indicators",
         width=440,
         height=320,
     )

--- a/src/samples/material_widgets/selection_controls.py
+++ b/src/samples/material_widgets/selection_controls.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Checkbox, RadioButton, RadioGroup, Switch, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -56,7 +55,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Selection Controls"),
+        title="Selection Controls",
         width=520,
         height=360,
     )

--- a/src/samples/material_widgets/slider.py
+++ b/src/samples/material_widgets/slider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, CenteredSlider, RangeSlider, Slider, Text
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -35,7 +34,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Slider"),
+        title="Slider",
         width=480,
         height=420,
     )

--- a/src/samples/material_widgets/text.py
+++ b/src/samples/material_widgets/text.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, Text
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.layout.column import Column
@@ -31,7 +30,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Text"),
+        title="Text",
         width=420,
         height=300,
     )

--- a/src/samples/material_widgets/text_field.py
+++ b/src/samples/material_widgets/text_field.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, TextField, TextFieldStyle
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -42,7 +41,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="TextField"),
+        title="TextField",
         width=440,
         height=360,
     )

--- a/src/samples/material_widgets/toggle_button.py
+++ b/src/samples/material_widgets/toggle_button.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, ToggleButton, ToggleButtonStyle
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -46,7 +45,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="ToggleButton"),
+        title="ToggleButton",
         width=560,
         height=260,
     )

--- a/src/samples/material_widgets/toolbar.py
+++ b/src/samples/material_widgets/toolbar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, DockedToolbar, FloatingToolbar, IconButton, Text
 from nuiitivet.material.styles import IconButtonStyle, ToolbarStyle
 from nuiitivet.layout.column import Column
@@ -43,7 +42,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Toolbar"),
+        title="Toolbar",
         width=560,
         height=300,
     )

--- a/src/samples/material_widgets/tooltip.py
+++ b/src/samples/material_widgets/tooltip.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import nuiitivet as nv
 from nuiitivet.material import App, RichTooltip, Text, Tooltip
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -30,7 +29,7 @@ def main(png_path: str = "") -> None:
     )
     app = App(
         content=content,
-        title_bar=nv.DefaultTitleBar(title="Tooltip"),
+        title="Tooltip",
         width=440,
         height=320,
     )

--- a/src/samples/modifier/basic_usage.py
+++ b/src/samples/modifier/basic_usage.py
@@ -13,7 +13,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Modifier Basic Usage"), width=400)
+    app = md.App(content=content, title="Modifier Basic Usage", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_decoration/background_border.py
+++ b/src/samples/modifier_decoration/background_border.py
@@ -29,7 +29,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Background & Border"), width=400)
+    app = md.App(content=content, title="Background & Border", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_decoration/corner_radius_clip.py
+++ b/src/samples/modifier_decoration/corner_radius_clip.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Corner Radius & Clip"), width=400)
+    app = md.App(content=content, title="Corner Radius & Clip", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_decoration/shadow.py
+++ b/src/samples/modifier_decoration/shadow.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=32,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Shadow Modifier"), width=400)
+    app = md.App(content=content, title="Shadow Modifier", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_interaction/clickable.py
+++ b/src/samples/modifier_interaction/clickable.py
@@ -17,7 +17,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Clickable Modifier"), width=400)
+    app = md.App(content=content, title="Clickable Modifier", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_interaction/focusable.py
+++ b/src/samples/modifier_interaction/focusable.py
@@ -35,7 +35,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Focusable Modifier"))
+    app = md.App(content=content, title="Focusable Modifier")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_interaction/hoverable.py
+++ b/src/samples/modifier_interaction/hoverable.py
@@ -30,7 +30,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Hoverable Modifier"))
+    app = md.App(content=content, title="Hoverable Modifier")
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_others/scrollable.py
+++ b/src/samples/modifier_others/scrollable.py
@@ -20,7 +20,7 @@ def main(png: str = ""):
         child=nv.Column(children=items, gap=8),
     ).modifier(scrollable(axis="y"))
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Scrollable Modifier"), width=400)
+    app = md.App(content=content, title="Scrollable Modifier", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_others/stick.py
+++ b/src/samples/modifier_others/stick.py
@@ -28,7 +28,7 @@ def main(png: str = "") -> None:
         padding=24,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="stick Modifier"), width=500)
+    app = md.App(content=content, title="stick Modifier", width=500)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -111,7 +111,7 @@ def main(png: str = ""):
         ),
         width=400,
         height=200,
-        title_bar=nv.DefaultTitleBar(title="Will Pop Modifier"),
+        title="Will Pop Modifier",
     )
     if png:
         app.render_to_png(png)

--- a/src/samples/modifier_popup/light_dismiss_menu.py
+++ b/src/samples/modifier_popup/light_dismiss_menu.py
@@ -63,7 +63,7 @@ def main(png: str = "") -> None:
         )
         app = md.App(
             content=nv.Column(children=[_anchor, _menu], gap=4, padding=16),
-            title_bar=nv.DefaultTitleBar(title="light_dismiss Modifier"),
+            title="light_dismiss Modifier",
             width=400,
             height=400,
         )
@@ -72,7 +72,7 @@ def main(png: str = "") -> None:
         return
     app = md.App(
         content=nv.Column(children=[anchor], gap=8, padding=16),
-        title_bar=nv.DefaultTitleBar(title="light_dismiss Modifier"),
+        title="light_dismiss Modifier",
         width=400,
         height=400,
     )

--- a/src/samples/modifier_popup/modeless_basic.py
+++ b/src/samples/modifier_popup/modeless_basic.py
@@ -75,7 +75,7 @@ def main(png: str = "") -> None:
         )
         app = md.App(
             content=nv.Column(children=[_anchor, _panel], gap=4, padding=16),
-            title_bar=nv.DefaultTitleBar(title="modeless Modifier"),
+            title="modeless Modifier",
             width=300,
             height=350,
         )
@@ -84,7 +84,7 @@ def main(png: str = "") -> None:
         return
     app = md.App(
         content=nv.Column(children=[anchor], gap=8, padding=16),
-        title_bar=nv.DefaultTitleBar(title="modeless Modifier"),
+        title="modeless Modifier",
         width=300,
         height=250,
     )

--- a/src/samples/modifier_popup/tooltip_basic.py
+++ b/src/samples/modifier_popup/tooltip_basic.py
@@ -22,14 +22,14 @@ def main(png: str = "") -> None:
                 padding=24,
                 cross_alignment="start",
             ),
-            title_bar=nv.DefaultTitleBar(title="tooltip Modifier"),
+            title="tooltip Modifier",
             width=400,
         )
         app.render_to_png(png)
         print(f"Rendered {png}")
         return
     content = nv.Column(children=[nv.Container(height=20), target], gap=16, padding=24)
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="tooltip Modifier"), width=400, height=200)
+    app = md.App(content=content, title="tooltip Modifier", width=400, height=200)
     app.run()
 
 

--- a/src/samples/modifier_transform/opacity.py
+++ b/src/samples/modifier_transform/opacity.py
@@ -29,7 +29,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Opacity Modifier"), width=400)
+    app = md.App(content=content, title="Opacity Modifier", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_transform/rotate_scale.py
+++ b/src/samples/modifier_transform/rotate_scale.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=48,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Rotate & Scale"), width=400)
+    app = md.App(content=content, title="Rotate & Scale", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/modifier_transform/translate.py
+++ b/src/samples/modifier_transform/translate.py
@@ -23,7 +23,7 @@ def main(png: str = ""):
         padding=16,
     )
 
-    app = md.App(content=content, title_bar=nv.DefaultTitleBar(title="Translate Modifier"), width=400)
+    app = md.App(content=content, title="Translate Modifier", width=400)
     if png:
         app.render_to_png(png)
         print(f"Rendered {png}")

--- a/src/samples/my_widget.py
+++ b/src/samples/my_widget.py
@@ -350,13 +350,12 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     model = MyWidgetModel()
     widget = MyWidget(model)
-    import nuiitivet as nv
 
     app = App(
         content=widget,
         # width=750,
         # height=850,
-        title_bar=nv.DefaultTitleBar(title="MyWidget Demo"),
+        title="MyWidget Demo",
     )
     try:
         app.run()

--- a/src/samples/navigation/basic.py
+++ b/src/samples/navigation/basic.py
@@ -45,7 +45,7 @@ class HomeScreen(ComposableWidget):
 def main(png_path: str | None = None) -> None:
     app = App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="Navigation Basic"),
+        title="Navigation Basic",
         width=400,
         height=300,
     )

--- a/src/samples/navigation/intent.py
+++ b/src/samples/navigation/intent.py
@@ -78,7 +78,7 @@ def main(png_path: str | None = None) -> None:
                 DetailsIntent: lambda intent: DetailsScreen(item_id=intent.item_id),
             },
         ),
-        title_bar=nv.DefaultTitleBar(title="Navigation Intent"),
+        title="Navigation Intent",
         width=400,
         height=300,
     )

--- a/src/samples/navigation/route.py
+++ b/src/samples/navigation/route.py
@@ -76,7 +76,7 @@ class HomeScreen(ComposableWidget):
 def main(png_path: str | None = None) -> None:
     app = App(
         content=HomeScreen(),
-        title_bar=nv.DefaultTitleBar(title="Navigation Route"),
+        title="Navigation Route",
         width=400,
         height=300,
     )

--- a/src/samples/navigation/sub.py
+++ b/src/samples/navigation/sub.py
@@ -100,7 +100,7 @@ class MainScreen(ComposableWidget):
 def main(png_path: str | None = None) -> None:
     app = App(
         content=MainScreen(),
-        title_bar=nv.DefaultTitleBar(title="Nested Navigation"),
+        title="Nested Navigation",
         width=400,
         height=300,
     )

--- a/src/samples/readme/readme_counter_app.py
+++ b/src/samples/readme/readme_counter_app.py
@@ -31,7 +31,7 @@ def main(png: str = "") -> None:
         app_widget.count.value = 3
     app = md.App(
         content=app_widget,
-        title_bar=nv.DefaultTitleBar(title="Counter Demo"),
+        title="Counter Demo",
         width=250,
     )
 

--- a/src/samples/readme/readme_hero_showcase.py
+++ b/src/samples/readme/readme_hero_showcase.py
@@ -787,7 +787,7 @@ def main() -> None:
 
     app = md.App(
         content=PulseApp(autoplay=not args.no_autoplay),
-        title_bar=nv.DefaultTitleBar(title="Pulse"),
+        title="Pulse",
         width=1150,
         height=720,
         theme=theme,

--- a/src/samples/readme/readme_layout_demo.py
+++ b/src/samples/readme/readme_layout_demo.py
@@ -26,7 +26,7 @@ def build_layout_demo():
 
 
 def main(png: str = "") -> None:
-    app = md.App(content=build_layout_demo(), title_bar=nv.DefaultTitleBar(title="Layout Demo"))
+    app = md.App(content=build_layout_demo(), title="Layout Demo")
 
     if png:
         app.render_to_png(png)

--- a/src/samples/readme/readme_login_form.py
+++ b/src/samples/readme/readme_login_form.py
@@ -28,7 +28,7 @@ def build_login_form():
 
 
 def main(png: str = "") -> None:
-    app = md.App(content=build_login_form(), title_bar=nv.DefaultTitleBar(title="Login Form"))
+    app = md.App(content=build_login_form(), title="Login Form")
 
     if png:
         app.render_to_png(png)

--- a/src/samples/readme/readme_modifier_demo.py
+++ b/src/samples/readme/readme_modifier_demo.py
@@ -34,7 +34,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    app = md.App(content=build_modifier_demo(), title_bar=nv.DefaultTitleBar(title="Modifier Demo"))
+    app = md.App(content=build_modifier_demo(), title="Modifier Demo")
 
     if args.png:
         app.render_to_png(args.png)

--- a/src/samples/readme/readme_multi_counter_app.py
+++ b/src/samples/readme/readme_multi_counter_app.py
@@ -47,7 +47,7 @@ def main(png: str = "") -> None:
         app_widget.count_b.value = 5
     app = md.App(
         content=app_widget,
-        title_bar=nv.DefaultTitleBar(title="Multi Counter Demo"),
+        title="Multi Counter Demo",
         width=250,
     )
 


### PR DESCRIPTION
## Summary

Closes #170

Redesigns the window decoration API replacing the old `title_bar=` parameter with
a cleaner `chrome=` / `title=` split.

## Changes

### New API
- `App(title=..., chrome=...)` replaces `App(title_bar=DefaultTitleBar(title=...))`
- `title` accepts a plain `str`, `None`, or a `ReadOnlyObservableProtocol[str | None]`
  for dynamic window title updates
- `chrome` accepts:
  - `OSChrome(variant=...)` — OS-managed decoration (default when omitted)
  - `CustomChrome(header, corner_radius, border)` — app-drawn header
  - `None` — bare borderless window

### New types (`nuiitivet.OSChrome`, `nuiitivet.CustomChrome`, `nuiitivet.Border`)
- `OSChrome`: maps `variant` to pyglet window style
- `CustomChrome`: wraps header widget in `WindowDragArea`; renders
  corner-radius clipping and border stroke in the GPU frame
- `Border`: color + width for `CustomChrome` outline

### Bug fixes
- `CustomChrome` now always uses `WINDOW_STYLE_BORDERLESS` (was
  `WINDOW_STYLE_TRANSPARENT` for `corner_radius > 0`, which restored
  the OS title bar on macOS)
- `border` is now actually rendered (was silently ignored before)
- `InteractionRegion.layout()` now propagates layout to its child,
  fixing header widgets not resizing when the window is resized
- `MaterialApp.chrome` default fixed to `_UNSET` sentinel (was `None`,
  silently producing a borderless window)

### Removed
- `DefaultTitleBar`, `CustomTitleBar` removed from public API