### PR TITLE
ci: add Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
## Summary

Add Python 3.13 and 3.14 to the CI test matrix and declare support in package classifiers. Closes #180.

## Changes

- `.github/workflows/ci.yml`: Add `'3.13'` and `'3.14'` to `jobs.check.strategy.matrix.python-version`
- `pyproject.toml`: Add `Programming Language :: Python :: 3.13` and `Programming Language :: Python :: 3.14` classifiers

## Notes

`requires-python = ">=3.10"` already covers these versions; no constraint change needed.