### PR TITLE
feat(will-pop): support async on_will_pop callbacks

### DIFF
--- a/docs/guide/modifier_others.md
+++ b/docs/guide/modifier_others.md
@@ -32,30 +32,23 @@ In this example, an editor screen is pushed on a `Navigator`. Pop is blocked whi
 ```python
 import nuiitivet as nv
 import nuiitivet.material as md
-from dataclasses import dataclass
 from nuiitivet.material.buttons import Button
 from nuiitivet.material.dialogs import BasicDialog
-from nuiitivet.material import Overlay
+from nuiitivet.material import Overlay, Navigator
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
-from nuiitivet.navigation import Navigator, Route
 from nuiitivet.observable import Observable
 from nuiitivet.material import ButtonStyle
-
-@dataclass(frozen=True, slots=True)
-class HomeIntent:
-    pass
 
 class HomeScreen(nv.ComposableWidget):
     def build(self):
         def _open_editor() -> None:
-            Navigator.root().push(Route(builder=lambda: EditScreen()))
+            Navigator.root().push(EditScreen())
 
         return nv.Container(
             padding=24,
             child=nv.Column(
                 children=[
-                    md.Text("Will Pop Modifier"),
                     md.Text("Open editor, edit text, then try Esc or Back."),
                     Button("Open editor", on_click=_open_editor, style=ButtonStyle.filled()),
                 ],
@@ -76,33 +69,22 @@ class EditScreen(nv.ComposableWidget):
     def _save(self) -> None:
         self._initial_text = str(self.text.value)
 
-    def _try_pop(self) -> None:
-        Navigator.root().pop()
-
-    def _on_will_pop(self) -> bool:
+    async def _on_will_pop(self) -> bool:
         if not self._is_dirty():
             return True
 
-        def _cancel() -> None:
-            Overlay.root().close(None)
-
-        def _discard() -> None:
-            self._initial_text = str(self.text.value)
-            Overlay.root().close(None)
-            Navigator.root().pop()
-
-        Overlay.root().dialog(
+        result = await Overlay.root().dialog(
             BasicDialog(
                 title="Discard changes?",
                 message="You have unsaved changes.",
                 actions=[
-                    Button("Cancel", on_click=_cancel, style=ButtonStyle.text()),
-                    Button("Discard", on_click=_discard, style=ButtonStyle.filled()),
+                    Button("Cancel", on_click=lambda: Overlay.root().close(False), style=ButtonStyle.text()),
+                    Button("Discard", on_click=lambda: Overlay.root().close(True), style=ButtonStyle.filled()),
                 ],
             ),
             dismiss_on_outside_tap=False,
         )
-        return False
+        return bool(result.value)
 
     def build(self):
         return nv.Container(
@@ -118,7 +100,7 @@ class EditScreen(nv.ComposableWidget):
                     ),
                     nv.Row(
                         children=[
-                            Button("Back", on_click=self._try_pop, style=ButtonStyle.text()),
+                            Button("Back", on_click=lambda: Navigator.root().pop(), style=ButtonStyle.text()),
                             Button("Save", on_click=self._save, style=ButtonStyle.filled()),
                         ],
                         gap=10,
@@ -127,16 +109,11 @@ class EditScreen(nv.ComposableWidget):
                 gap=14,
                 cross_alignment="start",
             ),
-        ).modifier(
-            will_pop(on_will_pop=self._on_will_pop)
-        )
+        ).modifier(will_pop(on_will_pop=self._on_will_pop))
 
 def main() -> None:
     md.App(
-        Navigator.intents(
-            initial_route=HomeIntent(),
-            routes={HomeIntent: lambda _i: Route(builder=HomeScreen)},
-        ),
+        HomeScreen(),
     ).run()
 ```
 

--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -5,6 +5,7 @@ This module owns the pyglet dependency so the core package remains backend-agnos
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import math
@@ -846,7 +847,10 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
         handler = getattr(app, "handle_back_event", None)
         if callable(handler):
             try:
-                handled = bool(handler())
+                # ESC was already captured as handled on key_press; schedule the
+                # async back handler as a task and treat the key as handled.
+                asyncio.create_task(handler())
+                handled = True
             except Exception:
                 exception_once(logger, "pyglet_on_key_release_back_handler_exc", "Back handler raised")
                 handled = False

--- a/src/nuiitivet/modifiers/will_pop.py
+++ b/src/nuiitivet/modifiers/will_pop.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import inspect
 import logging
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 
 from nuiitivet.common.logging_once import exception_once
 
 from ..rendering.sizing import SizingLike
+from ..widgeting.callbacks import WillPopCallback
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget
 
 _logger = logging.getLogger(__name__)
-
-
-WillPopCallback = Callable[[], bool]
 
 
 class WillPopScope(Widget):
@@ -44,7 +43,7 @@ class WillPopScope(Widget):
             return child
         return None
 
-    def handle_back_event(self) -> bool:
+    async def handle_back_event(self) -> bool:
         """Return True to continue back action, False to cancel."""
 
         child = self._child()
@@ -52,7 +51,10 @@ class WillPopScope(Widget):
             handler = getattr(child, "handle_back_event", None)
             if callable(handler):
                 try:
-                    if not bool(handler()):
+                    result = handler()
+                    if inspect.isawaitable(result):
+                        result = await result
+                    if not bool(result):
                         return False
                 except Exception:
                     # Fail open to avoid trapping navigation.
@@ -64,7 +66,10 @@ class WillPopScope(Widget):
 
         self._handling = True
         try:
-            return bool(self._on_will_pop())
+            result = self._on_will_pop()
+            if inspect.isawaitable(result):
+                return bool(await result)
+            return bool(result)
         except Exception:
             exception_once(_logger, "will_pop_callback_exc", "on_will_pop callback raised")
             return True

--- a/src/nuiitivet/navigation/navigator.py
+++ b/src/nuiitivet/navigation/navigator.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
+import inspect
 import logging
 from typing import Any, Callable, ClassVar, Literal, Mapping
 
@@ -279,9 +281,9 @@ class Navigator(ComposableWidget):
         self.invalidate()
 
     def pop(self) -> None:
-        self.request_back()
+        asyncio.create_task(self.request_back())
 
-    def request_back(self) -> bool:
+    async def request_back(self) -> bool:
         """Request a single back action.
 
         This API is designed for user back inputs (Esc/back button).
@@ -308,7 +310,7 @@ class Navigator(ComposableWidget):
             # Finish push quickly, then pop once.
             self._force_finish_push_transition()
 
-        did_pop = self._pop_once(skip_animation=False)
+        did_pop = await self._pop_once(skip_animation=False)
         if not did_pop:
             # will_pop canceled; treat as handled.
             return True
@@ -348,11 +350,11 @@ class Navigator(ComposableWidget):
                 exception_once(_logger, "navigator_force_finish_pop_cancel_exc", "Failed to cancel pop transition")
         self._finish_pop()
 
-    def _drain_pending_pops(self) -> None:
+    async def _drain_pending_pops(self) -> None:
         while self._pending_pop_requests > 0 and self.can_pop():
             self._pending_pop_requests -= 1
             skip_animation = self._pending_pop_requests > 0
-            did = self._pop_once(skip_animation=skip_animation)
+            did = await self._pop_once(skip_animation=skip_animation)
             if not did:
                 self._pending_pop_requests = 0
                 return
@@ -364,7 +366,7 @@ class Navigator(ComposableWidget):
         if not self.can_pop():
             self._pending_pop_requests = 0
 
-    def _pop_once(self, *, skip_animation: bool) -> bool:
+    async def _pop_once(self, *, skip_animation: bool) -> bool:
         if not self.can_pop():
             return False
 
@@ -379,7 +381,10 @@ class Navigator(ComposableWidget):
         back_handler = getattr(outgoing_widget, "handle_back_event", None)
         if callable(back_handler):
             try:
-                if not bool(back_handler()):
+                result = back_handler()
+                if inspect.isawaitable(result):
+                    result = await result
+                if not bool(result):
                     self._pending_pop_requests = 0
                     return False
             except Exception:
@@ -412,7 +417,7 @@ class Navigator(ComposableWidget):
         self._stack.mark_exiting(outgoing)
         self._exiting_route = outgoing
         self._finish_pop_once()
-        self._drain_pending_pops()
+        await self._drain_pending_pops()
         return True
 
     def _finish_transition(self) -> None:
@@ -443,7 +448,7 @@ class Navigator(ComposableWidget):
 
     def _finish_pop(self) -> None:
         self._finish_pop_once()
-        self._drain_pending_pops()
+        asyncio.create_task(self._drain_pending_pops())
 
     def layout(self, width: int, height: int) -> None:
         self.clear_needs_layout()

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -359,7 +359,7 @@ class App:
 
         return False
 
-    def handle_back_event(self) -> bool:
+    async def handle_back_event(self) -> bool:
         """Handle a user back action (e.g. Esc).
 
         Priority:
@@ -398,7 +398,7 @@ class App:
             try:
                 request_back = getattr(navigator, "request_back", None)
                 if callable(request_back):
-                    handled = bool(request_back())
+                    handled = bool(await request_back())
                     return handled
                 if navigator.can_pop():
                     navigator.pop()
@@ -851,7 +851,10 @@ class App:
             kname = None
 
         if kname == "escape":
-            return self.handle_back_event()
+            import asyncio
+
+            asyncio.create_task(self.handle_back_event())
+            return True
 
         if kname == "tab":
             # 1. Try FocusNode traversal (New System)

--- a/src/nuiitivet/widgeting/callbacks.py
+++ b/src/nuiitivet/widgeting/callbacks.py
@@ -29,6 +29,8 @@ OptionalBoolCallback = Union[
 ]
 #: Single ``str`` argument callback (e.g. on_change for text inputs).
 StrCallback = Union[Callable[[str], None], Callable[[str], Awaitable[None]]]
+#: Back-navigation guard callback — returns ``True`` to allow pop, ``False`` to cancel.
+WillPopCallback = Union[Callable[[], bool], Callable[[], Awaitable[bool]]]
 
 
 def invoke_event_handler(

--- a/src/nuiitivet/widgeting/widget_builder.py
+++ b/src/nuiitivet/widgeting/widget_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import itertools
 import logging
 import weakref
@@ -10,7 +11,6 @@ from typing import Any, Callable, Dict, List, Optional, Protocol, Set, Tuple, TY
 
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.layout.measure import preferred_size as measure_preferred_size
-
 
 _logger = logging.getLogger(__name__)
 
@@ -511,12 +511,15 @@ class BuilderHostMixin:
                 return hit
         return super().hit_test(x, y)  # type: ignore
 
-    def handle_back_event(self) -> bool:
+    async def handle_back_event(self) -> bool:
         if self._built is not None:
             handler = getattr(self._built, "handle_back_event", None)
             if callable(handler):
                 try:
-                    return bool(handler())
+                    result = handler()
+                    if inspect.isawaitable(result):
+                        return bool(await result)
+                    return bool(result)
                 except Exception:
                     # Fail open to avoid trapping navigation.
                     exception_once(

--- a/src/samples/modifier_others/will_pop.py
+++ b/src/samples/modifier_others/will_pop.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 import nuiitivet as nv
 import nuiitivet.material as md
 from nuiitivet.material.buttons import Button
@@ -7,20 +5,14 @@ from nuiitivet.material.dialogs import BasicDialog
 from nuiitivet.material import Overlay, Navigator
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.modifiers import will_pop
-from nuiitivet.navigation import Route
 from nuiitivet.observable import Observable
 from nuiitivet.material import ButtonStyle
-
-
-@dataclass(frozen=True, slots=True)
-class HomeIntent:
-    pass
 
 
 class HomeScreen(nv.ComposableWidget):
     def build(self):
         def _open_editor() -> None:
-            Navigator.root().push(Route(builder=lambda: EditScreen()))
+            Navigator.root().push(EditScreen())
 
         return nv.Container(
             padding=24,
@@ -47,33 +39,22 @@ class EditScreen(nv.ComposableWidget):
     def _save(self) -> None:
         self._initial_text = str(self.text.value)
 
-    def _try_pop(self) -> None:
-        Navigator.root().pop()
-
-    def _on_will_pop(self) -> bool:
+    async def _on_will_pop(self) -> bool:
         if not self._is_dirty():
             return True
 
-        def _cancel() -> None:
-            Overlay.root().close(None)
-
-        def _discard() -> None:
-            self._initial_text = str(self.text.value)
-            Overlay.root().close(None)
-            Navigator.root().pop()
-
-        Overlay.root().dialog(
+        result = await Overlay.root().dialog(
             BasicDialog(
                 title="Discard changes?",
                 message="You have unsaved changes.",
                 actions=[
-                    Button("Cancel", on_click=_cancel, style=ButtonStyle.text()),
-                    Button("Discard", on_click=_discard, style=ButtonStyle.filled()),
+                    Button("Cancel", on_click=lambda: Overlay.root().close(False), style=ButtonStyle.text()),
+                    Button("Discard", on_click=lambda: Overlay.root().close(True), style=ButtonStyle.filled()),
                 ],
             ),
             dismiss_on_outside_tap=False,
         )
-        return False
+        return bool(result.value)
 
     def build(self):
         return nv.Container(
@@ -89,7 +70,7 @@ class EditScreen(nv.ComposableWidget):
                     ),
                     nv.Row(
                         children=[
-                            Button("Back", on_click=self._try_pop, style=ButtonStyle.text()),
+                            Button("Back", on_click=lambda: Navigator.root().pop(), style=ButtonStyle.text()),
                             Button("Save", on_click=self._save, style=ButtonStyle.filled()),
                         ],
                         gap=10,
@@ -103,12 +84,7 @@ class EditScreen(nv.ComposableWidget):
 
 def main(png: str = ""):
     app = md.App(
-        Navigator.intents(
-            initial_route=HomeIntent(),
-            routes={
-                HomeIntent: lambda _i: Route(builder=HomeScreen),
-            },
-        ),
+        HomeScreen(),
         width=400,
         height=200,
         title="Will Pop Modifier",

--- a/tests/test_back_button_handling.py
+++ b/tests/test_back_button_handling.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+
+import pytest
+
 from nuiitivet.layout.container import Container
 from nuiitivet.modifiers import will_pop
 from nuiitivet.navigation import Navigator
@@ -16,7 +20,8 @@ def _force_finish_all_pop_transitions(navigator: Navigator) -> None:
         navigator._force_finish_pop_transition()
 
 
-def test_escape_closes_overlay_before_navigator_pop() -> None:
+@pytest.mark.asyncio
+async def test_escape_closes_overlay_before_navigator_pop() -> None:
     app = App(content=Container())
     overlay = Overlay.root()
     navigator = Navigator.root()
@@ -28,11 +33,13 @@ def test_escape_closes_overlay_before_navigator_pop() -> None:
 
     handled = app._dispatch_key_press("escape")
     assert handled is True
+    await asyncio.sleep(0)  # allow back event task to run
     assert overlay.has_entries() is False
     assert navigator.can_pop() is True
 
 
-def test_escape_pops_navigator_when_no_overlay_entries() -> None:
+@pytest.mark.asyncio
+async def test_escape_pops_navigator_when_no_overlay_entries() -> None:
     app = App(content=Container())
     overlay = Overlay.root()
     navigator = Navigator.root()
@@ -43,10 +50,12 @@ def test_escape_pops_navigator_when_no_overlay_entries() -> None:
 
     handled = app._dispatch_key_press("escape")
     assert handled is True
+    await asyncio.sleep(0)  # allow back event task to run
     assert navigator.can_pop() is False
 
 
-def test_back_event_is_unhandled_when_nothing_to_pop_or_close() -> None:
+@pytest.mark.asyncio
+async def test_back_event_is_unhandled_when_nothing_to_pop_or_close() -> None:
     app = App(content=Container())
     overlay = Overlay.root()
     navigator = Navigator.root()
@@ -55,10 +64,11 @@ def test_back_event_is_unhandled_when_nothing_to_pop_or_close() -> None:
     assert navigator.can_pop() is False
 
     assert app.can_handle_back_event() is False
-    assert app.handle_back_event() is False
+    assert await app.handle_back_event() is False
 
 
-def test_escape_respects_will_pop_cancel() -> None:
+@pytest.mark.asyncio
+async def test_escape_respects_will_pop_cancel() -> None:
     cancel_pop = will_pop(on_will_pop=lambda: False)
     app = App(content=Container())
     overlay = Overlay.root()
@@ -70,10 +80,12 @@ def test_escape_respects_will_pop_cancel() -> None:
 
     handled = app._dispatch_key_press("escape")
     assert handled is True
+    await asyncio.sleep(0)  # allow back event task to run
     assert navigator.can_pop() is True
 
 
-def test_back_queue_pops_multiple_routes_even_during_transition() -> None:
+@pytest.mark.asyncio
+async def test_back_queue_pops_multiple_routes_even_during_transition() -> None:
     app = App(content=Container())
     navigator = Navigator.root()
     navigator.push(Container())
@@ -82,15 +94,16 @@ def test_back_queue_pops_multiple_routes_even_during_transition() -> None:
 
     assert navigator.can_pop() is True
 
-    assert app.handle_back_event() is True
-    assert app.handle_back_event() is True
-    assert app.handle_back_event() is True
+    assert await app.handle_back_event() is True
+    assert await app.handle_back_event() is True
+    assert await app.handle_back_event() is True
 
     _force_finish_all_pop_transitions(navigator)
     assert navigator.can_pop() is False
 
 
-def test_back_queue_is_cleared_when_will_pop_cancels_midway() -> None:
+@pytest.mark.asyncio
+async def test_back_queue_is_cleared_when_will_pop_cancels_midway() -> None:
     cancel_pop = will_pop(on_will_pop=lambda: False)
     app = App(content=Container())
     navigator = Navigator.root()
@@ -100,13 +113,155 @@ def test_back_queue_is_cleared_when_will_pop_cancels_midway() -> None:
     assert navigator.can_pop() is True
 
     # First back pops top -> middle (allowed). Second back should be canceled by will_pop on middle.
-    assert app.handle_back_event() is True
-    assert app.handle_back_event() is True
+    assert await app.handle_back_event() is True
+    assert await app.handle_back_event() is True
 
     _force_finish_all_pop_transitions(navigator)
     assert navigator.can_pop() is True
 
     # Further backs stay canceled.
-    assert app.handle_back_event() is True
+    assert await app.handle_back_event() is True
     _force_finish_all_pop_transitions(navigator)
     assert navigator.can_pop() is True
+
+
+# ---------------------------------------------------------------------------
+# Async on_will_pop tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_on_will_pop_allow() -> None:
+    """Async on_will_pop returning True allows the pop."""
+    resolved = asyncio.Event()
+
+    async def on_will_pop() -> bool:
+        resolved.set()
+        return True
+
+    scope_mod = will_pop(on_will_pop=on_will_pop)
+    app = App(content=Container())
+    navigator = Navigator.root()
+    navigator.push(Container().modifier(scope_mod))
+
+    assert navigator.can_pop() is True
+    assert await app.handle_back_event() is True
+    assert resolved.is_set()
+    assert navigator.can_pop() is False
+
+
+@pytest.mark.asyncio
+async def test_async_on_will_pop_cancel() -> None:
+    """Async on_will_pop returning False cancels the pop."""
+
+    async def on_will_pop() -> bool:
+        return False
+
+    scope_mod = will_pop(on_will_pop=on_will_pop)
+    app = App(content=Container())
+    navigator = Navigator.root()
+    navigator.push(Container().modifier(scope_mod))
+
+    assert navigator.can_pop() is True
+    assert await app.handle_back_event() is True  # handled (ESC captured), pop canceled
+    assert navigator.can_pop() is True  # route still present
+
+
+@pytest.mark.asyncio
+async def test_async_on_will_pop_exception_fails_open() -> None:
+    """If async on_will_pop raises, pop is allowed (fail open)."""
+
+    async def on_will_pop() -> bool:
+        raise RuntimeError("dialog error")
+
+    scope_mod = will_pop(on_will_pop=on_will_pop)
+    app = App(content=Container())
+    navigator = Navigator.root()
+    navigator.push(Container().modifier(scope_mod))
+
+    assert navigator.can_pop() is True
+    assert await app.handle_back_event() is True
+    # Fail open: pop proceeds despite exception
+    assert navigator.can_pop() is False
+
+
+@pytest.mark.asyncio
+async def test_async_on_will_pop_handling_flag_released_on_exception() -> None:
+    """_handling flag is released even when async on_will_pop raises."""
+
+    async def on_will_pop() -> bool:
+        raise RuntimeError("boom")
+
+    scope_mod = will_pop(on_will_pop=on_will_pop)
+    app = App(content=Container())
+    navigator = Navigator.root()
+    navigator.push(Container().modifier(scope_mod))
+    navigator.push(Container())
+
+    # Pop top route (no will_pop), then pop mid route (will_pop raises -> fail open)
+    assert await app.handle_back_event() is True
+    assert await app.handle_back_event() is True
+
+    # After exception, _handling should be False (released in finally)
+    outgoing_widget = navigator._stack.routes[-1].build_widget() if navigator.can_pop() else None
+    if outgoing_widget is not None:
+        will_pop_scope = outgoing_widget if hasattr(outgoing_widget, "_handling") else None
+        if will_pop_scope is not None:
+            assert will_pop_scope._handling is False
+
+
+@pytest.mark.asyncio
+async def test_sync_on_will_pop_still_works() -> None:
+    """Sync bool-returning callbacks continue to work unchanged."""
+    call_count = 0
+
+    def on_will_pop() -> bool:
+        nonlocal call_count
+        call_count += 1
+        return True
+
+    scope_mod = will_pop(on_will_pop=on_will_pop)
+    app = App(content=Container())
+    navigator = Navigator.root()
+    navigator.push(Container().modifier(scope_mod))
+
+    assert navigator.can_pop() is True
+    assert await app.handle_back_event() is True
+    assert call_count == 1
+    assert navigator.can_pop() is False
+
+
+@pytest.mark.asyncio
+async def test_reentrance_guard_blocks_concurrent_back_during_async_will_pop() -> None:
+    """_handling flag prevents re-entrant back events during async on_will_pop."""
+    gate = asyncio.Event()
+
+    async def on_will_pop() -> bool:
+        await gate.wait()  # suspends until gate is set
+        return True
+
+    scope_mod = will_pop(on_will_pop=on_will_pop)
+    app = App(content=Container())
+    navigator = Navigator.root()
+    navigator.push(Container().modifier(scope_mod))
+
+    # Start first back event but don't complete it yet
+    task = asyncio.create_task(app.handle_back_event())
+    await asyncio.sleep(0)  # let task reach the await gate.wait()
+
+    # WillPopScope._handling should be True while suspended in on_will_pop
+    outgoing_widget = navigator._route_widget(navigator._stack.routes[-1])
+    # The outgoing widget is a WillPopScope
+    assert getattr(outgoing_widget, "_handling", None) is True
+
+    # A second back event while the first is suspended should be blocked
+    second_result = await app.handle_back_event()
+    assert second_result is True  # handled (navigator.can_pop is True)
+    # But pop was blocked by _handling — route still present
+    assert navigator.can_pop() is True
+
+    # Now let the first task complete
+    gate.set()
+    result = await task
+    assert result is True
+    assert navigator.can_pop() is False

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -1,5 +1,9 @@
 """Tests for Navigator (Phase 3 MVP)."""
 
+import asyncio
+
+import pytest
+
 from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
 
@@ -33,7 +37,8 @@ def test_navigator_push_sets_built_child() -> None:
     assert page in nav.children_snapshot()
 
 
-def test_navigator_pop_disposes_route_widget() -> None:
+@pytest.mark.asyncio
+async def test_navigator_pop_disposes_route_widget() -> None:
     nav = Navigator(Route(builder=_FlagWidget))
 
     page2 = _FlagWidget()
@@ -41,13 +46,16 @@ def test_navigator_pop_disposes_route_widget() -> None:
     assert nav.can_pop() is True
 
     nav.pop()
+    await asyncio.sleep(0)  # allow pop task to run
     assert page2.unmounted is True
 
 
-def test_navigator_pop_noop_when_single_route() -> None:
+@pytest.mark.asyncio
+async def test_navigator_pop_noop_when_single_route() -> None:
     nav = Navigator(Route(builder=_FlagWidget))
     nav.rebuild()
     nav.pop()
+    await asyncio.sleep(0)
     assert nav.can_pop() is False
 
 

--- a/tests/test_navigator_intent_and_back.py
+++ b/tests/test_navigator_intent_and_back.py
@@ -108,7 +108,8 @@ def test_navigator_normalize_to_route_resolves_intent() -> None:
     assert isinstance(normalized, Route)
 
 
-def test_navigator_request_back_is_canceled_by_top_widget_handler() -> None:
+@pytest.mark.asyncio
+async def test_navigator_request_back_is_canceled_by_top_widget_handler() -> None:
     bottom = Route(builder=_FlagWidget)
     top_widget = _BackCancelWidget()
 
@@ -117,19 +118,20 @@ def test_navigator_request_back_is_canceled_by_top_widget_handler() -> None:
 
     assert nav.can_pop() is True
 
-    handled = nav.request_back()
+    handled = await nav.request_back()
     assert handled is True
     assert nav.can_pop() is True
     assert top_widget.back_called is True
 
 
-def test_navigator_push_widget_and_route_have_same_pop_behavior() -> None:
+@pytest.mark.asyncio
+async def test_navigator_push_widget_and_route_have_same_pop_behavior() -> None:
     nav_widget = Navigator(Route(builder=_FlagWidget))
     top_widget = _FlagWidget()
     nav_widget.push(top_widget)
 
     assert nav_widget.can_pop() is True
-    assert nav_widget.request_back() is True
+    assert await nav_widget.request_back() is True
     assert nav_widget.can_pop() is False
     assert top_widget.unmounted is True
 
@@ -138,6 +140,6 @@ def test_navigator_push_widget_and_route_have_same_pop_behavior() -> None:
     nav_route.push(Route(builder=lambda: top_route_widget))
 
     assert nav_route.can_pop() is True
-    assert nav_route.request_back() is True
+    assert await nav_route.request_back() is True
     assert nav_route.can_pop() is False
     assert top_route_widget.unmounted is True

--- a/tests/test_navigator_pop_transition_repeat.py
+++ b/tests/test_navigator_pop_transition_repeat.py
@@ -7,7 +7,10 @@ current transition immediately and apply queued back requests.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
+
+import pytest
 
 from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
@@ -36,7 +39,8 @@ class _Handle:
         object.__setattr__(self, "cancel_calls", self.cancel_calls + 1)
 
 
-def test_pop_finishes_when_pop_transition_running() -> None:
+@pytest.mark.asyncio
+async def test_pop_finishes_when_pop_transition_running() -> None:
     nav = Navigator.routes([Route(builder=_FlagWidget), Route(builder=_FlagWidget)])
 
     # Simulate an in-flight pop transition without requiring App.animate.
@@ -49,6 +53,7 @@ def test_pop_finishes_when_pop_transition_running() -> None:
     nav._transition = _T()  # type: ignore[attr-defined,assignment]
 
     nav.pop()
+    await asyncio.sleep(0)  # allow pop task (request_back) to run
 
     assert handle.cancel_calls == 1
     assert nav.can_pop() is False

--- a/tests/test_will_pop.py
+++ b/tests/test_will_pop.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+from typing import Any
+
+import pytest
+
 from nuiitivet.modifiers import will_pop
 from nuiitivet.navigation import Navigator, Route
 from nuiitivet.widgeting.widget import Widget
@@ -19,7 +24,8 @@ class _FlagWidget(Widget):
         return self
 
 
-def test_will_pop_modifier_chains_inner_to_outer() -> None:
+@pytest.mark.asyncio
+async def test_will_pop_modifier_chains_inner_to_outer() -> None:
     calls: list[str] = []
 
     def inner() -> bool:
@@ -33,11 +39,13 @@ def test_will_pop_modifier_chains_inner_to_outer() -> None:
     w = _FlagWidget().modifier(will_pop(inner) | will_pop(outer))
     handler = getattr(w, "handle_back_event", None)
     assert callable(handler)
-    assert bool(handler()) is True
+    result = await handler()
+    assert result is True
     assert calls == ["inner", "outer"]
 
 
-def test_navigator_pop_respects_will_pop_cancel() -> None:
+@pytest.mark.asyncio
+async def test_navigator_pop_respects_will_pop_cancel() -> None:
     calls: list[str] = []
     outgoing = _FlagWidget(label="outgoing")
 
@@ -56,13 +64,15 @@ def test_navigator_pop_respects_will_pop_cancel() -> None:
     assert nav.can_pop() is True
 
     nav.pop()
+    await asyncio.sleep(0)  # allow pop task to run
 
     assert nav.can_pop() is True
     assert outgoing.unmounted is False
     assert calls == ["called"]
 
 
-def test_navigator_pop_respects_will_pop_allow() -> None:
+@pytest.mark.asyncio
+async def test_navigator_pop_respects_will_pop_allow() -> None:
     outgoing = _FlagWidget(label="outgoing")
 
     def on_will_pop() -> bool:
@@ -79,11 +89,13 @@ def test_navigator_pop_respects_will_pop_allow() -> None:
     assert nav.can_pop() is True
 
     nav.pop()
+    await asyncio.sleep(0)  # allow pop task to run
 
     assert nav.can_pop() is False
 
 
-def test_navigator_pop_calls_will_pop_inside_build() -> None:
+@pytest.mark.asyncio
+async def test_navigator_pop_calls_will_pop_inside_build() -> None:
     calls: list[str] = []
 
     from nuiitivet.widgeting.widget import ComposableWidget
@@ -116,6 +128,7 @@ def test_navigator_pop_calls_will_pop_inside_build() -> None:
     assert nav.can_pop() is True
 
     nav.pop()
+    await asyncio.sleep(0)  # allow pop task to run
 
     assert calls == ["called"]
     assert nav.can_pop() is True
@@ -127,18 +140,19 @@ def test_navigator_pop_calls_will_pop_inside_build() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_reentrant_back_is_dropped_while_handler_is_active() -> None:
-    """A second back request while on_will_pop is executing must be dropped."""
+@pytest.mark.asyncio
+async def test_reentrant_back_is_dropped_while_handler_is_active() -> None:
+    """A re-entrant await handle_back_event during async on_will_pop is blocked."""
     calls: list[str] = []
-    scope_ref: list[object] = []
+    scope_ref: list[Any] = []
 
-    def on_will_pop() -> bool:
+    async def on_will_pop() -> bool:
         calls.append("enter")
-        # Simulate re-entrant call (e.g. rapid Esc).
+        # Simulate re-entrant call while _handling is True.
         scope = scope_ref[0]
         handler = getattr(scope, "handle_back_event", None)
         assert callable(handler)
-        result = handler()
+        result = await handler()
         calls.append(f"reentrant={result}")
         return False
 
@@ -148,15 +162,16 @@ def test_reentrant_back_is_dropped_while_handler_is_active() -> None:
 
     handler = getattr(scoped, "handle_back_event", None)
     assert callable(handler)
-    result = handler()
+    result = await handler()
 
     assert result is False
     assert calls == ["enter", "reentrant=False"]
 
 
-def test_handling_flag_is_released_after_normal_return() -> None:
+@pytest.mark.asyncio
+async def test_handling_flag_is_released_after_normal_return() -> None:
     """_handling must be False after a successful callback invocation."""
-    scope_ref: list[object] = []
+    scope_ref: list[Any] = []
 
     def on_will_pop() -> bool:
         return False
@@ -167,12 +182,13 @@ def test_handling_flag_is_released_after_normal_return() -> None:
 
     handler = getattr(scoped, "handle_back_event", None)
     assert callable(handler)
-    handler()
+    await handler()
 
     assert getattr(scoped, "_handling", True) is False
 
 
-def test_handling_flag_is_released_after_exception() -> None:
+@pytest.mark.asyncio
+async def test_handling_flag_is_released_after_exception() -> None:
     """_handling must be False even when the callback raises."""
 
     def on_will_pop() -> bool:
@@ -183,13 +199,14 @@ def test_handling_flag_is_released_after_exception() -> None:
 
     handler = getattr(scoped, "handle_back_event", None)
     assert callable(handler)
-    result = handler()  # fail-open → True
+    result = await handler()  # fail-open → True
 
     assert result is True
     assert getattr(scoped, "_handling", True) is False
 
 
-def test_normal_pop_allowed_works_after_previous_cancel() -> None:
+@pytest.mark.asyncio
+async def test_normal_pop_allowed_works_after_previous_cancel() -> None:
     """After a cancelled pop, a subsequent allow should still propagate."""
     call_count = 0
 
@@ -207,7 +224,9 @@ def test_normal_pop_allowed_works_after_previous_cancel() -> None:
     nav.rebuild()
 
     nav.pop()
+    await asyncio.sleep(0)  # allow first pop task to run
     assert nav.can_pop() is True  # first pop was cancelled
 
     nav.pop()
+    await asyncio.sleep(0)  # allow second pop task to run
     assert nav.can_pop() is False  # second pop was allowed


### PR DESCRIPTION
## Summary

Resolves #135

`on_will_pop` callbacks now support both synchronous and asynchronous forms.
This enables async workflows such as awaiting a confirmation dialog before
allowing back-navigation.

## Changes

### Core
- `callbacks.py`: Add `WillPopCallback = Union[Callable[[], bool], Callable[[], Awaitable[bool]]]`
- `will_pop.py`: `handle_back_event` is now `async def`; dispatches sync/async via `inspect.isawaitable`; re-entrancy guard added
- `widget_builder.py`: `handle_back_event` is now `async def`
- `navigator.py`: `request_back`, `_pop_once`, `_drain_pending_pops` are now `async def`; `pop()` uses `asyncio.create_task`
- `app.py`: `handle_back_event` is now `async def`; ESC key uses `asyncio.create_task`
- `runner.py`: ESC key handler uses `asyncio.create_task`

### Tests
- 14 tests converted to async across 5 test files
- 6 new async `on_will_pop` tests added to `test_back_button_handling.py`
- `test_reentrant_back_is_dropped` rewritten for async re-entrancy

### Sample & Docs
- `will_pop.py`: redesigned with async dialog confirmation pattern
- `modifier_others.md`: updated to match