### PR TITLE
feat(overlay): unify dismiss paths through will_pop pipeline (#186)

### DIFF
--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
-from typing import Any, Callable, Literal, Mapping
+from typing import Any, Callable, Literal, Mapping, TypeVar
 
 from nuiitivet.material.loading_indicator import LoadingIndicator
 from nuiitivet.material.buttons import Button
@@ -24,6 +24,20 @@ from .transition_spec import (
 )
 
 from .intents import BasicDialogIntent, LoadingIntent
+
+_T = TypeVar("_T", bound=Widget)
+
+
+def _find_descendant(widget: Widget, target: type[_T]) -> _T | None:
+    """Return the first descendant (or *widget* itself) of type *target*."""
+    if isinstance(widget, target):
+        return widget
+    for child in widget.children:
+        if isinstance(child, Widget):
+            found = _find_descendant(child, target)
+            if found is not None:
+                return found
+    return None
 
 
 class _MappingIntentResolver(IntentResolver):
@@ -257,7 +271,7 @@ class MaterialOverlay(Overlay):
 
     def side_sheet(
         self,
-        sheet: SideSheet,
+        sheet: Widget,
         *,
         dismiss_on_outside_tap: bool = True,
     ) -> OverlayHandle[Any]:
@@ -268,15 +282,20 @@ class MaterialOverlay(Overlay):
         fully owned by the :class:`SideSheet` widget.
 
         Args:
-            sheet: SideSheet widget that defines content, headline, and styling.
+            sheet: SideSheet widget (or a wrapper such as one produced by
+                ``.modifier(will_pop(...))``) that defines content, headline,
+                and styling.
             dismiss_on_outside_tap: Whether tapping the scrim dismisses the sheet.
                 Defaults to ``True``.
         """
-        alignment = "top-right" if sheet.side == "right" else "top-left"
+        inner = _find_descendant(sheet, SideSheet)
+        if inner is None:
+            raise TypeError("side_sheet() requires a SideSheet widget (possibly wrapped by modifiers)")
+        alignment = "top-right" if inner.side == "right" else "top-left"
 
         route = OverlayRoute(
             builder=lambda: sheet,
-            transition_spec=MaterialTransitions.side_sheet(side=sheet.side),
+            transition_spec=MaterialTransitions.side_sheet(side=inner.side),
             barrier_dismissible=bool(dismiss_on_outside_tap),
         )
 
@@ -288,7 +307,7 @@ class MaterialOverlay(Overlay):
 
     def bottom_sheet(
         self,
-        sheet: BottomSheet,
+        sheet: Widget,
         *,
         dismiss_on_outside_tap: bool = True,
     ) -> OverlayHandle[Any]:
@@ -298,10 +317,14 @@ class MaterialOverlay(Overlay):
         :class:`BottomSheet` widget.
 
         Args:
-            sheet: BottomSheet widget that defines content, headline, and styling.
+            sheet: BottomSheet widget (or a wrapper such as one produced by
+                ``.modifier(will_pop(...))``) that defines content, headline,
+                and styling.
             dismiss_on_outside_tap: Whether tapping the scrim dismisses the sheet.
                 Defaults to ``True``.
         """
+        if _find_descendant(sheet, BottomSheet) is None:
+            raise TypeError("bottom_sheet() requires a BottomSheet widget (possibly wrapped by modifiers)")
         route = OverlayRoute(
             builder=lambda: sheet,
             transition_spec=MaterialTransitions.bottom_sheet(),

--- a/src/nuiitivet/material/sheet.py
+++ b/src/nuiitivet/material/sheet.py
@@ -35,6 +35,15 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
         *on_back* is not ``None``.  Providing ``show_back_button=True`` alone
         without *on_back* will silently suppress the button.
 
+    The Close button always dismisses the sheet through the overlay's unified
+    dismissal pipeline. To intercept the close (for unsaved changes, etc.),
+    attach a ``will_pop`` modifier::
+
+        overlay.side_sheet(
+            SideSheet(content, headline="Settings")
+            .modifier(will_pop(on_will_pop=lambda: not has_unsaved_changes))
+        )
+
     Args:
         content: Widget to display below the header.
         headline: Header title text (str or Observable[str]). Required by M3.
@@ -47,9 +56,6 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
             (e.g. driven by in-sheet navigation state). Defaults to ``False``.
             The button is only rendered when this is truthy **and** *on_back* is
             not ``None``.
-        on_close: Callback invoked when the Close icon button is pressed.
-            If ``None`` and the sheet is shown via an ``Overlay`` API, the
-            button automatically calls ``self.overlay_handle.close(None)``.
         style: Container style. Defaults to :class:`SideSheetStyle`.
     """
 
@@ -61,7 +67,6 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
         side: Literal["right", "left"] = "right",
         on_back: Optional[Callable[[], None]] = None,
         show_back_button: Union[bool, ReadOnlyObservableProtocol[bool]] = False,
-        on_close: Optional[Callable[[], None]] = None,
         style: Optional[SideSheetStyle] = None,
     ) -> None:
         """Initialize SideSheet.
@@ -74,10 +79,6 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
             show_back_button: Back button visibility (bool or Observable[bool]).
                 Defaults to ``False``. Rendered only when truthy **and** *on_back*
                 is not ``None``.
-            on_close: Callback for the Close icon button press. When ``None``
-                and the sheet is shown via an ``Overlay`` API, the button
-                automatically closes the sheet through the injected
-                :class:`OverlayHandle`.
             style: Container style. Defaults to :class:`SideSheetStyle`.
         """
         _style = style if style is not None else SideSheetStyle()
@@ -87,7 +88,6 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
         self.side = side
         self._on_back = on_back
         self._show_back_button = show_back_button
-        self._on_close = on_close
         self._user_style = style
 
     @property
@@ -100,13 +100,11 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
             return bool(self._show_back_button.value)
         return bool(self._show_back_button)
 
-    def _resolve_on_close(self) -> Optional[Callable[[], None]]:
-        """Pick the close handler: explicit ``on_close`` > injected overlay handle."""
-        if self._on_close is not None:
-            return self._on_close
-        if self._overlay_handle is not None:
-            return lambda: self.overlay_handle.close(None)
-        return None
+    def _on_close_click(self) -> None:
+        """Close button handler: route through overlay's unified dismissal pipeline."""
+        if self._overlay_handle is None:
+            return
+        self.overlay_handle.request_close(None)
 
     def on_mount(self) -> None:
         """Mount and subscribe to show_back_button observable if provided."""
@@ -141,7 +139,7 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
                     width="100%",
                     padding=(8, 0, 8, 0),
                 ),
-                IconButton("close", on_click=self._resolve_on_close()),
+                IconButton("close", on_click=self._on_close_click if self._overlay_handle is not None else None),
             ],
             width="100%",
             height=72,
@@ -179,12 +177,13 @@ class BottomSheet(ComposableWidget, OverlayAware[None]):
 
         [ Headline ]  [ Close ]
 
+    The Close button always dismisses the sheet through the overlay's unified
+    dismissal pipeline. To intercept the close (for unsaved changes, etc.),
+    attach a ``will_pop`` modifier.
+
     Args:
         content: Widget to display below the header.
         headline: Header title text (str or Observable[str]). Required by M3.
-        on_close: Callback invoked when the Close icon button is pressed.
-            If ``None`` and the sheet is shown via an ``Overlay`` API, the
-            button automatically calls ``self.overlay_handle.close(None)``.
         style: Container size, background, and shape options.
             Defaults to :class:`BottomSheetStyle`.
     """
@@ -194,7 +193,6 @@ class BottomSheet(ComposableWidget, OverlayAware[None]):
         content: Widget,
         *,
         headline: Union[str, ReadOnlyObservableProtocol[str]],
-        on_close: Optional[Callable[[], None]] = None,
         style: Optional[BottomSheetStyle] = None,
     ) -> None:
         """Initialize BottomSheet.
@@ -202,17 +200,12 @@ class BottomSheet(ComposableWidget, OverlayAware[None]):
         Args:
             content: Widget to display below the header.
             headline: Header title text (str or Observable[str]).
-            on_close: Callback for the Close icon button press. When ``None``
-                and the sheet is shown via an ``Overlay`` API, the button
-                automatically closes the sheet through the injected
-                :class:`OverlayHandle`.
             style: Container style. Defaults to :class:`BottomSheetStyle`.
         """
         _style = style if style is not None else BottomSheetStyle()
         super().__init__(width=_style.width)
         self._content = content
         self._headline = headline
-        self._on_close = on_close
         self._user_style = style
 
     @property
@@ -220,13 +213,11 @@ class BottomSheet(ComposableWidget, OverlayAware[None]):
         """Return resolved sheet style."""
         return self._user_style if self._user_style is not None else BottomSheetStyle()
 
-    def _resolve_on_close(self) -> Optional[Callable[[], None]]:
-        """Pick the close handler: explicit ``on_close`` > injected overlay handle."""
-        if self._on_close is not None:
-            return self._on_close
-        if self._overlay_handle is not None:
-            return lambda: self.overlay_handle.close(None)
-        return None
+    def _on_close_click(self) -> None:
+        """Close button handler: route through overlay's unified dismissal pipeline."""
+        if self._overlay_handle is None:
+            return
+        self.overlay_handle.request_close(None)
 
     def build(self) -> Widget:
         """Build the sheet: outer Box with header Row and content Column."""
@@ -242,7 +233,7 @@ class BottomSheet(ComposableWidget, OverlayAware[None]):
                     width="100%",
                     padding=(8, 0, 8, 0),
                 ),
-                IconButton("close", on_click=self._resolve_on_close()),
+                IconButton("close", on_click=self._on_close_click if self._overlay_handle is not None else None),
             ],
             width="100%",
             height=72,

--- a/src/nuiitivet/overlay/overlay.py
+++ b/src/nuiitivet/overlay/overlay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from typing import Any, Callable, Dict, Optional
 
@@ -28,6 +29,22 @@ from .layer_composer import OverlayLayerComposer, OverlayLayerCompositionContext
 from .transition_state import OverlayTransitionState
 
 logger = logging.getLogger(__name__)
+
+
+def _find_overlay_aware(widget: Widget) -> OverlayAware[Any] | None:
+    """Walk the widget subtree to find the first OverlayAware widget.
+
+    Wrappers added by modifiers (e.g. WillPopScope) sit above the user widget,
+    so the search needs to descend into their children.
+    """
+    if isinstance(widget, OverlayAware):
+        return widget
+    for child in widget.children:
+        if isinstance(child, Widget):
+            found = _find_overlay_aware(child)
+            if found is not None:
+                return found
+    return None
 
 
 class _ModalNavigator(ComposableWidget):
@@ -183,6 +200,7 @@ class _OverlayEntryRoute(Route):
         self.barrier_dismissible = bool(barrier_dismissible)
         self.transition_state: OverlayTransitionState = OverlayTransitionState.create(self.transition_spec)
         self._transition_engine = TransitionEngine()
+        self._content_widget: Widget | None = None
 
     @property
     def transition_phase_obs(self) -> Observable[TransitionPhase]:
@@ -362,6 +380,126 @@ class Overlay(ComposableWidget):
         self._complete_entry_future(entry, OverlayResult(value=value, reason=OverlayDismissReason.CLOSED))
         self.remove_entry(entry)
 
+    def _entry_content_widget(self, entry: OverlayEntry) -> Widget | None:
+        route = self._entry_to_route.get(entry)
+        if route is None:
+            return None
+        return getattr(route, "_content_widget", None)
+
+    def _top_entry(self) -> OverlayEntry | None:
+        routes = getattr(self._modal_navigator, "_routes", None)
+        if not isinstance(routes, list) or len(routes) <= 1:
+            return None
+        top = routes[-1]
+        if top is self._base_route:
+            return None
+        for entry, route in reversed(list(self._entry_to_route.items())):
+            if route is top:
+                return entry
+        return None
+
+    async def _consult_will_pop(self, widget: Widget | None) -> bool:
+        """Return True if dismiss should proceed; False if intercepted."""
+        if widget is None:
+            return True
+        handler = getattr(widget, "handle_back_event", None)
+        if not callable(handler):
+            return True
+        try:
+            result = handler()
+            if inspect.isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception:
+            exception_once(logger, "overlay_consult_will_pop_exc", "handle_back_event raised")
+            return True
+
+    def _will_pop_proceed_sync(self, widget: Widget | None) -> bool | None:
+        """Try to evaluate will_pop synchronously.
+
+        Returns True/False if determined synchronously, or None if the handler
+        is async and must be awaited.
+        """
+        if widget is None:
+            return True
+        handler = getattr(widget, "handle_back_event", None)
+        if not callable(handler):
+            return True
+        try:
+            result = handler()
+        except Exception:
+            exception_once(logger, "overlay_consult_will_pop_sync_exc", "handle_back_event raised")
+            return True
+        if inspect.isawaitable(result):
+            # Caller must re-invoke and await; close this throwaway coroutine
+            # so Python does not emit a "never awaited" warning.
+            close = getattr(result, "close", None)
+            if callable(close):
+                close()
+            return None
+        return bool(result)
+
+    def request_close_topmost(self) -> None:
+        """Request dismissal of the topmost entry through the will_pop pipeline."""
+        entry = self._top_entry()
+        if entry is None:
+            return
+        self._request_dismiss_entry(entry, value=None, reason=OverlayDismissReason.CLOSED)
+
+    async def async_request_close_topmost(self) -> bool:
+        """Async variant: returns True if a dismiss was handled (closed or intercepted)."""
+        entry = self._top_entry()
+        if entry is None:
+            return False
+        content = self._entry_content_widget(entry)
+        if not await self._consult_will_pop(content):
+            return True
+        self._dismiss_entry(entry, reason=OverlayDismissReason.CLOSED)
+        return True
+
+    def _request_dismiss_entry(
+        self,
+        entry: OverlayEntry,
+        *,
+        value: Any = None,
+        reason: OverlayDismissReason,
+    ) -> None:
+        """Dismiss an entry after consulting handle_back_event on its content widget.
+
+        Sync path when the handler is synchronous; otherwise schedule an async task
+        and fall back to immediate dismissal if no event loop is running.
+        """
+        content = self._entry_content_widget(entry)
+        sync = self._will_pop_proceed_sync(content)
+        if sync is True:
+            self._dismiss_entry_with_value(entry, value=value, reason=reason)
+            return
+        if sync is False:
+            return
+        # Async handler: schedule resolution.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No event loop; cannot await will_pop. Fall back to immediate dismiss.
+            self._dismiss_entry_with_value(entry, value=value, reason=reason)
+            return
+
+        async def _go() -> None:
+            if await self._consult_will_pop(content):
+                self._dismiss_entry_with_value(entry, value=value, reason=reason)
+
+        loop.create_task(_go())
+
+    def _dismiss_entry_with_value(
+        self,
+        entry: OverlayEntry,
+        *,
+        value: Any,
+        reason: OverlayDismissReason,
+    ) -> None:
+        self._complete_entry_future(entry, OverlayResult(value=value, reason=reason))
+        self.remove_entry(entry)
+
     def _dismiss_entry(self, entry: OverlayEntry, *, reason: OverlayDismissReason) -> None:
         self._complete_entry_future(entry, OverlayResult(value=None, reason=reason))
         self.remove_entry(entry)
@@ -535,7 +673,7 @@ class Overlay(ComposableWidget):
         def build_layer(route: _OverlayEntryRoute) -> Widget:
             def on_barrier_click() -> None:
                 if barrier_dismissible:
-                    self._dismiss_entry(entry, reason=OverlayDismissReason.OUTSIDE_TAP)
+                    self._request_dismiss_entry(entry, reason=OverlayDismissReason.OUTSIDE_TAP)
 
             context = OverlayLayerCompositionContext(
                 content=content_widget,
@@ -569,12 +707,14 @@ class Overlay(ComposableWidget):
             barrier_dismissible=barrier_dismissible,
         )
         route_holder["route"] = modal_route
+        modal_route._content_widget = content_widget
 
         # Construct the handle first so OverlayAware widgets receive it
         # before the entry is inserted (i.e. before first build / mount).
         handle: OverlayHandle[Any] = OverlayHandle(overlay=self, entry=entry)
-        if isinstance(content_widget, OverlayAware):
-            content_widget._set_overlay_handle(handle)
+        aware = _find_overlay_aware(content_widget)
+        if aware is not None:
+            aware._set_overlay_handle(handle)
 
         self._insert_entry_with_route(entry, modal_route)
 
@@ -651,7 +791,7 @@ class Overlay(ComposableWidget):
         self.invalidate()
 
     def close_topmost(self) -> None:
-        self.close(None)
+        self.request_close_topmost()
 
     def close(self, value: Any = None, target: Widget | Route | None = None) -> None:
         if target is not None:

--- a/src/nuiitivet/overlay/overlay_handle.py
+++ b/src/nuiitivet/overlay/overlay_handle.py
@@ -8,7 +8,6 @@ from typing import Any, Generic, Optional, Protocol, TypeVar
 
 from .result import OverlayResult
 
-
 T = TypeVar("T")
 
 
@@ -22,6 +21,14 @@ class _OverlayHandleHost(Protocol):
     def _get_pending_result_for_entry(self, entry: Any) -> OverlayResult[Any] | None: ...
 
     def _pop_pending_result_for_entry(self, entry: Any) -> OverlayResult[Any] | None: ...
+
+    def _request_dismiss_entry(
+        self,
+        entry: Any,
+        *,
+        value: Any = None,
+        reason: Any,
+    ) -> None: ...
 
 
 class OverlayHandle(Generic[T]):
@@ -41,6 +48,18 @@ class OverlayHandle(Generic[T]):
 
     def close(self, value: T | None = None) -> None:
         self._overlay._close_entry(self._entry, value)
+
+    def request_close(self, value: T | None = None) -> None:
+        """Request close, consulting any ``will_pop`` modifier on the entry.
+
+        If a ``will_pop`` callback returns ``False`` (sync or async), the close
+        is aborted and the entry stays open. With no ``will_pop`` present this
+        behaves like :meth:`close`. Used by the framework for unified dismissal
+        paths (Close button, ESC, scrim tap).
+        """
+        from .result import OverlayDismissReason
+
+        self._overlay._request_dismiss_entry(self._entry, value=value, reason=OverlayDismissReason.CLOSED)
 
     def __await__(self) -> Generator[Any, None, OverlayResult[T]]:
         future: asyncio.Future[OverlayResult[T]] = self._overlay._future_for_entry(self._entry)

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -380,8 +380,9 @@ class App:
             try:
                 has_entries = bool(overlay.has_entries())
                 if has_entries:
-                    overlay.close_topmost()
-                    return True
+                    handled = bool(await overlay.async_request_close_topmost())
+                    if handled:
+                        return True
             except Exception:
                 exception_once(logger, "app_overlay_close_topmost_exc", "overlay.close_topmost() failed")
 

--- a/tests/test_bottom_sheet.py
+++ b/tests/test_bottom_sheet.py
@@ -87,7 +87,6 @@ def test_bottom_sheet_defaults():
     content = Box(width=200, height=100)
     sheet = BottomSheet(content, headline="Filters")
     assert sheet._headline == "Filters"
-    assert sheet._on_close is None
 
 
 def test_bottom_sheet_style_property_default():
@@ -147,45 +146,27 @@ def test_bottom_sheet_transition_fallback_for_string_height():
     assert visuals_mid.translate_y_fraction == pytest.approx(0.5)
 
 
-def test_bottom_sheet_resolve_on_close_uses_explicit_callback():
-    """Explicit on_close takes precedence over the injected overlay handle."""
-    calls = []
-    sheet = BottomSheet(Box(), headline="Filters", on_close=lambda: calls.append("explicit"))
+def test_bottom_sheet_close_button_calls_request_close():
+    """Close button click routes through overlay_handle.request_close(None)."""
+    calls: list[object] = []
 
     class _FakeHandle:
         def close(self, value=None) -> None:
-            calls.append("handle")
+            calls.append(("close", value))
 
-        def done(self) -> bool:
-            return False
-
-    sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
-    handler = sheet._resolve_on_close()
-    assert handler is not None
-    handler()
-    assert calls == ["explicit"]
-
-
-def test_bottom_sheet_resolve_on_close_uses_overlay_handle():
-    """Without explicit on_close, falls back to overlay_handle.close(None)."""
-    closed = []
-
-    class _FakeHandle:
-        def close(self, value=None) -> None:
-            closed.append(value)
+        def request_close(self, value=None) -> None:
+            calls.append(("request_close", value))
 
         def done(self) -> bool:
             return False
 
     sheet = BottomSheet(Box(), headline="Filters")
     sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
-    handler = sheet._resolve_on_close()
-    assert handler is not None
-    handler()
-    assert closed == [None]
+    sheet._on_close_click()
+    assert calls == [("request_close", None)]
 
 
-def test_bottom_sheet_resolve_on_close_returns_none_when_standalone():
-    """No on_close, no overlay handle → close button stays inert."""
+def test_bottom_sheet_close_button_inert_when_standalone():
+    """No overlay handle → close click is a no-op (does not raise)."""
     sheet = BottomSheet(Box(), headline="Filters")
-    assert sheet._resolve_on_close() is None
+    sheet._on_close_click()  # should not raise

--- a/tests/test_overlay_will_pop.py
+++ b/tests/test_overlay_will_pop.py
@@ -1,0 +1,140 @@
+"""Tests for unified overlay dismissal through ``will_pop`` (issue #186).
+
+Covers the three dismiss paths converging on a single pipeline:
+    - ESC / system back  -> Overlay.async_request_close_topmost
+    - scrim (outside) tap -> _request_dismiss_entry
+    - Close button (SideSheet/BottomSheet) -> OverlayHandle.request_close
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nuiitivet.layout.container import Container
+from nuiitivet.material.overlay import MaterialOverlay
+from nuiitivet.material.sheet import BottomSheet, SideSheet
+from nuiitivet.modifiers import will_pop
+from nuiitivet.overlay import Overlay
+from nuiitivet.runtime.app import App
+
+
+@pytest.mark.asyncio
+async def test_overlay_async_close_topmost_respects_will_pop_cancel() -> None:
+    """async_request_close_topmost returns True (handled) but does not remove the entry
+    when will_pop returns False."""
+    App(content=Container())
+    overlay = Overlay.root()
+    overlay.show_modal(Container(width=100, height=100).modifier(will_pop(on_will_pop=lambda: False)))
+
+    handled = await overlay.async_request_close_topmost()
+    assert handled is True
+    assert overlay.has_entries() is True
+
+
+@pytest.mark.asyncio
+async def test_overlay_async_close_topmost_proceeds_when_will_pop_allows() -> None:
+    App(content=Container())
+    overlay = Overlay.root()
+    overlay.show_modal(Container(width=100, height=100).modifier(will_pop(on_will_pop=lambda: True)))
+
+    handled = await overlay.async_request_close_topmost()
+    assert handled is True
+    assert overlay.has_entries() is False
+
+
+@pytest.mark.asyncio
+async def test_overlay_async_close_topmost_respects_async_will_pop_cancel() -> None:
+    async def deny() -> bool:
+        await asyncio.sleep(0)
+        return False
+
+    App(content=Container())
+    overlay = Overlay.root()
+    overlay.show_modal(Container(width=100, height=100).modifier(will_pop(on_will_pop=deny)))
+
+    handled = await overlay.async_request_close_topmost()
+    assert handled is True
+    assert overlay.has_entries() is True
+
+
+@pytest.mark.asyncio
+async def test_app_escape_overlay_will_pop_cancels_close() -> None:
+    """ESC routed through App.handle_back_event respects will_pop on the top overlay entry."""
+    app = App(content=Container())
+    overlay = Overlay.root()
+    overlay.show_modal(Container(width=100, height=100).modifier(will_pop(on_will_pop=lambda: False)))
+
+    handled = app._dispatch_key_press("escape")
+    assert handled is True
+    # Drain the scheduled async back-event task.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert overlay.has_entries() is True
+
+
+@pytest.mark.asyncio
+async def test_side_sheet_close_button_respects_will_pop() -> None:
+    """Close button on SideSheet routes through request_close, which honors will_pop."""
+    App(content=Container())
+    overlay = MaterialOverlay(intents={})
+    Overlay.set_root(overlay)
+    try:
+        sheet = SideSheet(Container(width=10, height=10), headline="X")
+        overlay.side_sheet(sheet.modifier(will_pop(on_will_pop=lambda: False)))
+
+        sheet._on_close_click()
+        # Sync will_pop: cancellation is immediate.
+        assert overlay.has_entries() is True
+    finally:
+        Overlay._root_overlay = None
+
+
+@pytest.mark.asyncio
+async def test_side_sheet_close_button_proceeds_without_will_pop() -> None:
+    App(content=Container())
+    overlay = MaterialOverlay(intents={})
+    Overlay.set_root(overlay)
+    try:
+        sheet = SideSheet(Container(width=10, height=10), headline="X")
+        overlay.side_sheet(sheet)
+
+        sheet._on_close_click()
+        # Default handle_back_event on ComposableWidget is async; let the
+        # scheduled dismiss task run.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert overlay.has_entries() is False
+    finally:
+        Overlay._root_overlay = None
+
+
+@pytest.mark.asyncio
+async def test_bottom_sheet_close_button_respects_will_pop() -> None:
+    App(content=Container())
+    overlay = MaterialOverlay(intents={})
+    Overlay.set_root(overlay)
+    try:
+        sheet = BottomSheet(Container(width=10, height=10), headline="Y")
+        overlay.bottom_sheet(sheet.modifier(will_pop(on_will_pop=lambda: False)))
+
+        sheet._on_close_click()
+        assert overlay.has_entries() is True
+    finally:
+        Overlay._root_overlay = None
+
+
+@pytest.mark.asyncio
+async def test_material_overlay_side_sheet_accepts_wrapped_widget() -> None:
+    """MaterialOverlay.side_sheet walks the tree to find SideSheet inside a wrapper."""
+    App(content=Container())
+    overlay = MaterialOverlay(intents={})
+    Overlay.set_root(overlay)
+    try:
+        sheet = SideSheet(Container(width=10, height=10), headline="X", side="left")
+        handle = overlay.side_sheet(sheet.modifier(will_pop(on_will_pop=lambda: True)))
+        assert handle is not None
+        assert overlay.has_entries() is True
+    finally:
+        Overlay._root_overlay = None

--- a/tests/test_side_sheet.py
+++ b/tests/test_side_sheet.py
@@ -87,7 +87,6 @@ def test_side_sheet_defaults():
     assert sheet.side == "right"
     assert sheet._headline == "Settings"
     assert sheet._on_back is None
-    assert sheet._on_close is None
 
 
 def test_side_sheet_style_property_default():
@@ -196,48 +195,30 @@ def test_side_sheet_transition_fallback_for_non_int_width():
     assert visuals_end.translate_x_fraction == pytest.approx(1.0)
 
 
-def test_side_sheet_resolve_on_close_uses_explicit_callback():
-    """Explicit on_close takes precedence over the injected overlay handle."""
-    calls = []
-    sheet = SideSheet(Box(), headline="Settings", on_close=lambda: calls.append("explicit"))
+def test_side_sheet_close_button_calls_request_close():
+    """Close button click routes through overlay_handle.request_close(None)."""
+    calls: list[object] = []
 
     class _FakeHandle:
         def close(self, value=None) -> None:
-            calls.append("handle")
+            calls.append(("close", value))
 
-        def done(self) -> bool:
-            return False
-
-    sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
-    handler = sheet._resolve_on_close()
-    assert handler is not None
-    handler()
-    assert calls == ["explicit"]
-
-
-def test_side_sheet_resolve_on_close_uses_overlay_handle():
-    """Without explicit on_close, falls back to overlay_handle.close(None)."""
-    closed = []
-
-    class _FakeHandle:
-        def close(self, value=None) -> None:
-            closed.append(value)
+        def request_close(self, value=None) -> None:
+            calls.append(("request_close", value))
 
         def done(self) -> bool:
             return False
 
     sheet = SideSheet(Box(), headline="Settings")
     sheet._set_overlay_handle(_FakeHandle())  # type: ignore[arg-type]
-    handler = sheet._resolve_on_close()
-    assert handler is not None
-    handler()
-    assert closed == [None]
+    sheet._on_close_click()
+    assert calls == [("request_close", None)]
 
 
-def test_side_sheet_resolve_on_close_returns_none_when_standalone():
-    """No on_close, no overlay handle → close button stays inert."""
+def test_side_sheet_close_button_inert_when_standalone():
+    """No overlay handle → close click is a no-op (does not raise)."""
     sheet = SideSheet(Box(), headline="Settings")
-    assert sheet._resolve_on_close() is None
+    sheet._on_close_click()  # should not raise
 
 
 def test_side_sheet_back_button_suppressed_without_on_back():


### PR DESCRIPTION
Closes #186

## Summary

Route all overlay dismissals (Close button, ESC key, scrim tap) through a
single `handle_back_event` / `will_pop` pipeline, replacing the
sheet-specific `on_close` callback.

## Changes

### `overlay/overlay.py`
- Added `_find_overlay_aware()` to inject `OverlayHandle` into the top widget.
- Added `_consult_will_pop()` / `_will_pop_proceed_sync()` to query
  `handle_back_event` before any dismiss.
- `close_topmost()`, barrier click, and `_dismiss_entry()` all go through
  `request_close_topmost` / `_request_dismiss_entry`, which consult
  `will_pop` and abort if it returns `False`.

### `overlay/overlay_handle.py`
- Added `request_close(value)` — lets widget-internal close buttons trigger
  the unified dismiss path.

### `material/sheet.py`
- Removed `on_close` parameter and `_resolve_on_close` from `SideSheet` and
  `BottomSheet`.
- Close button now calls `overlay_handle.request_close(None)`.

### `material/overlay.py`
- `side_sheet()` / `bottom_sheet()` now accept any `Widget` (not just the
  sheet class directly), so `SideSheet(...).modifier(will_pop(...))` works
  transparently.

### `runtime/app.py`
- `handle_back_event` routes through `overlay.async_request_close_topmost()`
  before falling back to the navigator.

### Tests
- Updated `test_side_sheet.py` / `test_bottom_sheet.py`: removed
  `on_close`-related assertions, added close-button + `will_pop` tests.
- New `tests/test_overlay_will_pop.py` (8 tests): ESC + sync/async
  `will_pop`, Close button respects gate, `MaterialOverlay` accepts wrapper
  widgets.