### PR TITLE
ci: enable skia-python on Linux with system dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,18 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Install Skia system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            libfontconfig1 \
+            libegl1 \
+            libegl-mesa0 \
+            libgl1 \
+            libgl1-mesa-dri \
+            libglvnd0
+
       - name: Sync locked dependencies
         run: uv sync --locked --dev
 

--- a/tests/test_scroller_interaction_extended.py
+++ b/tests/test_scroller_interaction_extended.py
@@ -14,7 +14,6 @@ from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
 def _make_basic_scroller():
     controller = ScrollController()
-    controller._update_metrics(max_extent=300.0, viewport_size=200, content_size=500)
     child = Column([Text(f"Item {i}") for i in range(20)])
     scroller = Scroller(
         child=child,
@@ -24,6 +23,11 @@ def _make_basic_scroller():
     )
     scroller.layout(200, 200)
     scroller.set_last_rect(0, 0, 200, 200)
+    # Set metrics after layout so the layout pass does not overwrite them.
+    # On platforms where Text items have no measurable height (e.g. Linux without
+    # matching system fonts), layout would produce content_size=0 and zero out the
+    # scroll metrics needed for these interaction tests.
+    controller._update_metrics(max_extent=300.0, viewport_size=200, content_size=500)
     if scroller._scrollbar:
         scroller._scrollbar.set_last_rect(180, 0, 20, 200)
         scroller._scrollbar.thumb_rect = (180, 80, 20, 40)


### PR DESCRIPTION
## Summary

Install the required system libraries on GitHub Actions Linux runners so that
skia-python can be imported and used in CI.  Previously skia was unavailable
on Linux, causing many rendering/layout tests to be silently skipped.

## Changes

- `.github/workflows/ci.yml`: add "Install Skia system dependencies" step
  (`libfontconfig1 libegl1 libegl-mesa0 libgl1 libgl1-mesa-dri libglvnd0`)
  that runs only on Linux (`if: runner.os == 'Linux'`)
- `tests/test_scroller_interaction_extended.py`: move `_update_metrics()` call
  to after `scroller.layout()` so the explicit test metrics are not overwritten
  by the layout pass (which produces `content_size=0` on Linux where system
  fonts are measured differently)

## Related

Closes #3