### PR TITLE
fix(scroller): correct mouse wheel scroll direction on Windows

### DIFF
--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -736,6 +736,20 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
         y_conv = int(getattr(app, "height", 0)) - y_log
         return x_log, y_conv
 
+    def _normalize_scroll_delta(scroll_x: float, scroll_y: float) -> tuple[float, float]:
+        """Normalize Pyglet raw scroll values to the app convention.
+
+        Convention: positive scroll_y = move content downward (offset increases).
+        On macOS the OS already adjusts values for the Natural Scrolling
+        preference, so pass through unchanged.  On Windows and Linux, Pyglet
+        reports scroll_y > 0 for wheel-forward (up), which is opposite to the
+        app convention.
+        """
+        if sys.platform == "darwin":
+            return scroll_x, scroll_y
+        # Windows and Linux: negate to match app convention
+        return -scroll_x, -scroll_y
+
     @window.event
     def on_mouse_press(x, y, button, modifiers):
         x_log, y_conv = _to_logical(x, y)
@@ -771,8 +785,9 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
     @window.event
     def on_mouse_scroll(x, y, scroll_x, scroll_y):
         x_log, y_conv = _to_logical(x, y)
+        scroll_x_n, scroll_y_n = _normalize_scroll_delta(scroll_x, scroll_y)
         try:
-            app._dispatch_mouse_scroll(x_log, y_conv, scroll_x, scroll_y)
+            app._dispatch_mouse_scroll(x_log, y_conv, scroll_x_n, scroll_y_n)
         except Exception:
             exception_once(logger, "pyglet_on_mouse_scroll_dispatch_exc", "Mouse scroll dispatch raised")
 

--- a/src/nuiitivet/layout/scroller.py
+++ b/src/nuiitivet/layout/scroller.py
@@ -14,7 +14,6 @@ from ..input.pointer import PointerEvent, PointerEventType
 from ..widgets.scrollbar import Scrollbar, ScrollbarBehavior
 from .scroll_viewport import ScrollViewport
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -418,9 +417,7 @@ class Scroller(Widget):
         elif self.direction is ScrollDirection.HORIZONTAL:
             delta = event.scroll_x
             if abs(delta) < 1e-6:
-                delta = -event.scroll_y
-            else:
-                delta = -delta
+                delta = event.scroll_y
         else:
             return False
 

--- a/tests/test_scroller.py
+++ b/tests/test_scroller.py
@@ -386,10 +386,10 @@ def test_scroller_horizontal_scroll_wheel_direction():
     controller._update_metrics(max_extent=400.0, viewport_size=300, content_size=700)
     child = Row([Text(f"Item {i}") for i in range(10)], gap=8)
     scroller = Scroller(child=child, direction=ScrollDirection.HORIZONTAL, scroll_controller=controller)
-    assert send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_x=-2) is True
+    assert send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_x=2) is True
     assert controller.get_offset(axis=ScrollDirection.HORIZONTAL) > 0.0
     prev = controller.get_offset(axis=ScrollDirection.HORIZONTAL)
-    assert send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_x=2) is True
+    assert send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_x=-2) is True
     assert controller.get_offset(axis=ScrollDirection.HORIZONTAL) < prev
 
 


### PR DESCRIPTION
## Summary
Fixes #182

On Windows, scrolling with the mouse wheel moved the scrollbar in the
opposite direction (wheel down → scrollbar up).

## Root Cause
Pyglet reports `scroll_y > 0` for wheel-forward (up), which is the opposite
of the app's internal convention (positive = content moves down). The vertical
scroll path in `scroller.py` used the raw value without sign correction, while
the horizontal path did invert — creating an asymmetric implementation.

## Changes
- **`runner.py`**: Add `_normalize_scroll_delta()` to invert scroll values on
  Windows/Linux at the OS boundary. On macOS the OS already applies the
  Natural Scrolling preference to the delivered values, so they are passed
  through unchanged.
- **`scroller.py`**: Remove the asymmetric sign inversions in `_handle_scroll()`
  — normalization is now handled upstream.
- **`tests/test_scroller.py`**: Update `test_scroller_horizontal_scroll_wheel_direction`
  to match the new internal convention (`scroll_x > 0` = scroll right).