### PR TITLE
docs(guide): reorganize guide navigation with Overlay section

### DIFF
--- a/docs/guide/material_overlay.md
+++ b/docs/guide/material_overlay.md
@@ -12,7 +12,7 @@
 
     The rest of this guide follows this convention.
 
-The base `Overlay` exposes three primitives: `show_modal`, `show_modeless`, and `show_light_dismiss`. `Overlay` wraps these with two additions:
+The base `Overlay` exposes three primitives: `show_modal`, `show_modeless`, and `show_light_dismiss` — see [Primitives](overlay_primitives.md) for details. `MaterialOverlay` wraps these with two additions:
 
 1. **Shortcut methods** — `dialog()`, `snackbar()`, `bottom_sheet()`, `side_sheet()`, `loading()` — each pre-configured with the correct MD3 position and transition.
 2. **Intent resolution** — shortcuts accept plain data objects (intents) in addition to widgets, decoupling business logic from the widget layer.

--- a/docs/guide/overlay.md
+++ b/docs/guide/overlay.md
@@ -1,0 +1,47 @@
+# Overlay
+
+`Overlay` is the framework's system for displaying content above the main widget tree. It acts as a transparent full-screen layer that sits on top of all other widgets, allowing you to show dialogs, toasts, menus, and other transient UI elements without disturbing the underlying layout.
+
+## Role in the Widget Tree
+
+`App` creates and mounts an `Overlay` at the root of the widget tree. Content pushed into the overlay is rendered above all other widgets, regardless of their position in the tree.
+
+```text
+App
+└── Overlay                  ← always on top
+    ├── (overlay entries)    ← managed by show_modal / show_modeless / show_light_dismiss
+    └── child                ← your main widget tree
+```
+
+## Accessing Overlay
+
+Use `Overlay.root()` to retrieve the globally registered overlay instance. This works from anywhere in the application.
+
+```python
+from nuiitivet.overlay import Overlay
+
+overlay = Overlay.root()
+```
+
+`Overlay.of(self)` walks up the widget tree and returns the nearest ancestor `Overlay`. Use this only when you have intentionally nested an `Overlay` inside the widget tree.
+
+```python
+# Only needed when an Overlay is nested in the widget tree
+overlay = Overlay.of(self)
+```
+
+## Primitives
+
+`Overlay` exposes three primitives for displaying content above the widget tree:
+
+| Primitive | Interaction | Outside tap |
+| --------- | ----------- | ----------- |
+| `show_modal` | Blocks background input | Configurable |
+| `show_modeless` | Passes through to background | None |
+| `show_light_dismiss` | Invisible hit layer | Closes overlay |
+
+See [Primitives](overlay_primitives.md) for full documentation and usage examples of each primitive.
+
+## Material Design
+
+`MaterialOverlay` is a subclass that adds Material Design 3-specific shortcuts — `dialog()`, `snackbar()`, `bottom_sheet()`, `side_sheet()`, and `loading()`. For Material Design-specific usage, see [Material Overlay](material_overlay.md).

--- a/docs/guide/overlay_primitives.md
+++ b/docs/guide/overlay_primitives.md
@@ -1,0 +1,137 @@
+# Overlay Primitives
+
+The base `Overlay` exposes three primitives for displaying content above the widget tree. Each primitive determines how user input is handled while the overlay is visible. See [Overview](overlay.md) for context.
+
+## `show_modal`
+
+Displays content with a blocking modal barrier. Background interaction is disabled — all pointer events are captured by the overlay layer.
+
+Use `show_modal` for actions that require user attention before the application can continue: confirmation dialogs, error alerts, bottom sheets.
+
+```python
+from nuiitivet.overlay import Overlay, OverlayPosition
+from nuiitivet.layout.container import Container
+from nuiitivet.material.text import Text
+
+overlay = Overlay.root()
+
+handle = overlay.show_modal(
+    Container(
+        width=300, height=200,
+        child=Text("Modal content"),
+    ),
+)
+
+result = await handle   # OverlayResult[Any]
+```
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `content` | `Widget \| Route` | required | Widget or route to display |
+| `dismiss_on_outside_tap` | `bool` | `False` | Dismiss when tapping the barrier |
+| `barrier_color` | `tuple[int, int, int, int]` | `(0, 0, 0, 128)` | RGBA barrier color |
+| `timeout` | `float \| None` | `None` | Auto-dismiss after seconds |
+| `position` | `OverlayPosition \| None` | `None` (center) | Positioning strategy |
+| `transition_spec` | `TransitionSpec \| None` | `None` | Entry/exit transition |
+
+## `show_modeless`
+
+Displays content above the widget tree without blocking background interaction. Pointer events pass through to the layers below.
+
+Use `show_modeless` for informational overlays that do not require user action: toasts, progress indicators, snackbar messages.
+
+```python
+from nuiitivet.overlay import Overlay, OverlayPosition
+from nuiitivet.material.text import Text
+
+overlay = Overlay.root()
+
+handle = overlay.show_modeless(
+    Text("Operation complete"),
+    timeout=3.0,
+    position=OverlayPosition.alignment("bottom-center", offset=(0, -24)),
+)
+```
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `content` | `Widget \| Route` | required | Widget or route to display |
+| `timeout` | `float \| None` | `None` | Auto-dismiss after seconds |
+| `position` | `OverlayPosition \| None` | `None` (center) | Positioning strategy |
+| `transition_spec` | `TransitionSpec \| None` | `None` | Entry/exit transition |
+
+## `show_light_dismiss`
+
+Displays content with an invisible full-screen hit layer. Tapping outside the content closes the overlay and consumes the outside tap. Background interaction is blocked while the overlay is visible.
+
+Use `show_light_dismiss` for menus and dropdowns that should close when the user clicks away.
+
+```python
+from nuiitivet.overlay import Overlay, OverlayPosition
+
+overlay = Overlay.root()
+
+handle = overlay.show_light_dismiss(
+    MenuWidget(),
+    position=OverlayPosition.alignment("top-left"),
+)
+```
+
+| Parameter | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| `content` | `Widget \| Route` | required | Widget or route to display |
+| `timeout` | `float \| None` | `None` | Auto-dismiss after seconds |
+| `position` | `OverlayPosition \| None` | `None` (center) | Positioning strategy |
+| `transition_spec` | `TransitionSpec \| None` | `None` | Entry/exit transition |
+
+## OverlayHandle and OverlayResult
+
+All three primitives return an `OverlayHandle`. You can close the overlay programmatically or await the result.
+
+```python
+handle = overlay.show_modal(widget)
+
+# Close programmatically
+handle.close("confirmed")
+
+# Await the result
+result = await handle   # OverlayResult[Any]
+print(result.value)     # "confirmed"
+print(result.reason)    # OverlayDismissReason.CLOSED
+```
+
+`OverlayResult` carries the value passed to `close()` and a `reason` indicating how the overlay was dismissed:
+
+| Reason | Trigger |
+| ------ | ------- |
+| `CLOSED` | `handle.close(value)` called explicitly |
+| `OUTSIDE_TAP` | User tapped outside (`dismiss_on_outside_tap=True` or `show_light_dismiss`) |
+| `TIMEOUT` | `timeout` elapsed |
+| `DISPOSED` | Entry removed without explicit close |
+
+## OverlayPosition
+
+`OverlayPosition.alignment(alignment, *, offset=(0, 0))` specifies where the content appears within the overlay root. Supported alignment values:
+
+`top-left`, `top-center`, `top-right`, `center-left`, `center`, `center-right`, `bottom-left`, `bottom-center`, `bottom-right`
+
+```python
+# Bottom center with 24 px upward offset
+position = OverlayPosition.alignment("bottom-center", offset=(0, -24))
+```
+
+## OverlayAware
+
+Widgets that need to close themselves can implement `OverlayAware[T]`. When displayed through any `Overlay` show API, the framework automatically injects the handle into the widget before mounting:
+
+```python
+from nuiitivet.overlay import OverlayAware
+from nuiitivet.widgeting.widget import ComposableWidget, Widget
+
+class MyDialog(ComposableWidget, OverlayAware[str]):
+    def on_confirm(self) -> None:
+        self.overlay_handle.close("confirmed")
+
+    def build(self) -> Widget:
+        ...
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,8 +142,10 @@ nav:
           - Grid: guide/layout_grid.md
           - Overflow: guide/layout_overflow.md
           - Extras: guide/layout_extras.md
-      - Dialogs:
-          - guide/dialogs.md
+      - Overlay:
+          - Overview: guide/overlay.md
+          - Primitives: guide/overlay_primitives.md
+          - Dialogs: guide/dialogs.md
       - Navigation:
           - Overview: guide/navigation.md
           - Route & Animations: guide/navigation_route.md


### PR DESCRIPTION
## Summary

Restructures the guide navigation so that the `Dialogs` section becomes `Overlay`, reflecting that dialogs are just one use case of the overlay system.

## Changes

- **`mkdocs.yml`**: Rename `Dialogs` nav section to `Overlay`; add `Overview` and `Primitives` entries
- **`docs/guide/overlay.md`** *(new)*: Overview page — explains what `Overlay` is, its role in the widget tree, access via `Overlay.root()` / `Overlay.of()`, a summary table of the three primitives, and a link to `material_overlay.md`
- **`docs/guide/overlay_primitives.md`** *(new)*: Primitives page — detailed documentation for `show_modal`, `show_modeless`, and `show_light_dismiss` with parameter tables, usage examples, `OverlayHandle`/`OverlayResult` reference, `OverlayPosition` alignment values, and `OverlayAware` usage
- **`docs/guide/material_overlay.md`**: Add cross-link to `overlay_primitives.md` near the sentence describing the three primitives

Closes #196