### PR TITLE
fix(tooltip): default RichTooltip width to auto with min/max clamp

### DIFF
--- a/src/nuiitivet/material/tooltip.py
+++ b/src/nuiitivet/material/tooltip.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional, Tuple
 
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
@@ -13,7 +13,7 @@ from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.styles.tooltip_style import RichTooltipStyle, TooltipStyle
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.elevation import md3_elevation_to_shadow
-from nuiitivet.rendering.sizing import SizingLike
+from nuiitivet.rendering.sizing import Sizing, SizingLike
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.widgets.box import Box
 
@@ -134,6 +134,21 @@ class RichTooltip(ComposableWidget):
 
         return RichTooltipStyle.from_theme(Theme.of(self))
 
+    def preferred_size(
+        self,
+        max_width: Optional[int] = None,
+        max_height: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        """Return preferred size clamped to [min_width, max_width] when auto-sized."""
+        if self.width_sizing.kind != "fixed":
+            style = self.style
+            effective_max = style.max_width
+            if max_width is not None:
+                effective_max = min(effective_max, max_width)
+            w, h = super().preferred_size(max_width=effective_max, max_height=max_height)
+            return max(w, style.min_width), h
+        return super().preferred_size(max_width=max_width, max_height=max_height)
+
     def build(self) -> Widget:
         style = self.style
         _shadow = md3_elevation_to_shadow(style.elevation)
@@ -194,7 +209,7 @@ class RichTooltip(ComposableWidget):
             gap=8,
             cross_alignment="start",
         )
-        content_width = self.width_sizing if self.width_sizing.kind == "fixed" else style.min_width
+        content_width = self.width_sizing if self.width_sizing.kind == "fixed" else Sizing.auto()
         return Box(
             child=body,
             width=content_width,

--- a/src/samples/material_widgets/tooltip.py
+++ b/src/samples/material_widgets/tooltip.py
@@ -22,7 +22,6 @@ def main(png_path: str = "") -> None:
                     subhead="Save changes",
                     action_label="Learn more",
                     action_label_2="Dismiss",
-                    width=340,
                 ),
             ],
         ),

--- a/tests/test_tooltip.py
+++ b/tests/test_tooltip.py
@@ -400,3 +400,61 @@ def test_tooltip_esc_suppression_clears_after_pointer_leaves() -> None:
         assert box._is_open.value is True
     finally:
         _observable_runtime.set_clock(_prev_clock)
+
+
+# ---------------------------------------------------------------------------
+# Issue #169: RichTooltip default width should be auto (fit-to-content)
+# ---------------------------------------------------------------------------
+
+
+def test_rich_tooltip_build_box_has_auto_width_by_default() -> None:
+    """Box returned by build() must have auto width_sizing when no explicit width is given."""
+    from nuiitivet.rendering.sizing import Sizing
+
+    widget = RichTooltip("Supporting text")
+    box = widget.build()
+    assert isinstance(box, Box)
+    assert box.width_sizing == Sizing.auto()
+
+
+def test_rich_tooltip_build_box_has_fixed_width_when_explicit() -> None:
+    """Box returned by build() must have fixed width_sizing when an explicit width is given."""
+    from nuiitivet.rendering.sizing import Sizing
+
+    widget = RichTooltip("Supporting text", width=240)
+    box = widget.build()
+    assert isinstance(box, Box)
+    assert box.width_sizing == Sizing.fixed(240)
+
+
+def test_rich_tooltip_preferred_size_clamps_to_min_width() -> None:
+    """preferred_size() must return at least min_width even for very short content."""
+    style = RichTooltipStyle.standard().copy_with(min_width=500, max_width=1000)
+    widget = RichTooltip("A", style=style)
+    w, _h = widget.preferred_size()
+    assert w >= 500
+
+
+def test_rich_tooltip_preferred_size_respects_max_width_from_style() -> None:
+    """preferred_size() must not exceed max_width from style."""
+    style = RichTooltipStyle.standard().copy_with(min_width=0, max_width=50)
+    widget = RichTooltip("A very long supporting text that would exceed the max width", style=style)
+    w, _h = widget.preferred_size()
+    assert w <= 50
+
+
+def test_rich_tooltip_preferred_size_respects_parent_max_width_constraint() -> None:
+    """preferred_size(max_width=...) must cap width at the given parent constraint."""
+    style = RichTooltipStyle.standard().copy_with(min_width=0, max_width=1000)
+    widget = RichTooltip("Some text", style=style)
+    w, _h = widget.preferred_size(max_width=80)
+    assert w <= 80
+
+
+def test_rich_tooltip_explicit_width_bypasses_auto_clamp() -> None:
+    """When explicit width is set, preferred_size() must reflect the fixed size (no min/max clamping)."""
+    style = RichTooltipStyle.standard().copy_with(min_width=500, max_width=1000)
+    widget = RichTooltip("A", width=200, style=style)
+    w, _h = widget.preferred_size()
+    # Fixed width = 200, which is below min_width=500, but clamping does not apply.
+    assert w == 200


### PR DESCRIPTION
## Summary

`RichTooltip` used `style.min_width` (160 px) as a fixed width by default, causing action buttons (e.g. "Learn more" + "Dismiss") to overflow the card boundary when their combined label width exceeded 128 px (160 − 2×16 px padding).

## Changes

- **`RichTooltip.build()`**: pass `Sizing.auto()` to `Box` instead of the fixed `style.min_width` when no explicit width is provided
- **`RichTooltip.preferred_size()`**: new override that clamps the auto-computed width to `[style.min_width, style.max_width]`, preserving the style bounds without causing overflow
- **Demo** (`src/samples/material_widgets/tooltip.py`): removed the explicit `width=` override that was working around the old behaviour
- **Tests**: 6 new cases covering auto width, min/max clamping, parent `max_width` constraint, and explicit-width pass-through

## Before / After

| Scenario | Before | After |
|---|---|---|
| No explicit width | Fixed 160 px (overflow risk) | Auto, clamped to [160, 320] |
| `action_label` + `action_label_2` | Buttons may overflow | Card expands to fit |
| `width=200` passed | Fixed 200 px | Fixed 200 px (unchanged) |

Closes #169