### PR TITLE
feat(widgets): add SizeTransition for animated layout size changes

### DIFF
--- a/src/nuiitivet/animation/animatable.py
+++ b/src/nuiitivet/animation/animatable.py
@@ -88,6 +88,47 @@ class Animatable(Generic[T]):
 
         self._start_ticking()
 
+    def snap_to(self, value: T) -> None:
+        """Immediately set both value and target without animating.
+
+        Stops any active motion and resets the resolved value and target to
+        ``value``. Useful for establishing an initial state before the first
+        animated transition.
+
+        Args:
+            value: New current and target value.
+        """
+        self._stop_ticking()
+        self._target = value
+        self._value.value = value
+        if self._motion is not None:
+            vector = self._converter.to_vector(value)
+            if self._state is None:
+                self._state = self._motion.create_state(vector, vector)
+            else:
+                self._state.value = vector.copy()
+                self._state.start = vector.copy()
+                self._state.target = vector.copy()
+                self._state.velocity = [0.0 for _ in vector]
+                self._state.done = True
+
+    def set_motion(self, motion: Motion) -> None:
+        """Replace the active motion model.
+
+        Useful when the same animatable must switch motions depending on
+        direction (e.g. distinct enter/exit timing). Any in-flight motion
+        continues from its current value/velocity using the new motion on the
+        next ``target`` assignment.
+
+        Args:
+            motion: New motion model to drive subsequent retargets.
+        """
+        self._motion = motion
+        if self._state is None:
+            current_vector = self._converter.to_vector(self.value)
+            target_vector = self._converter.to_vector(self._target)
+            self._state = motion.create_state(current_vector, target_vector)
+
     def stop(self) -> None:
         """Stop any active motion and keep the current value."""
         self._stop_ticking()

--- a/src/nuiitivet/widgets/__init__.py
+++ b/src/nuiitivet/widgets/__init__.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 from .text import TextBase
 from .icon import IconBase
+from .size_transition import SizeTransition
 
 __all__ = [
     "TextBase",
     "IconBase",
+    "SizeTransition",
 ]

--- a/src/nuiitivet/widgets/size_transition.py
+++ b/src/nuiitivet/widgets/size_transition.py
@@ -1,0 +1,308 @@
+"""SizeTransition - animate a child's layout size as it changes.
+
+``SizeTransition`` participates in the *layout* phase: it interpolates the
+allocated width/height it reports to its parent so that a child growing or
+shrinking (or being collapsed via ``condition``) does so smoothly instead of
+snapping.
+
+This is the layout-aware counterpart of the paint-only ``visible()`` modifier.
+Use ``visible()`` for opacity/scale fades that keep their layout space; use
+``SizeTransition`` when the layout footprint itself must animate (side sheets,
+expandable panels, etc.).
+
+Following the framework's overflow philosophy (see ``docs/design/LAYOUT.md``),
+``SizeTransition`` does **not** clip its child: clipping is the responsibility
+of the ``clip()`` modifier. While the animated rectangle is smaller than the
+child's natural size the child overflows by default; wrap the widget in
+``clip()`` when the overflow must be hidden::
+
+    SizeTransition(panel, condition=vm.is_open).modifier(clip())
+
+Usage::
+
+    # Follow the child's natural size changes.
+    SizeTransition(my_panel)
+
+    # Open / close along the horizontal axis with distinct exit timing.
+    SizeTransition(
+        my_panel,
+        condition=vm.is_open,
+        axis="horizontal",
+        motion=EXPRESSIVE_DEFAULT_SPATIAL,   # design-layer curve (optional)
+        motion_out=EXPRESSIVE_FAST_SPATIAL,
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
+
+from nuiitivet.animation.animatable import Animatable
+from nuiitivet.animation.motion import BezierMotion, Motion
+from nuiitivet.common.logging_once import exception_once
+from nuiitivet.layout.alignment import normalize_alignment
+from nuiitivet.layout.measure import preferred_size as measure_preferred_size
+from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.widgeting.widget import Widget
+
+if TYPE_CHECKING:
+    from nuiitivet.observable.protocols import Disposable
+
+logger = logging.getLogger(__name__)
+
+
+Axis = Literal["both", "horizontal", "vertical"]
+ConditionLike = Union[bool, ReadOnlyObservableProtocol[bool]]
+
+# Sub-pixel changes below this threshold do not trigger a retarget.
+_EPSILON = 0.5
+
+# Default size motion. Defined locally so this widget depends only on the
+# animation layer (avoids a widgets -> material cross dependency). Design
+# layers may pass an explicit ``motion`` to apply M3 expressive curves.
+_DEFAULT_MOTION: Motion = BezierMotion(0.38, 1.21, 0.22, 1.00, 0.50)
+
+
+def _read_condition(condition: ConditionLike) -> bool:
+    if isinstance(condition, ReadOnlyObservableProtocol):
+        try:
+            return bool(condition.value)
+        except Exception:
+            exception_once(
+                logger,
+                "size_transition_condition_read_exc",
+                "Failed to read SizeTransition condition observable",
+            )
+            return True
+    return bool(condition)
+
+
+class SizeTransition(Widget):
+    """Single-child widget that animates its layout size.
+
+    The child is always mounted and laid out at its own natural size; the
+    *allocated* rectangle reported to the parent is interpolated per axis. While
+    the size is smaller than the child's natural size, the child overflows the
+    allocated rectangle (positioned by ``alignment``) and is not clipped. Wrap
+    the widget in the ``clip()`` modifier to hide the overflow.
+    """
+
+    def __init__(
+        self,
+        child: Optional[Widget] = None,
+        *,
+        condition: Optional[ConditionLike] = None,
+        motion: Motion = _DEFAULT_MOTION,
+        motion_out: Optional[Motion] = None,
+        axis: Axis = "both",
+        alignment: Union[str, Tuple[str, str]] = "top_left",
+    ) -> None:
+        """Initialize a SizeTransition.
+
+        Args:
+            child: The ``Widget`` whose layout size is animated.
+            condition: Optional ``bool`` / ``Observable[bool]``. When ``False``
+                the child collapses to zero size along the animated axes; when
+                ``True`` it expands to the child's natural size. When omitted,
+                the widget simply follows the child's natural size changes.
+            motion: Base motion used for both grow (enter) and shrink (exit).
+            motion_out: Optional motion that overrides only the shrink (exit)
+                direction. When omitted, ``motion`` is used for both.
+            axis: Which axis/axes to animate (``"both"``, ``"horizontal"``,
+                ``"vertical"``). Axes that are not animated pass the child's
+                natural size through unchanged.
+            alignment: Alignment of the child within the animated rectangle.
+        """
+        super().__init__(max_children=1, overflow_policy="replace_last")
+        self._condition = condition
+        self._motion_in = motion
+        self._motion_out = motion_out if motion_out is not None else motion
+        self._axis: Axis = axis
+        self._align = normalize_alignment(alignment, default=("start", "start"))
+
+        self._width_anim: Animatable[float] = Animatable(0.0, motion=self._motion_in)
+        self._height_anim: Animatable[float] = Animatable(0.0, motion=self._motion_in)
+        self._width_sub: Optional["Disposable"] = None
+        self._height_sub: Optional["Disposable"] = None
+        self._initialized = False
+
+        if child is not None:
+            self.add_child(child)
+
+    # --- Child access ------------------------------------------------------
+    def _child(self) -> Optional[Widget]:
+        if not self.children:
+            return None
+        child = self.children[0]
+        return child if isinstance(child, Widget) else None
+
+    def _animates_width(self) -> bool:
+        return self._axis in ("both", "horizontal")
+
+    def _animates_height(self) -> bool:
+        return self._axis in ("both", "vertical")
+
+    # --- Lifecycle ---------------------------------------------------------
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._width_sub = self._width_anim.subscribe(self._on_tick)
+        self._height_sub = self._height_anim.subscribe(self._on_tick)
+        if isinstance(self._condition, ReadOnlyObservableProtocol):
+            self.observe(self._condition, self._on_condition_changed)
+
+    def on_unmount(self) -> None:
+        self._dispose_subscription(self._width_sub)
+        self._dispose_subscription(self._height_sub)
+        self._width_sub = None
+        self._height_sub = None
+        try:
+            self._width_anim.stop()
+            self._height_anim.stop()
+        except Exception:
+            exception_once(
+                logger,
+                "size_transition_stop_exc",
+                "SizeTransition failed to stop animatables on unmount",
+            )
+        super().on_unmount()
+
+    def _dispose_subscription(self, sub: Optional["Disposable"]) -> None:
+        if sub is None:
+            return
+        dispose = getattr(sub, "dispose", None)
+        if callable(dispose):
+            try:
+                dispose()
+            except Exception:
+                exception_once(
+                    logger,
+                    "size_transition_unsubscribe_exc",
+                    "SizeTransition failed to dispose subscription",
+                )
+
+    def _on_tick(self, _: float) -> None:
+        self.mark_needs_layout()
+        self.invalidate()
+
+    def _on_condition_changed(self, _: bool) -> None:
+        # Re-measure and retarget on the next layout pass.
+        self.mark_needs_layout()
+        self.invalidate()
+
+    # --- Target resolution -------------------------------------------------
+    def _natural_size(self, max_width: Optional[int], max_height: Optional[int]) -> Tuple[int, int]:
+        child = self._child()
+        if child is None:
+            return (0, 0)
+        try:
+            return measure_preferred_size(child, max_width=max_width, max_height=max_height)
+        except Exception:
+            exception_once(
+                logger,
+                "size_transition_measure_exc",
+                "SizeTransition failed to measure child preferred size",
+            )
+            return (0, 0)
+
+    def _retarget(self, anim: Animatable[float], target: float) -> None:
+        if abs(anim.target - target) <= _EPSILON:
+            return
+        motion = self._motion_in if target >= anim.target else self._motion_out
+        anim.set_motion(motion)
+        anim.target = target
+
+    def _sync_targets(self, natural_w: int, natural_h: int) -> Tuple[int, int]:
+        """Sync animation targets to current natural size / condition.
+
+        Returns the resolved (possibly animating) outer size.
+        """
+        open_ = True if self._condition is None else _read_condition(self._condition)
+
+        width_target = float(natural_w) if open_ else 0.0
+        height_target = float(natural_h) if open_ else 0.0
+
+        if not self._initialized:
+            # Snap to initial state without animating on first measure.
+            self._initialized = True
+            self._width_anim.snap_to(width_target if self._animates_width() else float(natural_w))
+            self._height_anim.snap_to(height_target if self._animates_height() else float(natural_h))
+
+        if self._animates_width():
+            self._retarget(self._width_anim, width_target)
+            out_w = int(round(self._width_anim.value))
+        else:
+            out_w = natural_w
+
+        if self._animates_height():
+            self._retarget(self._height_anim, height_target)
+            out_h = int(round(self._height_anim.value))
+        else:
+            out_h = natural_h
+
+        return (max(0, out_w), max(0, out_h))
+
+    # --- Layout / measure --------------------------------------------------
+    def preferred_size(
+        self,
+        max_width: Optional[int] = None,
+        max_height: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        natural_w, natural_h = self._natural_size(max_width, max_height)
+        return self._sync_targets(natural_w, natural_h)
+
+    def layout(self, width: int, height: int) -> None:
+        super().layout(width, height)
+        child = self._child()
+        if child is None:
+            return
+
+        # Child is always laid out at its natural size; only the outer
+        # allocation animates. The child is then aligned within `width`/
+        # `height` (and overflows when the allocation is smaller).
+        natural_w, natural_h = self._natural_size(None, None)
+        self._sync_targets(natural_w, natural_h)
+
+        child_w = natural_w if self._animates_width() else width
+        child_h = natural_h if self._animates_height() else height
+        try:
+            child.layout(child_w, child_h)
+        except Exception:
+            exception_once(
+                logger,
+                "size_transition_child_layout_exc",
+                "SizeTransition child layout raised",
+            )
+            return
+
+        fx = {"start": 0.0, "center": 0.5, "end": 1.0}.get(self._align[0], 0.0)
+        fy = {"start": 0.0, "center": 0.5, "end": 1.0}.get(self._align[1], 0.0)
+        cx = int(round((width - child_w) * fx))
+        cy = int(round((height - child_h) * fy))
+        child.set_layout_rect(cx, cy, child_w, child_h)
+
+    def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        child = self._child()
+        if child is None:
+            return
+
+        rect = child.layout_rect
+        if rect is None:
+            cx, cy, cw, ch = x, y, width, height
+        else:
+            rx, ry, rw, rh = rect
+            cx, cy, cw, ch = x + rx, y + ry, rw, rh
+
+        try:
+            child.set_last_rect(cx, cy, cw, ch)
+            child.paint(canvas, cx, cy, cw, ch)
+        except Exception:
+            exception_once(
+                logger,
+                "size_transition_child_paint_exc",
+                "SizeTransition child paint raised",
+            )
+
+
+__all__ = ["SizeTransition"]

--- a/tests/widgets/test_size_transition.py
+++ b/tests/widgets/test_size_transition.py
@@ -1,0 +1,190 @@
+"""Tests for SizeTransition widget."""
+
+from contextlib import contextmanager
+from typing import Callable, Generator
+
+from nuiitivet.animation.motion import LinearMotion
+from nuiitivet.observable import runtime as observable_runtime
+from nuiitivet.observable.value import _ObservableValue
+from nuiitivet.rendering.sizing import Sizing
+from nuiitivet.widgets import SizeTransition
+from nuiitivet.widgets.box import Box
+
+# ---------------------------------------------------------------------------
+# Fake clock helper
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self._interval_callbacks: list[Callable[[float], None]] = []
+
+    def schedule_once(self, fn: Callable[[float], None], delay: float) -> None:
+        del fn, delay
+
+    def schedule_interval(self, fn: Callable[[float], None], interval: float) -> None:
+        del interval
+        if fn not in self._interval_callbacks:
+            self._interval_callbacks.append(fn)
+
+    def unschedule(self, fn: Callable[[float], None]) -> None:
+        self._interval_callbacks = [cb for cb in self._interval_callbacks if cb is not fn]
+
+    def advance(self, dt: float) -> None:
+        for cb in list(self._interval_callbacks):
+            cb(dt)
+
+    def advance_frames(self, count: int, fps: float = 60.0) -> None:
+        dt = 1.0 / fps
+        for _ in range(count):
+            self.advance(dt)
+
+    @property
+    def active(self) -> int:
+        return len(self._interval_callbacks)
+
+
+@contextmanager
+def _fake_clock() -> Generator[_FakeClock, None, None]:
+    prev = observable_runtime.clock
+    fake = _FakeClock()
+    observable_runtime.set_clock(fake)
+    try:
+        yield fake
+    finally:
+        observable_runtime.set_clock(prev)
+
+
+class _DummyApp:
+    def __init__(self) -> None:
+        self.invalidated = 0
+
+    def invalidate(self, immediate: bool = False) -> None:
+        del immediate
+        self.invalidated += 1
+
+
+def _make_child(w: int = 100, h: int = 50) -> Box:
+    return Box(width=Sizing.fixed(w), height=Sizing.fixed(h))
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+
+def test_initial_size_snaps_to_natural_without_animation() -> None:
+    with _fake_clock():
+        widget = SizeTransition(_make_child(100, 50))
+        widget.mount(_DummyApp())
+        assert widget.preferred_size() == (100, 50)
+
+
+def test_condition_false_collapses_initial_size() -> None:
+    with _fake_clock():
+        widget = SizeTransition(_make_child(100, 50), condition=False)
+        widget.mount(_DummyApp())
+        assert widget.preferred_size() == (0, 0)
+
+
+def test_axis_horizontal_only_animates_width() -> None:
+    with _fake_clock():
+        cond = _ObservableValue(True)
+        widget = SizeTransition(_make_child(100, 50), condition=cond, axis="horizontal")
+        widget.mount(_DummyApp())
+        # Height passes through unchanged immediately even mid-animation.
+        cond.value = False
+        widget.preferred_size()
+        _, h = widget.preferred_size()
+        assert h == 50
+
+
+# ---------------------------------------------------------------------------
+# Animated open / close
+# ---------------------------------------------------------------------------
+
+
+def test_condition_toggle_animates_width_to_zero() -> None:
+    with _fake_clock() as clock:
+        cond = _ObservableValue(True)
+        widget = SizeTransition(
+            _make_child(100, 50),
+            condition=cond,
+            axis="horizontal",
+            motion=LinearMotion(0.2),
+        )
+        widget.mount(_DummyApp())
+        assert widget.preferred_size()[0] == 100
+
+        cond.value = False
+        widget.preferred_size()  # triggers retarget to 0
+        clock.advance_frames(6)  # ~0.1s of 0.2s
+        mid_w = widget.preferred_size()[0]
+        assert 0 < mid_w < 100
+
+        clock.advance_frames(20)  # finish
+        assert widget.preferred_size()[0] == 0
+
+
+def test_distinct_motion_out_used_on_shrink() -> None:
+    with _fake_clock() as clock:
+        cond = _ObservableValue(True)
+        widget = SizeTransition(
+            _make_child(100, 50),
+            condition=cond,
+            axis="horizontal",
+            motion=LinearMotion(1.0),
+            motion_out=LinearMotion(0.1),
+        )
+        widget.mount(_DummyApp())
+        widget.preferred_size()
+
+        cond.value = False
+        widget.preferred_size()
+        # motion_out is fast (0.1s); after ~0.12s it should be fully collapsed.
+        clock.advance_frames(8)
+        assert widget.preferred_size()[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Follow natural size changes (no condition)
+# ---------------------------------------------------------------------------
+
+
+def test_follows_child_natural_size_change() -> None:
+    with _fake_clock() as clock:
+        child = _make_child(100, 50)
+        widget = SizeTransition(child, motion=LinearMotion(0.2))
+        widget.mount(_DummyApp())
+        assert widget.preferred_size() == (100, 50)
+
+        child.width_sizing = Sizing.fixed(200)
+        widget.preferred_size()  # detect + retarget
+        clock.advance_frames(20)
+        assert widget.preferred_size()[0] == 200
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_unmount_stops_ticking_and_disposes() -> None:
+    with _fake_clock() as clock:
+        cond = _ObservableValue(True)
+        widget = SizeTransition(
+            _make_child(100, 50),
+            condition=cond,
+            axis="horizontal",
+            motion=LinearMotion(0.5),
+        )
+        widget.mount(_DummyApp())
+        widget.preferred_size()
+        cond.value = False
+        widget.preferred_size()
+        clock.advance_frames(2)
+        assert clock.active > 0
+
+        widget.unmount()
+        # No active interval callbacks remain after unmount.
+        assert clock.active == 0


### PR DESCRIPTION
## Summary

Closes #113.

Adds `SizeTransition`, a widget that animates its **layout footprint** (width and/or height) as it grows or collapses. This is the layout-phase counterpart of the paint-only `visible()` modifier — use `SizeTransition` when the allocated space itself must animate (e.g. side sheets, expandable panels).

## Changes

### `src/nuiitivet/widgets/size_transition.py` (new)
- `SizeTransition(Widget)` — single-child widget that interpolates `preferred_size` per frame.
- `condition` — `Observable[bool] | bool | None`. `False` collapses to zero; `None` follows natural size changes.
- `axis` — `"both" | "horizontal" | "vertical"`.
- `motion` / `motion_out` — separate enter/exit timing.
- `alignment` — child alignment within the animated rectangle.
- Defaults to **Visible overflow** per the framework's overflow philosophy. Use `.modifier(clip())` to hide overflow.

### `src/nuiitivet/animation/animatable.py`
- `snap_to(value)` — set value and target immediately without animating (used for initial-state setup).
- `set_motion(motion)` — swap the motion model for the next retarget (used for in/out motion switching).

### `src/nuiitivet/widgets/__init__.py`
- Exports `SizeTransition`.

### `tests/widgets/test_size_transition.py` (new)
- 7 tests covering: initial snap, condition=False collapse, axis isolation, animated open/close, distinct motion_out, natural-size follow, unmount cleanup.

## Design Notes

- No internal `clipRect`; clipping is delegated to `clip()` modifier (`LAYOUT.md` §4: "Clip is the responsibility of Modifiers").
- `_DEFAULT_MOTION` defined locally (avoids `widgets → material` cross-dependency).
- `Animatable.snap_to()` resets state vectors and velocity so no animation fires on the first layout pass.