### PR TITLE
refactor(layout): replace SizeTransition with Collapsible

### DIFF
--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -14,6 +14,7 @@ from nuiitivet.layout.grid import Grid, GridItem
 from nuiitivet.layout.spacer import Spacer
 from nuiitivet.layout.cross_aligned import CrossAligned
 from nuiitivet.layout.deck import Deck
+from nuiitivet.layout.collapsible import Collapsible
 
 # Primitives / Widgets
 from nuiitivet.rendering.sizing import Sizing
@@ -42,6 +43,7 @@ __all__: list[str] = [
     "CustomChrome",
     "Border",
     "Deck",
+    "Collapsible",
     "Sizing",
     "Widget",
     "ComposableWidget",

--- a/src/nuiitivet/layout/collapsible.py
+++ b/src/nuiitivet/layout/collapsible.py
@@ -1,34 +1,29 @@
-"""SizeTransition - animate a child's layout size as it changes.
+"""Collapsible - animate a child's layout size as it opens and closes.
 
-``SizeTransition`` participates in the *layout* phase: it interpolates the
+``Collapsible`` participates in the *layout* phase: it interpolates the
 allocated width/height it reports to its parent so that a child growing or
-shrinking (or being collapsed via ``condition``) does so smoothly instead of
-snapping.
+collapsing does so smoothly instead of snapping.
 
 This is the layout-aware counterpart of the paint-only ``visible()`` modifier.
 Use ``visible()`` for opacity/scale fades that keep their layout space; use
-``SizeTransition`` when the layout footprint itself must animate (side sheets,
+``Collapsible`` when the layout footprint itself must animate (side sheets,
 expandable panels, etc.).
 
-Following the framework's overflow philosophy (see ``docs/design/LAYOUT.md``),
-``SizeTransition`` does **not** clip its child: clipping is the responsibility
-of the ``clip()`` modifier. While the animated rectangle is smaller than the
-child's natural size the child overflows by default; wrap the widget in
-``clip()`` when the overflow must be hidden::
+Clipping is applied internally at all times; no ``clip()`` modifier is needed::
 
-    SizeTransition(panel, condition=vm.is_open).modifier(clip())
+    Collapsible(panel, opened=vm.is_open)
 
 Usage::
 
-    # Follow the child's natural size changes.
-    SizeTransition(my_panel)
+    # Simple vertical expand/collapse driven by an observable.
+    Collapsible(my_panel, opened=vm.is_open)
 
-    # Open / close along the horizontal axis with distinct exit timing.
-    SizeTransition(
+    # Horizontal axis with distinct exit timing.
+    Collapsible(
         my_panel,
-        condition=vm.is_open,
+        opened=vm.is_open,
         axis="horizontal",
-        motion=EXPRESSIVE_DEFAULT_SPATIAL,   # design-layer curve (optional)
+        motion=EXPRESSIVE_DEFAULT_SPATIAL,
         motion_out=EXPRESSIVE_FAST_SPATIAL,
     )
 """
@@ -44,6 +39,7 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.layout.alignment import normalize_alignment
 from nuiitivet.layout.measure import preferred_size as measure_preferred_size
 from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.rendering.skia.geometry import clip_rect, make_rect
 from nuiitivet.widgeting.widget import Widget
 
 if TYPE_CHECKING:
@@ -53,61 +49,58 @@ logger = logging.getLogger(__name__)
 
 
 Axis = Literal["both", "horizontal", "vertical"]
-ConditionLike = Union[bool, ReadOnlyObservableProtocol[bool]]
 
 # Sub-pixel changes below this threshold do not trigger a retarget.
 _EPSILON = 0.5
 
 # Default size motion. Defined locally so this widget depends only on the
-# animation layer (avoids a widgets -> material cross dependency). Design
+# animation layer (avoids a layout -> material cross dependency). Design
 # layers may pass an explicit ``motion`` to apply M3 expressive curves.
 _DEFAULT_MOTION: Motion = BezierMotion(0.38, 1.21, 0.22, 1.00, 0.50)
 
 
-def _read_condition(condition: ConditionLike) -> bool:
-    if isinstance(condition, ReadOnlyObservableProtocol):
+def _read_opened(opened: Union[bool, ReadOnlyObservableProtocol[bool]]) -> bool:
+    if isinstance(opened, ReadOnlyObservableProtocol):
         try:
-            return bool(condition.value)
+            return bool(opened.value)
         except Exception:
             exception_once(
                 logger,
-                "size_transition_condition_read_exc",
-                "Failed to read SizeTransition condition observable",
+                "collapsible_opened_read_exc",
+                "Failed to read Collapsible opened observable",
             )
             return True
-    return bool(condition)
+    return bool(opened)
 
 
-class SizeTransition(Widget):
-    """Single-child widget that animates its layout size.
+class Collapsible(Widget):
+    """Single-child widget that animates its layout size open and closed.
 
     The child is always mounted and laid out at its own natural size; the
-    *allocated* rectangle reported to the parent is interpolated per axis. While
-    the size is smaller than the child's natural size, the child overflows the
-    allocated rectangle (positioned by ``alignment``) and is not clipped. Wrap
-    the widget in the ``clip()`` modifier to hide the overflow.
+    *allocated* rectangle reported to the parent is interpolated per axis.
+    The animated rectangle is clipped internally, so the child never overflows
+    its allocated bounds.
     """
 
     def __init__(
         self,
         child: Optional[Widget] = None,
         *,
-        condition: Optional[ConditionLike] = None,
+        opened: Union[bool, ReadOnlyObservableProtocol[bool]] = True,
         motion: Motion = _DEFAULT_MOTION,
         motion_out: Optional[Motion] = None,
         axis: Axis = "both",
         alignment: Union[str, Tuple[str, str]] = "top_left",
     ) -> None:
-        """Initialize a SizeTransition.
+        """Initialize a Collapsible.
 
         Args:
             child: The ``Widget`` whose layout size is animated.
-            condition: Optional ``bool`` / ``Observable[bool]``. When ``False``
-                the child collapses to zero size along the animated axes; when
-                ``True`` it expands to the child's natural size. When omitted,
-                the widget simply follows the child's natural size changes.
-            motion: Base motion used for both grow (enter) and shrink (exit).
-            motion_out: Optional motion that overrides only the shrink (exit)
+            opened: ``bool`` / ``Observable[bool]``. When ``False`` the child
+                collapses to zero size along the animated axes; when ``True``
+                it expands to the child's natural size.
+            motion: Base motion used for both open (enter) and close (exit).
+            motion_out: Optional motion that overrides only the close (exit)
                 direction. When omitted, ``motion`` is used for both.
             axis: Which axis/axes to animate (``"both"``, ``"horizontal"``,
                 ``"vertical"``). Axes that are not animated pass the child's
@@ -115,7 +108,7 @@ class SizeTransition(Widget):
             alignment: Alignment of the child within the animated rectangle.
         """
         super().__init__(max_children=1, overflow_policy="replace_last")
-        self._condition = condition
+        self._opened: Union[bool, ReadOnlyObservableProtocol[bool]] = opened
         self._motion_in = motion
         self._motion_out = motion_out if motion_out is not None else motion
         self._axis: Axis = axis
@@ -148,8 +141,8 @@ class SizeTransition(Widget):
         super().on_mount()
         self._width_sub = self._width_anim.subscribe(self._on_tick)
         self._height_sub = self._height_anim.subscribe(self._on_tick)
-        if isinstance(self._condition, ReadOnlyObservableProtocol):
-            self.observe(self._condition, self._on_condition_changed)
+        if isinstance(self._opened, ReadOnlyObservableProtocol):
+            self.observe(self._opened, self._on_opened_changed)
 
     def on_unmount(self) -> None:
         self._dispose_subscription(self._width_sub)
@@ -162,8 +155,8 @@ class SizeTransition(Widget):
         except Exception:
             exception_once(
                 logger,
-                "size_transition_stop_exc",
-                "SizeTransition failed to stop animatables on unmount",
+                "collapsible_stop_exc",
+                "Collapsible failed to stop animatables on unmount",
             )
         super().on_unmount()
 
@@ -177,15 +170,15 @@ class SizeTransition(Widget):
             except Exception:
                 exception_once(
                     logger,
-                    "size_transition_unsubscribe_exc",
-                    "SizeTransition failed to dispose subscription",
+                    "collapsible_unsubscribe_exc",
+                    "Collapsible failed to dispose subscription",
                 )
 
     def _on_tick(self, _: float) -> None:
         self.mark_needs_layout()
         self.invalidate()
 
-    def _on_condition_changed(self, _: bool) -> None:
+    def _on_opened_changed(self, _: bool) -> None:
         # Re-measure and retarget on the next layout pass.
         self.mark_needs_layout()
         self.invalidate()
@@ -200,8 +193,8 @@ class SizeTransition(Widget):
         except Exception:
             exception_once(
                 logger,
-                "size_transition_measure_exc",
-                "SizeTransition failed to measure child preferred size",
+                "collapsible_measure_exc",
+                "Collapsible failed to measure child preferred size",
             )
             return (0, 0)
 
@@ -213,11 +206,11 @@ class SizeTransition(Widget):
         anim.target = target
 
     def _sync_targets(self, natural_w: int, natural_h: int) -> Tuple[int, int]:
-        """Sync animation targets to current natural size / condition.
+        """Sync animation targets to current natural size / opened state.
 
         Returns the resolved (possibly animating) outer size.
         """
-        open_ = True if self._condition is None else _read_condition(self._condition)
+        open_ = _read_opened(self._opened)
 
         width_target = float(natural_w) if open_ else 0.0
         height_target = float(natural_h) if open_ else 0.0
@@ -259,7 +252,7 @@ class SizeTransition(Widget):
 
         # Child is always laid out at its natural size; only the outer
         # allocation animates. The child is then aligned within `width`/
-        # `height` (and overflows when the allocation is smaller).
+        # `height` and clipped to those bounds.
         natural_w, natural_h = self._natural_size(None, None)
         self._sync_targets(natural_w, natural_h)
 
@@ -270,8 +263,8 @@ class SizeTransition(Widget):
         except Exception:
             exception_once(
                 logger,
-                "size_transition_child_layout_exc",
-                "SizeTransition child layout raised",
+                "collapsible_child_layout_exc",
+                "Collapsible child layout raised",
             )
             return
 
@@ -294,15 +287,41 @@ class SizeTransition(Widget):
             rx, ry, rw, rh = rect
             cx, cy, cw, ch = x + rx, y + ry, rw, rh
 
+        clip_saved = False
+        if canvas is not None and width > 0 and height > 0:
+            clip_area = make_rect(x, y, width, height)
+            try:
+                canvas.save()
+                if clip_area is not None and clip_rect(canvas, clip_area, True):
+                    clip_saved = True
+                else:
+                    canvas.restore()
+            except Exception:
+                exception_once(
+                    logger,
+                    "collapsible_clip_save_exc",
+                    "Collapsible clip save failed",
+                )
+
         try:
             child.set_last_rect(cx, cy, cw, ch)
             child.paint(canvas, cx, cy, cw, ch)
         except Exception:
             exception_once(
                 logger,
-                "size_transition_child_paint_exc",
-                "SizeTransition child paint raised",
+                "collapsible_child_paint_exc",
+                "Collapsible child paint raised",
             )
+        finally:
+            if clip_saved:
+                try:
+                    canvas.restore()
+                except Exception:
+                    exception_once(
+                        logger,
+                        "collapsible_clip_restore_exc",
+                        "Collapsible clip restore failed",
+                    )
 
 
-__all__ = ["SizeTransition"]
+__all__ = ["Collapsible"]

--- a/src/nuiitivet/widgets/__init__.py
+++ b/src/nuiitivet/widgets/__init__.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 
 from .text import TextBase
 from .icon import IconBase
-from .size_transition import SizeTransition
 
 __all__ = [
     "TextBase",
     "IconBase",
-    "SizeTransition",
 ]

--- a/tests/layout/test_collapsible.py
+++ b/tests/layout/test_collapsible.py
@@ -1,13 +1,13 @@
-"""Tests for SizeTransition widget."""
+"""Tests for Collapsible widget."""
 
 from contextlib import contextmanager
 from typing import Callable, Generator
 
 from nuiitivet.animation.motion import LinearMotion
+from nuiitivet.layout.collapsible import Collapsible
 from nuiitivet.observable import runtime as observable_runtime
 from nuiitivet.observable.value import _ObservableValue
 from nuiitivet.rendering.sizing import Sizing
-from nuiitivet.widgets import SizeTransition
 from nuiitivet.widgets.box import Box
 
 # ---------------------------------------------------------------------------
@@ -75,25 +75,25 @@ def _make_child(w: int = 100, h: int = 50) -> Box:
 
 def test_initial_size_snaps_to_natural_without_animation() -> None:
     with _fake_clock():
-        widget = SizeTransition(_make_child(100, 50))
+        widget = Collapsible(_make_child(100, 50))
         widget.mount(_DummyApp())
         assert widget.preferred_size() == (100, 50)
 
 
-def test_condition_false_collapses_initial_size() -> None:
+def test_opened_false_collapses_initial_size() -> None:
     with _fake_clock():
-        widget = SizeTransition(_make_child(100, 50), condition=False)
+        widget = Collapsible(_make_child(100, 50), opened=False)
         widget.mount(_DummyApp())
         assert widget.preferred_size() == (0, 0)
 
 
 def test_axis_horizontal_only_animates_width() -> None:
     with _fake_clock():
-        cond = _ObservableValue(True)
-        widget = SizeTransition(_make_child(100, 50), condition=cond, axis="horizontal")
+        opened = _ObservableValue(True)
+        widget = Collapsible(_make_child(100, 50), opened=opened, axis="horizontal")
         widget.mount(_DummyApp())
         # Height passes through unchanged immediately even mid-animation.
-        cond.value = False
+        opened.value = False
         widget.preferred_size()
         _, h = widget.preferred_size()
         assert h == 50
@@ -104,19 +104,19 @@ def test_axis_horizontal_only_animates_width() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_condition_toggle_animates_width_to_zero() -> None:
+def test_opened_toggle_animates_width_to_zero() -> None:
     with _fake_clock() as clock:
-        cond = _ObservableValue(True)
-        widget = SizeTransition(
+        opened = _ObservableValue(True)
+        widget = Collapsible(
             _make_child(100, 50),
-            condition=cond,
+            opened=opened,
             axis="horizontal",
             motion=LinearMotion(0.2),
         )
         widget.mount(_DummyApp())
         assert widget.preferred_size()[0] == 100
 
-        cond.value = False
+        opened.value = False
         widget.preferred_size()  # triggers retarget to 0
         clock.advance_frames(6)  # ~0.1s of 0.2s
         mid_w = widget.preferred_size()[0]
@@ -126,12 +126,12 @@ def test_condition_toggle_animates_width_to_zero() -> None:
         assert widget.preferred_size()[0] == 0
 
 
-def test_distinct_motion_out_used_on_shrink() -> None:
+def test_distinct_motion_out_used_on_close() -> None:
     with _fake_clock() as clock:
-        cond = _ObservableValue(True)
-        widget = SizeTransition(
+        opened = _ObservableValue(True)
+        widget = Collapsible(
             _make_child(100, 50),
-            condition=cond,
+            opened=opened,
             axis="horizontal",
             motion=LinearMotion(1.0),
             motion_out=LinearMotion(0.1),
@@ -139,7 +139,7 @@ def test_distinct_motion_out_used_on_shrink() -> None:
         widget.mount(_DummyApp())
         widget.preferred_size()
 
-        cond.value = False
+        opened.value = False
         widget.preferred_size()
         # motion_out is fast (0.1s); after ~0.12s it should be fully collapsed.
         clock.advance_frames(8)
@@ -147,14 +147,14 @@ def test_distinct_motion_out_used_on_shrink() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Follow natural size changes (no condition)
+# Follow natural size changes (opened=True always)
 # ---------------------------------------------------------------------------
 
 
 def test_follows_child_natural_size_change() -> None:
     with _fake_clock() as clock:
         child = _make_child(100, 50)
-        widget = SizeTransition(child, motion=LinearMotion(0.2))
+        widget = Collapsible(child, motion=LinearMotion(0.2))
         widget.mount(_DummyApp())
         assert widget.preferred_size() == (100, 50)
 
@@ -171,16 +171,16 @@ def test_follows_child_natural_size_change() -> None:
 
 def test_unmount_stops_ticking_and_disposes() -> None:
     with _fake_clock() as clock:
-        cond = _ObservableValue(True)
-        widget = SizeTransition(
+        opened = _ObservableValue(True)
+        widget = Collapsible(
             _make_child(100, 50),
-            condition=cond,
+            opened=opened,
             axis="horizontal",
             motion=LinearMotion(0.5),
         )
         widget.mount(_DummyApp())
         widget.preferred_size()
-        cond.value = False
+        opened.value = False
         widget.preferred_size()
         clock.advance_frames(2)
         assert clock.active > 0


### PR DESCRIPTION
## Summary

Closes #222.

Replaces `SizeTransition` (added in #219) with `Collapsible`, a semantically clearer widget that expresses intent (open/close) rather than mechanism (size animation).

## Changes

### Added
- `src/nuiitivet/layout/collapsible.py` — `Collapsible` widget
- `tests/layout/test_collapsible.py` — 7 tests
- `Collapsible` exported from `nuiitivet/__init__.py`

### Removed
- `src/nuiitivet/widgets/size_transition.py`
- `tests/widgets/test_size_transition.py`
- `SizeTransition` export from `nuiitivet/widgets/__init__.py`

## Design Decisions

- **`opened` instead of `condition`** — aligns with expand/collapse mental model (`bool | Observable[bool]`)
- **Clip by default** — clipping is semantically required; no `.modifier(clip())` needed
- **Placed in `nuiitivet/layout/`** — consistent with other layout primitives