### PR TITLE
feat(material): add SplitButton widget (#89)

### DIFF
--- a/docs/md3/split-button.md
+++ b/docs/md3/split-button.md
@@ -1,0 +1,118 @@
+<!-- markdownlint-disable MD060 -->
+
+# Split Button MD3 Specs
+
+Source: <https://m3.material.io/components/split-button/specs>
+Collected: 2026-04-07
+
+## Summary
+
+- Tokens and specs expose five non-deprecated size token sets in order: Xsmall, Small, Medium, Large, Xlarge.
+- Each size set keeps `between-space` at 2dp and uses a fully rounded outer shape with size-specific inner corner behavior.
+- Inner corner sizes scale by size and increase for hovered/pressed states; selected trailing-button inner corner stays 50% across all sizes.
+- Measurements explicitly define unselected menu icon offset by size (XS/S -1dp, M -2dp, L -3dp, XL -6dp).
+- Measurements also state that split-button inner spacing should always be 2dp and that inner corner sizing varies by button size.
+
+## Tokens & Specs
+
+### Token sets discovered
+
+| Token set                    | Notes                                                    |
+|------------------------------|----------------------------------------------------------|
+| Split button - Size - Xsmall | Non-deprecated size token set under Tokens & specs menu. |
+| Split button - Size - Small  | Non-deprecated size token set under Tokens & specs menu. |
+| Split button - Size - Medium | Non-deprecated size token set under Tokens & specs menu. |
+| Split button - Size - Large  | Non-deprecated size token set under Tokens & specs menu. |
+| Split button - Size - Xlarge | Non-deprecated size token set under Tokens & specs menu. |
+
+### Extracted tokens
+
+| Token set                    | Group       | Label                                                          | Token                                                                         | Value                       | Notes                                                   |
+|------------------------------|-------------|----------------------------------------------------------------|-------------------------------------------------------------------------------|-----------------------------|---------------------------------------------------------|
+| Split button - Size - Xsmall | Size        | Split button xsmall container height                           | md.comp.split-button.xsmall.container.height                                  | 32dp                        |                                                         |
+| Split button - Size - Xsmall | Size        | Split button xsmall between space                              | md.comp.split-button.xsmall.between-space                                     | 2dp                         |                                                         |
+| Split button - Size - Xsmall | Shape       | Split button xsmall container shape                            | md.comp.split-button.xsmall.container.shape                                   | visual-only (shape preview) | No textual value exposed inline or via row interaction. |
+| Split button - Size - Xsmall | Shape       | Split button xsmall inner corner size                          | md.comp.split-button.xsmall.inner-corner.corner-size                          | 4dp                         |                                                         |
+| Split button - Size - Xsmall | Shape       | Split button xsmall outer corner size                          | md.comp.split-button.xsmall.outer-corner.corner-size                          | 50%                         | Present only in Xsmall token set on this page.          |
+| Split button - Size - Xsmall | Spacing     | Split button xsmall leading button leading space               | md.comp.split-button.xsmall.leading-button.leading-space                      | 12dp                        |                                                         |
+| Split button - Size - Xsmall | Spacing     | Split button xsmall leading button trailing space              | md.comp.split-button.xsmall.leading-button.trailing-space                     | 10dp                        |                                                         |
+| Split button - Size - Xsmall | Icon        | Split button xsmall trailing button icon size                  | md.comp.split-button.xsmall.trailing-button.icon.size                         | 22dp                        |                                                         |
+| Split button - Size - Xsmall | Spacing     | Split button xsmall trailing button leading space              | md.comp.split-button.xsmall.trailing-button.leading-space                     | 13dp                        |                                                         |
+| Split button - Size - Xsmall | Spacing     | Split button xsmall trailing button trailing space             | md.comp.split-button.xsmall.trailing-button.trailing-space                    | 13dp                        |                                                         |
+| Split button - Size - Xsmall | State shape | Split button xsmall inner corner hovered size                  | md.comp.split-button.xsmall.inner-corner.hovered.corner-size                  | 8dp                         |                                                         |
+| Split button - Size - Xsmall | State shape | Split button xsmall inner corner pressed size                  | md.comp.split-button.xsmall.inner-corner.pressed.corner-size                  | 8dp                         |                                                         |
+| Split button - Size - Xsmall | State shape | Split button xsmall trailing button inner corner selected size | md.comp.split-button.xsmall.trailing-button.inner-corner.selected.corner-size | 50%                         |                                                         |
+| Split button - Size - Small  | Size        | Split button small container height                            | md.comp.split-button.small.container.height                                   | 40dp                        |                                                         |
+| Split button - Size - Small  | Size        | Split button small between space                               | md.comp.split-button.small.between-space                                      | 2dp                         |                                                         |
+| Split button - Size - Small  | Shape       | Split button small container shape                             | md.comp.split-button.small.container.shape                                    | visual-only (shape preview) | No textual value exposed inline or via row interaction. |
+| Split button - Size - Small  | Shape       | Split button small inner corner size                           | md.comp.split-button.small.inner-corner.corner-size                           | 4dp                         |                                                         |
+| Split button - Size - Small  | Spacing     | Split button small leading button leading space                | md.comp.split-button.small.leading-button.leading-space                       | 16dp                        |                                                         |
+| Split button - Size - Small  | Spacing     | Split button small leading button trailing space               | md.comp.split-button.small.leading-button.trailing-space                      | 12dp                        |                                                         |
+| Split button - Size - Small  | Icon        | Split button small trailing button icon size                   | md.comp.split-button.small.trailing-button.icon.size                          | 22dp                        |                                                         |
+| Split button - Size - Small  | Spacing     | Split button small trailing button leading space               | md.comp.split-button.small.trailing-button.leading-space                      | 13dp                        |                                                         |
+| Split button - Size - Small  | Spacing     | Split button small trailing button trailing space              | md.comp.split-button.small.trailing-button.trailing-space                     | 13dp                        |                                                         |
+| Split button - Size - Small  | State shape | Split button small inner corner hovered size                   | md.comp.split-button.small.inner-corner.hovered.corner-size                   | 12dp                        |                                                         |
+| Split button - Size - Small  | State shape | Split button small inner corner pressed size                   | md.comp.split-button.small.inner-corner.pressed.corner-size                   | 12dp                        |                                                         |
+| Split button - Size - Small  | State shape | Split button small trailing button inner corner selected size  | md.comp.split-button.small.trailing-button.inner-corner.selected.corner-size  | 50%                         |                                                         |
+| Split button - Size - Medium | Size        | Split button medium container height                           | md.comp.split-button.medium.container.height                                  | 56dp                        |                                                         |
+| Split button - Size - Medium | Size        | Split button medium between space                              | md.comp.split-button.medium.between-space                                     | 2dp                         |                                                         |
+| Split button - Size - Medium | Shape       | Split button medium container shape                            | md.comp.split-button.medium.container.shape                                   | visual-only (shape preview) | No textual value exposed inline or via row interaction. |
+| Split button - Size - Medium | Shape       | Split button medium inner corner size                          | md.comp.split-button.medium.inner-corner.corner-size                          | 4dp                         |                                                         |
+| Split button - Size - Medium | Spacing     | Split button medium leading button leading space               | md.comp.split-button.medium.leading-button.leading-space                      | 24dp                        |                                                         |
+| Split button - Size - Medium | Spacing     | Split button medium leading button trailing space              | md.comp.split-button.medium.leading-button.trailing-space                     | 24dp                        |                                                         |
+| Split button - Size - Medium | Icon        | Split button medium trailing button icon size                  | md.comp.split-button.medium.trailing-button.icon.size                         | 26dp                        |                                                         |
+| Split button - Size - Medium | Spacing     | Split button medium trailing button leading space              | md.comp.split-button.medium.trailing-button.leading-space                     | 15dp                        |                                                         |
+| Split button - Size - Medium | Spacing     | Split button medium trailing button trailing space             | md.comp.split-button.medium.trailing-button.trailing-space                    | 15dp                        |                                                         |
+| Split button - Size - Medium | State shape | Split button medium inner corner hovered size                  | md.comp.split-button.medium.inner-corner.hovered.corner-size                  | 12dp                        |                                                         |
+| Split button - Size - Medium | State shape | Split button medium inner corner pressed size                  | md.comp.split-button.medium.inner-corner.pressed.corner-size                  | 12dp                        |                                                         |
+| Split button - Size - Medium | State shape | Split button medium trailing button inner corner selected size | md.comp.split-button.medium.trailing-button.inner-corner.selected.corner-size | 50%                         |                                                         |
+| Split button - Size - Large  | Size        | Split button large container height                            | md.comp.split-button.large.container.height                                   | 96dp                        |                                                         |
+| Split button - Size - Large  | Size        | Split button large between space                               | md.comp.split-button.large.between-space                                      | 2dp                         |                                                         |
+| Split button - Size - Large  | Shape       | Split button large container shape                             | md.comp.split-button.large.container.shape                                    | visual-only (shape preview) | No textual value exposed inline or via row interaction. |
+| Split button - Size - Large  | Shape       | Split button large inner corner size                           | md.comp.split-button.large.inner-corner.corner-size                           | 8dp                         |                                                         |
+| Split button - Size - Large  | Spacing     | Split button large leading button leading space                | md.comp.split-button.large.leading-button.leading-space                       | 48dp                        |                                                         |
+| Split button - Size - Large  | Spacing     | Split button large leading button trailing space               | md.comp.split-button.large.leading-button.trailing-space                      | 48dp                        |                                                         |
+| Split button - Size - Large  | Icon        | Split button large trailing button icon size                   | md.comp.split-button.large.trailing-button.icon.size                          | 38dp                        |                                                         |
+| Split button - Size - Large  | Spacing     | Split button large trailing button leading space               | md.comp.split-button.large.trailing-button.leading-space                      | 29dp                        |                                                         |
+| Split button - Size - Large  | Spacing     | Split button large trailing button trailing space              | md.comp.split-button.large.trailing-button.trailing-space                     | 29dp                        |                                                         |
+| Split button - Size - Large  | State shape | Split button large inner corner hovered size                   | md.comp.split-button.large.inner-corner.hovered.corner-size                   | 20dp                        |                                                         |
+| Split button - Size - Large  | State shape | Split button large inner corner pressed size                   | md.comp.split-button.large.inner-corner.pressed.corner-size                   | 20dp                        |                                                         |
+| Split button - Size - Large  | State shape | Split button large trailing button inner corner selected size  | md.comp.split-button.large.trailing-button.inner-corner.selected.corner-size  | 50%                         |                                                         |
+| Split button - Size - Xlarge | Size        | Split button xlarge container height                           | md.comp.split-button.xlarge.container.height                                  | 136dp                       |                                                         |
+| Split button - Size - Xlarge | Size        | Split button xlarge between space                              | md.comp.split-button.xlarge.between-space                                     | 2dp                         |                                                         |
+| Split button - Size - Xlarge | Shape       | Split button xlarge container shape                            | md.comp.split-button.xlarge.container.shape                                   | visual-only (shape preview) | No textual value exposed inline or via row interaction. |
+| Split button - Size - Xlarge | Shape       | Split button xlarge inner corner size                          | md.comp.split-button.xlarge.inner-corner.corner-size                          | 12dp                        |                                                         |
+| Split button - Size - Xlarge | Spacing     | Split button xlarge leading button leading space               | md.comp.split-button.xlarge.leading-button.leading-space                      | 64dp                        |                                                         |
+| Split button - Size - Xlarge | Spacing     | Split button xlarge leading button trailing space              | md.comp.split-button.xlarge.leading-button.trailing-space                     | 64dp                        |                                                         |
+| Split button - Size - Xlarge | Icon        | Split button xlarge trailing button icon size                  | md.comp.split-button.xlarge.trailing-button.icon.size                         | 50dp                        |                                                         |
+| Split button - Size - Xlarge | Spacing     | Split button xlarge trailing button leading space              | md.comp.split-button.xlarge.trailing-button.leading-space                     | 43dp                        |                                                         |
+| Split button - Size - Xlarge | Spacing     | Split button xlarge trailing button trailing space             | md.comp.split-button.xlarge.trailing-button.trailing-space                    | 43dp                        |                                                         |
+| Split button - Size - Xlarge | State shape | Split button xlarge inner corner hovered size                  | md.comp.split-button.xlarge.inner-corner.hovered.corner-size                  | 20dp                        |                                                         |
+| Split button - Size - Xlarge | State shape | Split button xlarge inner corner pressed size                  | md.comp.split-button.xlarge.inner-corner.pressed.corner-size                  | 20dp                        |                                                         |
+| Split button - Size - Xlarge | State shape | Split button xlarge trailing button inner corner selected size | md.comp.split-button.xlarge.trailing-button.inner-corner.selected.corner-size | 50%                         |                                                         |
+
+## Measurements
+
+| Category       | Item                              | Value                             | Notes                                       |
+|----------------|-----------------------------------|-----------------------------------|---------------------------------------------|
+| Configurations | Size configurations               | XS, S, M, L, XL                   | Listed in Configurations section.           |
+| Configurations | Color configurations              | Elevated, filled, tonal, outlined | Listed in Configurations section.           |
+| Measurements   | Menu icon offset (unselected, XS) | -1dp from center                  | Figure callout text.                        |
+| Measurements   | Menu icon offset (unselected, S)  | -1dp from center                  | Figure callout text.                        |
+| Measurements   | Menu icon offset (unselected, M)  | -2dp from center                  | Figure callout text.                        |
+| Measurements   | Menu icon offset (unselected, L)  | -3dp from center                  | Figure callout text.                        |
+| Measurements   | Menu icon offset (unselected, XL) | -6dp from center                  | Figure callout text.                        |
+| Measurements   | Inner spacing                     | 2dp                               | Explicit prose: space should always be 2dp. |
+| Measurements   | Inner corner size (extra small)   | 4dp                               | Figure callout text.                        |
+| Measurements   | Inner corner size (small)         | 4dp                               | Figure callout text.                        |
+| Measurements   | Inner corner size (medium)        | 4dp                               | Figure callout text.                        |
+| Measurements   | Inner corner size (large)         | 8dp                               | Figure callout text.                        |
+| Measurements   | Inner corner size (extra large)   | 12dp                              | Figure callout text.                        |
+
+## Implementation Notes
+
+- Drive split-button geometry from the size token set first (`xsmall` through `xlarge`), with a constant `between-space` of 2dp.
+- Keep leading/trailing horizontal spacing size-specific; those values increase significantly at Large and Xlarge and should not be derived from a simple linear scale.
+- Preserve state-specific inner corner transitions (`hovered` and `pressed`) and trailing-button selected inner corner (50%) for correct split-joint appearance.
+- Treat `container.shape` as preview-driven in this source; use concrete corner-size tokens where provided (`inner-corner` and Xsmall `outer-corner`) for implementation math.
+- Keep split-button color behavior aligned with standard button specs; selected state applies a state layer without changing the base color role.

--- a/samples/material_widgets/split_button.py
+++ b/samples/material_widgets/split_button.py
@@ -8,6 +8,8 @@ Demonstrates the M3 Expressive SplitButton with:
 
 from __future__ import annotations
 
+from typing import Callable
+
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
@@ -48,10 +50,14 @@ def _make_interactive_split_button() -> SplitButton:
     )
 
 
+def _make_action_callback(action: str) -> Callable[[], None]:
+    return lambda: _select_action(action)
+
+
 def _make_menu() -> Menu:
     """Build the dropdown menu for the interactive split button."""
     return Menu(
-        items=[MenuItem(a, on_click=lambda a=a: _select_action(a)) for a in _ACTIONS],
+        items=[MenuItem(a, on_click=_make_action_callback(a)) for a in _ACTIONS],
         on_dismiss=_close_menu,
     )
 

--- a/samples/material_widgets/split_button.py
+++ b/samples/material_widgets/split_button.py
@@ -1,0 +1,215 @@
+"""Material Widgets - SplitButton demo.
+
+Demonstrates the M3 Expressive SplitButton with:
+- Multiple size and variant presets displayed statically.
+- An interactive split button where the trailing button opens a menu,
+  and selecting a menu item changes the leading button label.
+"""
+
+from __future__ import annotations
+
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.container import Container
+from nuiitivet.layout.row import Row
+from nuiitivet.material import App, Menu, MenuItem, Text
+from nuiitivet.material.split_button import SplitButton
+from nuiitivet.material.styles.split_button_style import SplitButtonStyle
+from nuiitivet.modifiers import light_dismiss
+from nuiitivet.observable import Observable
+
+# ---------------------------------------------------------------------------
+# Interactive demo state
+# ---------------------------------------------------------------------------
+
+_ACTIONS = ["Start driving", "Navigate home", "Navigate to work", "Explore nearby"]
+
+_label: Observable[str] = Observable(_ACTIONS[0])
+_menu_open: Observable[bool] = Observable(False)
+
+
+def _close_menu() -> None:
+    _menu_open.value = False
+
+
+def _select_action(action: str) -> None:
+    _label.value = action
+    _close_menu()
+
+
+def _make_interactive_split_button() -> SplitButton:
+    """Build the interactive SplitButton bound to module-level observables."""
+    return SplitButton(
+        _label,
+        icon="directions_car",
+        on_click=lambda: print(f"Action: {_label.value}"),
+        on_menu_toggle=lambda open: setattr(_menu_open, "value", open),
+        menu_open=_menu_open,
+        style=SplitButtonStyle.filled("s"),
+    )
+
+
+def _make_menu() -> Menu:
+    """Build the dropdown menu for the interactive split button."""
+    return Menu(
+        items=[MenuItem(a, on_click=lambda a=a: _select_action(a)) for a in _ACTIONS],
+        on_dismiss=_close_menu,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interactive main content (uses overlay — for app.run())
+# ---------------------------------------------------------------------------
+
+
+def _build_interactive_content() -> Container:
+    split_btn = _make_interactive_split_button()
+    menu = _make_menu()
+
+    # Attach the menu as a light-dismiss popup anchored to the split button's
+    # trailing edge.  The menu aligns its top-left corner to the bottom-right
+    # of the split button with a 4dp gap.
+    anchored = split_btn.modifier(
+        light_dismiss(
+            menu,
+            is_open=_menu_open,
+            alignment="bottom-right",
+            anchor="top-right",
+            offset=(0.0, 4.0),
+        )
+    )
+
+    return Container(
+        padding=24,
+        child=Column(
+            gap=24,
+            cross_alignment="start",
+            children=[
+                Text("Interactive — click the trailing button to open the menu"),
+                anchored,
+                Text("Style variants (Small)"),
+                Row(
+                    gap=8,
+                    children=[
+                        SplitButton("Filled", icon="star", style=SplitButtonStyle.filled("s")),
+                        SplitButton("Tonal", icon="star", style=SplitButtonStyle.tonal("s")),
+                        SplitButton("Elevated", icon="star", style=SplitButtonStyle.elevated("s")),
+                        SplitButton("Outlined", icon="star", style=SplitButtonStyle.outlined("s")),
+                    ],
+                ),
+                Text("Size variants (filled)"),
+                Row(
+                    gap=8,
+                    cross_alignment="center",
+                    children=[
+                        SplitButton("XS", style=SplitButtonStyle.filled("xs")),
+                        SplitButton("S", style=SplitButtonStyle.filled("s")),
+                        SplitButton("M", style=SplitButtonStyle.filled("m")),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PNG screenshot content (static — overlay not captured by render_to_png)
+# ---------------------------------------------------------------------------
+
+
+def _build_png_content() -> Container:
+    """Build a static layout suitable for PNG rendering.
+
+    Uses a Column showing the split button above a static menu to mimic the
+    open-menu state since overlays are not captured by ``render_to_png``.
+    """
+    return Container(
+        padding=24,
+        child=Column(
+            gap=20,
+            cross_alignment="start",
+            children=[
+                Text("Style variants"),
+                Row(
+                    gap=8,
+                    children=[
+                        SplitButton("Filled", icon="star", style=SplitButtonStyle.filled("s")),
+                        SplitButton("Tonal", icon="star", style=SplitButtonStyle.tonal("s")),
+                        SplitButton("Elevated", icon="star", style=SplitButtonStyle.elevated("s")),
+                        SplitButton("Outlined", icon="star", style=SplitButtonStyle.outlined("s")),
+                    ],
+                ),
+                Text("Size variants (filled)"),
+                Row(
+                    gap=8,
+                    cross_alignment="center",
+                    children=[
+                        SplitButton("XS", style=SplitButtonStyle.filled("xs")),
+                        SplitButton("S", style=SplitButtonStyle.filled("s")),
+                        SplitButton("M", style=SplitButtonStyle.filled("m")),
+                        SplitButton("L", style=SplitButtonStyle.filled("l")),
+                    ],
+                ),
+                Text("With menu open (static preview)"),
+                Row(
+                    gap=8,
+                    cross_alignment="start",
+                    children=[
+                        Column(
+                            gap=4,
+                            cross_alignment="start",
+                            children=[
+                                SplitButton(
+                                    "Start driving",
+                                    icon="directions_car",
+                                    menu_open=True,
+                                    style=SplitButtonStyle.filled("s"),
+                                ),
+                                Menu(
+                                    items=[
+                                        MenuItem("Start driving"),
+                                        MenuItem("Navigate home"),
+                                        MenuItem("Navigate to work"),
+                                        MenuItem("Explore nearby"),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(png_path: str = "") -> None:
+    """Run the SplitButton demo.
+
+    Args:
+        png_path: If non-empty, render a static PNG to this path instead of
+            opening the interactive window.
+    """
+    if png_path:
+        app = App(
+            content=_build_png_content(),
+            title="SplitButton",
+            width=760,
+            height=600,
+        )
+        app.render_to_png(png_path)
+    else:
+        app = App(
+            content=_build_interactive_content(),
+            title="SplitButton",
+            width=760,
+            height=420,
+        )
+        app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docs/render_layout_images.py
+++ b/scripts/docs/render_layout_images.py
@@ -116,6 +116,7 @@ SAMPLES = [
     ("samples/material_widgets/icon_button.py", "material_widgets_icon_button.png"),
     ("samples/material_widgets/fab.py", "material_widgets_fab.png"),
     ("samples/material_widgets/button_group.py", "material_widgets_button_group.png"),
+    ("samples/material_widgets/split_button.py", "material_widgets_split_button.png"),
     ("samples/material_widgets/selection_controls.py", "material_widgets_selection_controls.png"),
     ("samples/material_widgets/slider.py", "material_widgets_slider.png"),
     ("samples/material_widgets/text_field.py", "material_widgets_text_field.png"),

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -57,6 +57,8 @@ if TYPE_CHECKING:
         StandardButtonGroupStyle,
         ConnectedButtonGroupStyle,
     )
+    from .split_button import SplitButton
+    from .styles.split_button_style import SplitButtonStyle
     from .transition_spec import MaterialTransitionSpec
     from nuiitivet.widgets.image import Image
 
@@ -133,6 +135,8 @@ __all__ = [
     "ConnectedButtonGroupStyle",
     "StandardButtonGroup",
     "ConnectedButtonGroup",
+    "SplitButton",
+    "SplitButtonStyle",
     "FadeIn",
     "FadeOut",
     "ScaleIn",
@@ -217,6 +221,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "ConnectedButtonGroupStyle": ("styles.button_group_style", "ConnectedButtonGroupStyle"),
     "StandardButtonGroup": ("button_group", "StandardButtonGroup"),
     "ConnectedButtonGroup": ("button_group", "ConnectedButtonGroup"),
+    "SplitButton": ("split_button", "SplitButton"),
+    "SplitButtonStyle": ("styles.split_button_style", "SplitButtonStyle"),
     "FadeIn": ("transitions", "FadeIn"),
     "FadeOut": ("transitions", "FadeOut"),
     "ScaleIn": ("transitions", "ScaleIn"),

--- a/src/nuiitivet/material/split_button.py
+++ b/src/nuiitivet/material/split_button.py
@@ -1,0 +1,714 @@
+"""Material Design 3 Expressive SplitButton widget.
+
+Provides a split button that combines a main action (leading button) with a
+menu trigger (trailing button).  The two halves share an animated inner corner
+junction that responds to hover and press interactions.  The trailing button's
+expand/collapse icon rotates 180° when the menu is toggled open.
+
+Component spec: https://m3.material.io/components/split-button/specs
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Tuple, TYPE_CHECKING
+
+from nuiitivet.animation import Animatable
+from nuiitivet.animation.converter import VectorConverter
+from nuiitivet.input.pointer import PointerEvent
+from nuiitivet.material.interactive_widget import InteractiveWidget
+from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL, EXPRESSIVE_DEFAULT_SPATIAL
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.observable import ObservableProtocol
+from nuiitivet.rendering.sizing import SizingLike
+from nuiitivet.theme.types import ColorSpec
+from nuiitivet.widgeting.callbacks import invoke_event_handler, VoidCallback, BoolCallback
+from nuiitivet.widgets.box import Box
+
+if TYPE_CHECKING:
+    from nuiitivet.material.styles.split_button_style import SplitButtonStyle
+    from nuiitivet.material.symbols import Symbol
+    from nuiitivet.widgeting.widget import Widget
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal corner-tuple animation converter
+# ---------------------------------------------------------------------------
+
+
+class _CornerTupleConverter(VectorConverter[Tuple[float, float, float, float]]):
+    """Animation vector converter for a 4-float corner-radius tuple."""
+
+    def to_vector(self, v: Tuple[float, float, float, float]) -> List[float]:
+        return [float(v[0]), float(v[1]), float(v[2]), float(v[3])]
+
+    def from_vector(self, vector: List[float]) -> Tuple[float, float, float, float]:
+        return (vector[0], vector[1], vector[2], vector[3])
+
+
+_CORNER_CONVERTER = _CornerTupleConverter()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_LEADING_CORNERS_IDLE_BASE = ("outer", "inner", "inner", "outer")
+"""Corner kinds for the leading button: (tl, tr, br, bl)."""
+
+_TRAILING_CORNERS_IDLE_BASE = ("inner", "outer", "outer", "inner")
+"""Corner kinds for the trailing button: (tl, tr, br, bl)."""
+
+
+def _snap_anim(
+    anim: "Animatable[Tuple[float, float, float, float]]",
+    value: Tuple[float, float, float, float],
+) -> None:
+    """Immediately snap a corner-radius animation to ``value`` without motion."""
+    anim.stop()
+    anim._value.value = value  # type: ignore[attr-defined]
+    anim._target = value  # type: ignore[attr-defined]
+    if anim._state is not None:  # type: ignore[attr-defined]
+        v = _CORNER_CONVERTER.to_vector(value)
+        state = anim._state  # type: ignore[attr-defined]
+        state.value = v.copy()
+        state.start = v.copy()
+        state.target = v.copy()
+
+
+# ---------------------------------------------------------------------------
+# _SplitLeadingButton
+# ---------------------------------------------------------------------------
+
+
+class _SplitLeadingButton(InteractiveWidget):
+    """Leading (main action) half of a :class:`SplitButton`.
+
+    Corners: ``(outer, inner, inner, outer)`` — fully-rounded left edges,
+    inner-corner right edges adjacent to the trailing button.
+
+    This class is private and should only be created by :class:`SplitButton`.
+    """
+
+    def __init__(
+        self,
+        child: "Widget",
+        style: "SplitButtonStyle",
+        on_click: Optional[VoidCallback] = None,
+        disabled: "bool | ObservableProtocol[bool]" = False,
+    ) -> None:
+        """Initialize the leading button segment.
+
+        Args:
+            child: Content widget (label, icon, or combined Row).
+            style: Shared :class:`SplitButtonStyle` instance.
+            on_click: Callback invoked when the leading button is clicked.
+            disabled: Whether the button is disabled.
+        """
+        self._style = style
+
+        # Interaction state
+        self._own_hovered: bool = False
+        self._own_pressed: bool = False
+        self._neighbor_hovered: bool = False
+        self._neighbor_pressed: bool = False
+
+        # Neighbor reference — set by SplitButton.on_mount()
+        self._neighbor: Optional["_SplitTrailingButton"] = None
+
+        outer = style.outer_corner_radius
+        inner = style.inner_corner_radius
+        initial_corners: Tuple[float, float, float, float] = (outer, inner, inner, outer)
+
+        self._corner_anim: "Animatable[Tuple[float, float, float, float]]" = Animatable.vector(
+            initial_value=initial_corners,
+            converter=_CORNER_CONVERTER,
+            motion=None,
+        )
+
+        padding = (style.leading_leading_space, 0, style.leading_trailing_space, 0)
+
+        super().__init__(
+            child=child,
+            on_click=on_click,
+            on_press=self._handle_press_down,
+            on_release=self._handle_press_up,
+            disabled=disabled,
+            height=style.container_height,
+            padding=padding,
+            background_color=style.background,
+            border_color=style.border_color,
+            border_width=style.border_width,
+            corner_radius=initial_corners,
+            state_layer_color=style.overlay_color or ColorRole.ON_SURFACE,
+            on_hover=self._handle_hover_change,
+        )
+        self._HOVER_OPACITY = style.overlay_alpha * 2 / 3
+        self._PRESS_OPACITY = style.overlay_alpha
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        """Subscribe to corner animation and enable expressive motion."""
+        super().on_mount()
+        self.bind(self._corner_anim.subscribe(self._on_corner_value_changed))
+        outer = self._style.outer_corner_radius
+        inner = self._style.inner_corner_radius
+        idle: Tuple[float, float, float, float] = (outer, inner, inner, outer)
+        _snap_anim(self._corner_anim, idle)
+        self._corner_anim._motion = EXPRESSIVE_FAST_SPATIAL  # type: ignore[attr-defined]
+        v0 = _CORNER_CONVERTER.to_vector(idle)
+        self._corner_anim._state = EXPRESSIVE_FAST_SPATIAL.create_state(v0, v0)  # type: ignore[attr-defined]
+        self.corner_radius = idle
+
+    # ------------------------------------------------------------------
+    # Interaction handlers
+    # ------------------------------------------------------------------
+
+    def _handle_hover_change(self, hovered: bool) -> None:
+        """React to own hover state changes."""
+        self._own_hovered = hovered
+        self._update_corner_target()
+        if self._neighbor is not None:
+            self._neighbor._on_neighbor_hover(hovered)
+
+    def _handle_press_down(self, event: PointerEvent) -> None:
+        """Start press shape animation and notify trailing neighbor."""
+        self._own_pressed = True
+        self._update_corner_target()
+        if self._neighbor is not None:
+            self._neighbor._on_neighbor_press(True)
+
+    def _handle_press_up(self, event: PointerEvent) -> None:
+        """Restore shape on release and notify trailing neighbor."""
+        self._own_pressed = False
+        self._update_corner_target()
+        if self._neighbor is not None:
+            self._neighbor._on_neighbor_press(False)
+
+    def _on_neighbor_hover(self, hovered: bool) -> None:
+        """Called by the trailing button when its hover state changes.
+
+        Args:
+            hovered: Whether the trailing button is now hovered.
+        """
+        self._neighbor_hovered = hovered
+        self._update_corner_target()
+
+    def _on_neighbor_press(self, pressed: bool) -> None:
+        """Called by the trailing button when its press state changes.
+
+        Args:
+            pressed: Whether the trailing button is now pressed.
+        """
+        self._neighbor_pressed = pressed
+        self._update_corner_target()
+
+    # ------------------------------------------------------------------
+    # Corner animation helpers
+    # ------------------------------------------------------------------
+
+    def _update_corner_target(self) -> None:
+        """Recompute and apply the corner animation target."""
+        self._corner_anim.target = self._compute_target_corners()
+
+    def _compute_target_corners(self) -> Tuple[float, float, float, float]:
+        """Compute the (tl, tr, br, bl) corner-radius tuple for the current state.
+
+        Returns:
+            Target corner radii in logical pixels.
+        """
+        outer = self._style.outer_corner_radius
+        inner = self._compute_active_inner_radius()
+        return (outer, inner, inner, outer)
+
+    def _compute_active_inner_radius(self) -> float:
+        """Return the currently active inner corner radius.
+
+        Priority: pressed > hovered > idle.
+
+        Returns:
+            Inner corner radius in logical pixels.
+        """
+        if self._own_pressed or self._neighbor_pressed:
+            return self._style.inner_corner_pressed_radius
+        if self._own_hovered or self._neighbor_hovered:
+            return self._style.inner_corner_hovered_radius
+        return self._style.inner_corner_radius
+
+    def _on_corner_value_changed(self, v: Tuple[float, float, float, float]) -> None:
+        """Animation tick: apply animated corners to the Box."""
+        self.corner_radius = v
+        self.invalidate()
+
+
+# ---------------------------------------------------------------------------
+# _SplitTrailingButton
+# ---------------------------------------------------------------------------
+
+
+class _SplitTrailingButton(InteractiveWidget):
+    """Trailing (menu trigger) half of a :class:`SplitButton`.
+
+    Corners: ``(inner, outer, outer, inner)`` — inner-corner left edges,
+    fully-rounded right edges.  When *selected* (menu open) all corners
+    become fully rounded.
+
+    The expand/collapse icon rotates inwards 180° when selected.
+    This class is private and should only be created by :class:`SplitButton`.
+    """
+
+    def __init__(
+        self,
+        style: "SplitButtonStyle",
+        on_menu_toggle: Optional[BoolCallback] = None,
+        menu_open: "bool | ObservableProtocol[bool]" = False,
+        disabled: "bool | ObservableProtocol[bool]" = False,
+    ) -> None:
+        """Initialize the trailing button segment.
+
+        Args:
+            style: Shared :class:`SplitButtonStyle` instance.
+            on_menu_toggle: Callback invoked with the new menu open state.
+            menu_open: Initial menu open (selected) state, or an observable.
+            disabled: Whether the button is disabled.
+        """
+        self._style = style
+        self._on_menu_toggle = on_menu_toggle
+
+        # Interaction state
+        self._own_hovered: bool = False
+        self._own_pressed: bool = False
+        self._neighbor_hovered: bool = False
+        self._neighbor_pressed: bool = False
+
+        # Selected state (menu open)
+        self._selected_external: "Optional[ObservableProtocol[bool]]" = None
+        if hasattr(menu_open, "subscribe") and hasattr(menu_open, "value"):
+            self._selected_external = menu_open  # type: ignore[assignment]
+            ext_obs: "ObservableProtocol[bool]" = self._selected_external  # type: ignore[assignment]
+            self._selected: bool = bool(ext_obs.value)
+        else:
+            self._selected = bool(menu_open)
+
+        # Neighbor reference — set by SplitButton.on_mount()
+        self._neighbor: Optional["_SplitLeadingButton"] = None
+
+        outer = style.outer_corner_radius
+        inner = style.inner_corner_radius
+        initial_corners: Tuple[float, float, float, float] = (inner, outer, outer, inner)
+
+        self._corner_anim: "Animatable[Tuple[float, float, float, float]]" = Animatable.vector(
+            initial_value=initial_corners,
+            converter=_CORNER_CONVERTER,
+            motion=None,
+        )
+
+        # Icon rotation animation: 0.0 (closed) → 180.0 (open).
+        self._rotation_anim: "Animatable[float]" = Animatable(
+            0.0 if not self._selected else 180.0,
+        )
+
+        content = self._build_content()
+
+        padding = (style.trailing_leading_space, 0, style.trailing_trailing_space, 0)
+
+        super().__init__(
+            child=content,
+            on_click=self._handle_click,
+            on_press=self._handle_press_down,
+            on_release=self._handle_press_up,
+            disabled=disabled,
+            height=style.container_height,
+            padding=padding,
+            background_color=style.background,
+            border_color=style.border_color,
+            border_width=style.border_width,
+            corner_radius=initial_corners,
+            state_layer_color=style.overlay_color or ColorRole.ON_SURFACE,
+            on_hover=self._handle_hover_change,
+        )
+        self._HOVER_OPACITY = style.overlay_alpha * 2 / 3
+        self._PRESS_OPACITY = style.overlay_alpha
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        """Subscribe to animations and external selected observable."""
+        super().on_mount()
+        self.bind(self._corner_anim.subscribe(self._on_corner_value_changed))
+        self.bind(self._rotation_anim.subscribe(lambda _: self.invalidate()))
+
+        idle = self._compute_target_corners()
+        _snap_anim(self._corner_anim, idle)
+        self._corner_anim._motion = EXPRESSIVE_FAST_SPATIAL  # type: ignore[attr-defined]
+        v0 = _CORNER_CONVERTER.to_vector(idle)
+        self._corner_anim._state = EXPRESSIVE_FAST_SPATIAL.create_state(v0, v0)  # type: ignore[attr-defined]
+        self.corner_radius = idle
+
+        # Arm rotation animation
+        self._rotation_anim._motion = EXPRESSIVE_DEFAULT_SPATIAL  # type: ignore[attr-defined]
+        rot_v = [self._rotation_anim.value]
+        self._rotation_anim._state = EXPRESSIVE_DEFAULT_SPATIAL.create_state(rot_v, rot_v)  # type: ignore[attr-defined]
+
+        # Subscribe to external menu_open observable
+        if self._selected_external is not None:
+            sub = self._selected_external.subscribe(lambda v: self._set_selected(bool(v)))
+            self.bind(sub)
+
+    # ------------------------------------------------------------------
+    # Interaction handlers
+    # ------------------------------------------------------------------
+
+    def _handle_hover_change(self, hovered: bool) -> None:
+        """React to own hover state changes."""
+        self._own_hovered = hovered
+        self._update_corner_target()
+        if self._neighbor is not None:
+            self._neighbor._on_neighbor_hover(hovered)
+
+    def _handle_press_down(self, event: PointerEvent) -> None:
+        """Start press animation and notify leading neighbor."""
+        self._own_pressed = True
+        self._update_corner_target()
+        if self._neighbor is not None:
+            self._neighbor._on_neighbor_press(True)
+
+    def _handle_press_up(self, event: PointerEvent) -> None:
+        """Restore shape on release and notify leading neighbor."""
+        self._own_pressed = False
+        self._update_corner_target()
+        if self._neighbor is not None:
+            self._neighbor._on_neighbor_press(False)
+
+    def _handle_click(self) -> None:
+        """Toggle menu open state and fire on_menu_toggle callback."""
+        if self.disabled:
+            return
+        new_selected = not self._selected
+        self._set_selected(new_selected)
+        if self._on_menu_toggle is not None:
+            invoke_event_handler(
+                self._on_menu_toggle,
+                new_selected,
+                error_key="split_button_trailing_on_menu_toggle",
+                error_msg="SplitButton on_menu_toggle raised",
+                owner_name=type(self).__name__,
+            )
+
+    def _on_neighbor_hover(self, hovered: bool) -> None:
+        """Called by the leading button when its hover state changes.
+
+        Args:
+            hovered: Whether the leading button is now hovered.
+        """
+        self._neighbor_hovered = hovered
+        self._update_corner_target()
+
+    def _on_neighbor_press(self, pressed: bool) -> None:
+        """Called by the leading button when its press state changes.
+
+        Args:
+            pressed: Whether the leading button is now pressed.
+        """
+        self._neighbor_pressed = pressed
+        self._update_corner_target()
+
+    # ------------------------------------------------------------------
+    # State management
+    # ------------------------------------------------------------------
+
+    def _set_selected(self, value: bool) -> None:
+        """Update the selected (menu open) state and trigger animations.
+
+        Args:
+            value: New selected state.
+        """
+        self._selected = bool(value)
+
+        # Write back to external observable if mutable
+        ext = self._selected_external
+        if ext is not None and hasattr(ext, "value"):
+            from nuiitivet.observable import ReadOnlyObservableProtocol
+
+            if not isinstance(ext, ReadOnlyObservableProtocol):
+                try:
+                    ext.value = bool(value)  # type: ignore[assignment]
+                except AttributeError:
+                    pass
+
+        self.state.selected = bool(value)
+        self._update_corner_target()
+        # Animate icon rotation: 0° closed, 180° open.
+        self._rotation_anim.target = 180.0 if self._selected else 0.0
+        self.invalidate()
+
+    # ------------------------------------------------------------------
+    # Corner animation helpers
+    # ------------------------------------------------------------------
+
+    def _update_corner_target(self) -> None:
+        """Recompute and apply the corner animation target."""
+        self._corner_anim.target = self._compute_target_corners()
+
+    def _compute_target_corners(self) -> Tuple[float, float, float, float]:
+        """Compute the (tl, tr, br, bl) corner-radius tuple for the current state.
+
+        When selected the trailing button becomes a fully-rounded pill
+        (all corners = outer_corner_radius).
+
+        Returns:
+            Target corner radii in logical pixels.
+        """
+        outer = self._style.outer_corner_radius
+        if self._selected:
+            # Trailing button selected: inner corners become fully rounded (50%).
+            return (outer, outer, outer, outer)
+        inner = self._compute_active_inner_radius()
+        return (inner, outer, outer, inner)
+
+    def _compute_active_inner_radius(self) -> float:
+        """Return the currently active inner corner radius.
+
+        Priority: pressed > hovered > idle.
+
+        Returns:
+            Inner corner radius in logical pixels.
+        """
+        if self._own_pressed or self._neighbor_pressed:
+            return self._style.inner_corner_pressed_radius
+        if self._own_hovered or self._neighbor_hovered:
+            return self._style.inner_corner_hovered_radius
+        return self._style.inner_corner_radius
+
+    def _on_corner_value_changed(self, v: Tuple[float, float, float, float]) -> None:
+        """Animation tick: apply animated corners to the Box."""
+        self.corner_radius = v
+        self.invalidate()
+
+    # ------------------------------------------------------------------
+    # Paint: icon rotation
+    # ------------------------------------------------------------------
+
+    def draw_children(self, canvas: Any, x: int, y: int, width: int, height: int) -> None:
+        """Draw children with icon rotation applied.
+
+        Rotates the canvas around the button centre by the current
+        rotation animation value.  The rotation is 0° when the menu is
+        closed and 180° when the menu is open.
+
+        Args:
+            canvas: Skia canvas.
+            x: Left edge in logical pixels.
+            y: Top edge in logical pixels.
+            width: Width in logical pixels.
+            height: Height in logical pixels.
+        """
+        angle = self._rotation_anim.value
+        if canvas is None:
+            super().draw_children(canvas, x, y, width, height)
+            return
+
+        cx = x + width / 2.0
+        cy = y + height / 2.0
+
+        if abs(angle) < 0.01:
+            super().draw_children(canvas, x, y, width, height)
+            return
+
+        try:
+            canvas.save()
+            canvas.translate(cx, cy)
+            canvas.rotate(angle)
+            canvas.translate(-cx, -cy)
+            super().draw_children(canvas, x, y, width, height)
+        finally:
+            canvas.restore()
+
+    # ------------------------------------------------------------------
+    # Content builder
+    # ------------------------------------------------------------------
+
+    def _build_content(self) -> "Widget":
+        """Build the trailing button's icon content.
+
+        Returns:
+            An :class:`Icon` widget for the expand/collapse indicator.
+        """
+        from nuiitivet.material.icon import Icon
+        from nuiitivet.material.styles.icon_style import IconStyle
+
+        fg = self._style.foreground or ColorRole.ON_SURFACE
+        return Icon(
+            "expand_more",
+            size=self._style.trailing_icon_size,
+            style=IconStyle(color=fg),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SplitButton
+# ---------------------------------------------------------------------------
+
+
+class SplitButton(Box):
+    """Material Design 3 Expressive Split Button.
+
+    Combines a leading button (main action) with a trailing button (menu
+    trigger).  The two halves share an animated inner corner junction that
+    morphs on hover and press.  The trailing button's icon rotates 180°
+    when the menu is opened.
+
+    Spec: https://m3.material.io/components/split-button/specs
+
+    Example::
+
+        SplitButton(
+            "Start",
+            icon="play_arrow",
+            on_click=lambda: start_action(),
+            on_menu_toggle=lambda open: handle_menu(open),
+            style=SplitButtonStyle.filled("s"),
+        )
+    """
+
+    def __init__(
+        self,
+        label: "str | Any | None" = None,
+        icon: "Symbol | str | Any | None" = None,
+        *,
+        on_click: Optional[VoidCallback] = None,
+        on_menu_toggle: Optional[BoolCallback] = None,
+        menu_open: "bool | ObservableProtocol[bool]" = False,
+        disabled: "bool | ObservableProtocol[bool]" = False,
+        width: SizingLike = None,
+        style: "Optional[SplitButtonStyle]" = None,
+    ) -> None:
+        """Initialize SplitButton.
+
+        Args:
+            label: Text label for the leading button.  Either ``label`` or
+                ``icon`` (or both) must be provided.
+            icon: Leading icon for the leading button.  Accepts a
+                :class:`Symbol`, a symbol name string, or a
+                :class:`ReadOnlyObservableProtocol`.
+            on_click: Callback invoked when the leading button is clicked.
+            on_menu_toggle: Callback invoked with the new ``bool`` menu open
+                state when the trailing button is clicked.
+            menu_open: Initial menu open (selected) state of the trailing
+                button.  Pass an :class:`ObservableProtocol` to bind
+                externally.
+            disabled: Disables both button halves when ``True``.
+            width: Optional width sizing for the overall widget.
+            style: Visual style.  Defaults to ``SplitButtonStyle.filled("s")``.
+        """
+        if label is None and icon is None:
+            raise ValueError("SplitButton requires at least one of label or icon")
+
+        from nuiitivet.material.styles.split_button_style import SplitButtonStyle as _Style
+
+        resolved_style: "SplitButtonStyle" = style or _Style.filled("s")
+
+        leading_child = self._build_leading_content(label, icon, resolved_style)
+
+        self._leading_btn = _SplitLeadingButton(
+            child=leading_child,
+            style=resolved_style,
+            on_click=on_click,
+            disabled=disabled,
+        )
+        self._trailing_btn = _SplitTrailingButton(
+            style=resolved_style,
+            on_menu_toggle=on_menu_toggle,
+            menu_open=menu_open,
+            disabled=disabled,
+        )
+
+        from nuiitivet.layout.row import Row
+
+        row = Row(
+            [self._leading_btn, self._trailing_btn],
+            gap=resolved_style.between_space,
+            cross_alignment="center",
+        )
+
+        super().__init__(child=row, width=width)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def on_mount(self) -> None:
+        """Wire neighbor references between leading and trailing buttons."""
+        super().on_mount()
+        self._leading_btn._neighbor = self._trailing_btn
+        self._trailing_btn._neighbor = self._leading_btn
+
+    # ------------------------------------------------------------------
+    # Content builder (leading button)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_leading_content(
+        label: Any,
+        icon: Any,
+        style: "SplitButtonStyle",
+    ) -> "Widget":
+        """Build the leading button content from label and/or icon.
+
+        Args:
+            label: Text label, or ``None``.
+            icon: Icon symbol / name, or ``None``.
+            style: Resolved :class:`SplitButtonStyle`.
+
+        Returns:
+            A widget representing the leading button content.
+        """
+        from nuiitivet.material.icon import Icon
+        from nuiitivet.material.text import Text
+        from nuiitivet.material.styles.icon_style import IconStyle
+        from nuiitivet.material.styles.text_style import TextStyle
+        from nuiitivet.layout.row import Row
+
+        fg: ColorSpec = style.foreground or ColorRole.ON_SURFACE
+
+        icon_w: Optional["Widget"] = None
+        text_w: Optional["Widget"] = None
+
+        if icon is not None:
+            icon_w = Icon(icon, size=style.icon_size, style=IconStyle(color=fg))
+
+        if label is not None:
+            text_w = Text(
+                label,
+                style=TextStyle(color=fg, font_size=style.label_font_size, text_alignment="center"),
+            )
+
+        if icon_w is not None and text_w is None:
+            return icon_w
+        if text_w is not None and icon_w is None:
+            return text_w
+        assert icon_w is not None and text_w is not None
+        return Row([icon_w, text_w], gap=8, cross_alignment="center")
+
+    # ------------------------------------------------------------------
+    # Public accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def menu_open(self) -> bool:
+        """Whether the menu is currently open (trailing button selected).
+
+        Returns:
+            ``True`` when the menu is open.
+        """
+        return self._trailing_btn._selected
+
+
+__all__ = ["SplitButton"]

--- a/src/nuiitivet/material/split_button.py
+++ b/src/nuiitivet/material/split_button.py
@@ -112,10 +112,6 @@ class _SplitLeadingButton(InteractiveWidget):
         # Interaction state
         self._own_hovered: bool = False
         self._own_pressed: bool = False
-        self._neighbor_pressed: bool = False
-
-        # Neighbor reference — set by SplitButton.on_mount()
-        self._neighbor: Optional["_SplitTrailingButton"] = None
 
         outer = style.outer_corner_radius
         inner = style.inner_corner_radius
@@ -174,26 +170,13 @@ class _SplitLeadingButton(InteractiveWidget):
         self._update_corner_target()
 
     def _handle_press_down(self, event: PointerEvent) -> None:
-        """Start press shape animation and notify trailing neighbor."""
+        """Start press shape animation."""
         self._own_pressed = True
         self._update_corner_target()
-        if self._neighbor is not None:
-            self._neighbor._on_neighbor_press(True)
 
     def _handle_press_up(self, event: PointerEvent) -> None:
-        """Restore shape on release and notify trailing neighbor."""
+        """Restore shape on release."""
         self._own_pressed = False
-        self._update_corner_target()
-        if self._neighbor is not None:
-            self._neighbor._on_neighbor_press(False)
-
-    def _on_neighbor_press(self, pressed: bool) -> None:
-        """Called by the trailing button when its press state changes.
-
-        Args:
-            pressed: Whether the trailing button is now pressed.
-        """
-        self._neighbor_pressed = pressed
         self._update_corner_target()
 
     # ------------------------------------------------------------------
@@ -222,7 +205,7 @@ class _SplitLeadingButton(InteractiveWidget):
         Returns:
             Inner corner radius in logical pixels.
         """
-        if self._own_pressed or self._neighbor_pressed:
+        if self._own_pressed:
             return self._style.inner_corner_pressed_radius
         if self._own_hovered:
             return self._style.inner_corner_hovered_radius
@@ -271,7 +254,6 @@ class _SplitTrailingButton(InteractiveWidget):
         # Interaction state
         self._own_hovered: bool = False
         self._own_pressed: bool = False
-        self._neighbor_pressed: bool = False
 
         # Selected state (menu open)
         self._selected_external: "Optional[ObservableProtocol[bool]]" = None
@@ -281,9 +263,6 @@ class _SplitTrailingButton(InteractiveWidget):
             self._selected: bool = bool(ext_obs.value)
         else:
             self._selected = bool(menu_open)
-
-        # Neighbor reference — set by SplitButton.on_mount()
-        self._neighbor: Optional["_SplitLeadingButton"] = None
 
         outer = style.outer_corner_radius
         inner = style.inner_corner_radius
@@ -359,18 +338,14 @@ class _SplitTrailingButton(InteractiveWidget):
         self._update_corner_target()
 
     def _handle_press_down(self, event: PointerEvent) -> None:
-        """Start press animation and notify leading neighbor."""
+        """Start press animation."""
         self._own_pressed = True
         self._update_corner_target()
-        if self._neighbor is not None:
-            self._neighbor._on_neighbor_press(True)
 
     def _handle_press_up(self, event: PointerEvent) -> None:
-        """Restore shape on release and notify leading neighbor."""
+        """Restore shape on release."""
         self._own_pressed = False
         self._update_corner_target()
-        if self._neighbor is not None:
-            self._neighbor._on_neighbor_press(False)
 
     def _handle_click(self) -> None:
         """Toggle menu open state and fire on_menu_toggle callback."""
@@ -386,15 +361,6 @@ class _SplitTrailingButton(InteractiveWidget):
                 error_msg="SplitButton on_menu_toggle raised",
                 owner_name=type(self).__name__,
             )
-
-    def _on_neighbor_press(self, pressed: bool) -> None:
-        """Called by the leading button when its press state changes.
-
-        Args:
-            pressed: Whether the leading button is now pressed.
-        """
-        self._neighbor_pressed = pressed
-        self._update_corner_target()
 
     # ------------------------------------------------------------------
     # State management
@@ -457,7 +423,7 @@ class _SplitTrailingButton(InteractiveWidget):
         Returns:
             Inner corner radius in logical pixels.
         """
-        if self._own_pressed or self._neighbor_pressed:
+        if self._own_pressed:
             return self._style.inner_corner_pressed_radius
         if self._own_hovered:
             return self._style.inner_corner_hovered_radius
@@ -615,16 +581,6 @@ class SplitButton(Box):
         )
 
         super().__init__(child=row, width=width)
-
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
-    def on_mount(self) -> None:
-        """Wire neighbor references between leading and trailing buttons."""
-        super().on_mount()
-        self._leading_btn._neighbor = self._trailing_btn
-        self._trailing_btn._neighbor = self._leading_btn
 
     # ------------------------------------------------------------------
     # Content builder (leading button)

--- a/src/nuiitivet/material/split_button.py
+++ b/src/nuiitivet/material/split_button.py
@@ -112,7 +112,6 @@ class _SplitLeadingButton(InteractiveWidget):
         # Interaction state
         self._own_hovered: bool = False
         self._own_pressed: bool = False
-        self._neighbor_hovered: bool = False
         self._neighbor_pressed: bool = False
 
         # Neighbor reference — set by SplitButton.on_mount()
@@ -173,8 +172,6 @@ class _SplitLeadingButton(InteractiveWidget):
         """React to own hover state changes."""
         self._own_hovered = hovered
         self._update_corner_target()
-        if self._neighbor is not None:
-            self._neighbor._on_neighbor_hover(hovered)
 
     def _handle_press_down(self, event: PointerEvent) -> None:
         """Start press shape animation and notify trailing neighbor."""
@@ -189,15 +186,6 @@ class _SplitLeadingButton(InteractiveWidget):
         self._update_corner_target()
         if self._neighbor is not None:
             self._neighbor._on_neighbor_press(False)
-
-    def _on_neighbor_hover(self, hovered: bool) -> None:
-        """Called by the trailing button when its hover state changes.
-
-        Args:
-            hovered: Whether the trailing button is now hovered.
-        """
-        self._neighbor_hovered = hovered
-        self._update_corner_target()
 
     def _on_neighbor_press(self, pressed: bool) -> None:
         """Called by the trailing button when its press state changes.
@@ -236,7 +224,7 @@ class _SplitLeadingButton(InteractiveWidget):
         """
         if self._own_pressed or self._neighbor_pressed:
             return self._style.inner_corner_pressed_radius
-        if self._own_hovered or self._neighbor_hovered:
+        if self._own_hovered:
             return self._style.inner_corner_hovered_radius
         return self._style.inner_corner_radius
 
@@ -283,7 +271,6 @@ class _SplitTrailingButton(InteractiveWidget):
         # Interaction state
         self._own_hovered: bool = False
         self._own_pressed: bool = False
-        self._neighbor_hovered: bool = False
         self._neighbor_pressed: bool = False
 
         # Selected state (menu open)
@@ -370,8 +357,6 @@ class _SplitTrailingButton(InteractiveWidget):
         """React to own hover state changes."""
         self._own_hovered = hovered
         self._update_corner_target()
-        if self._neighbor is not None:
-            self._neighbor._on_neighbor_hover(hovered)
 
     def _handle_press_down(self, event: PointerEvent) -> None:
         """Start press animation and notify leading neighbor."""
@@ -401,15 +386,6 @@ class _SplitTrailingButton(InteractiveWidget):
                 error_msg="SplitButton on_menu_toggle raised",
                 owner_name=type(self).__name__,
             )
-
-    def _on_neighbor_hover(self, hovered: bool) -> None:
-        """Called by the leading button when its hover state changes.
-
-        Args:
-            hovered: Whether the leading button is now hovered.
-        """
-        self._neighbor_hovered = hovered
-        self._update_corner_target()
 
     def _on_neighbor_press(self, pressed: bool) -> None:
         """Called by the leading button when its press state changes.
@@ -483,7 +459,7 @@ class _SplitTrailingButton(InteractiveWidget):
         """
         if self._own_pressed or self._neighbor_pressed:
             return self._style.inner_corner_pressed_radius
-        if self._own_hovered or self._neighbor_hovered:
+        if self._own_hovered:
             return self._style.inner_corner_hovered_radius
         return self._style.inner_corner_radius
 

--- a/src/nuiitivet/material/styles/split_button_style.py
+++ b/src/nuiitivet/material/styles/split_button_style.py
@@ -1,0 +1,279 @@
+"""Material Design 3 SplitButton style definitions.
+
+Provides :class:`SplitButtonStyle` with size-specific tokens sourced from the
+M3 Expressive split-button component spec:
+- https://m3.material.io/components/split-button/specs
+
+Four variant factory methods are available: ``filled``, ``elevated``,
+``tonal``, and ``outlined``.  Each accepts a :data:`ButtonSize` token
+(``"xs"``–``"xl"``) to select the corresponding M3 size token set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Optional, TypedDict
+
+from nuiitivet.material.styles.button_size import ButtonSize
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.theme.types import ColorSpec
+
+# ---------------------------------------------------------------------------
+# Size token table
+# ---------------------------------------------------------------------------
+
+
+class SplitButtonSizeTokens(TypedDict):
+    """Typed view over a single :data:`SPLIT_BUTTON_SIZE_TOKENS` row."""
+
+    container_height: int
+    between_space: int
+    outer_corner_radius: float
+    inner_corner_radius: float
+    inner_corner_hovered_radius: float
+    inner_corner_pressed_radius: float
+    leading_leading_space: int
+    leading_trailing_space: int
+    trailing_icon_size: int
+    trailing_leading_space: int
+    trailing_trailing_space: int
+    menu_icon_offset: int
+    label_font_size: int
+    icon_size: int
+
+
+SPLIT_BUTTON_SIZE_TOKENS: dict[ButtonSize, SplitButtonSizeTokens] = {
+    "xs": {
+        "container_height": 32,
+        "between_space": 2,
+        "outer_corner_radius": 16.0,
+        "inner_corner_radius": 4.0,
+        "inner_corner_hovered_radius": 8.0,
+        "inner_corner_pressed_radius": 8.0,
+        "leading_leading_space": 12,
+        "leading_trailing_space": 10,
+        "trailing_icon_size": 22,
+        "trailing_leading_space": 13,
+        "trailing_trailing_space": 13,
+        "menu_icon_offset": -1,
+        "label_font_size": 14,
+        "icon_size": 20,
+    },
+    "s": {
+        "container_height": 40,
+        "between_space": 2,
+        "outer_corner_radius": 20.0,
+        "inner_corner_radius": 4.0,
+        "inner_corner_hovered_radius": 12.0,
+        "inner_corner_pressed_radius": 12.0,
+        "leading_leading_space": 16,
+        "leading_trailing_space": 12,
+        "trailing_icon_size": 22,
+        "trailing_leading_space": 13,
+        "trailing_trailing_space": 13,
+        "menu_icon_offset": -1,
+        "label_font_size": 14,
+        "icon_size": 20,
+    },
+    "m": {
+        "container_height": 56,
+        "between_space": 2,
+        "outer_corner_radius": 28.0,
+        "inner_corner_radius": 4.0,
+        "inner_corner_hovered_radius": 12.0,
+        "inner_corner_pressed_radius": 12.0,
+        "leading_leading_space": 24,
+        "leading_trailing_space": 24,
+        "trailing_icon_size": 26,
+        "trailing_leading_space": 15,
+        "trailing_trailing_space": 15,
+        "menu_icon_offset": -2,
+        "label_font_size": 16,
+        "icon_size": 24,
+    },
+    "l": {
+        "container_height": 96,
+        "between_space": 2,
+        "outer_corner_radius": 48.0,
+        "inner_corner_radius": 8.0,
+        "inner_corner_hovered_radius": 20.0,
+        "inner_corner_pressed_radius": 20.0,
+        "leading_leading_space": 48,
+        "leading_trailing_space": 48,
+        "trailing_icon_size": 38,
+        "trailing_leading_space": 29,
+        "trailing_trailing_space": 29,
+        "menu_icon_offset": -3,
+        "label_font_size": 24,
+        "icon_size": 32,
+    },
+    "xl": {
+        "container_height": 136,
+        "between_space": 2,
+        "outer_corner_radius": 68.0,
+        "inner_corner_radius": 12.0,
+        "inner_corner_hovered_radius": 20.0,
+        "inner_corner_pressed_radius": 20.0,
+        "leading_leading_space": 64,
+        "leading_trailing_space": 64,
+        "trailing_icon_size": 50,
+        "trailing_leading_space": 43,
+        "trailing_trailing_space": 43,
+        "menu_icon_offset": -6,
+        "label_font_size": 32,
+        "icon_size": 40,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# SplitButtonStyle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SplitButtonStyle:
+    """Immutable style for :class:`SplitButton` (M3 Expressive-compliant).
+
+    Use the ``filled``, ``elevated``, ``tonal``, or ``outlined`` factory
+    classmethods rather than constructing directly where possible.
+
+    All size-related tokens are driven by :data:`SPLIT_BUTTON_SIZE_TOKENS`.
+    """
+
+    # Container colours
+    background: Optional[ColorSpec] = None
+    foreground: Optional[ColorSpec] = None
+    border_color: Optional[ColorSpec] = None
+    border_width: float = 0.0
+
+    # Elevation
+    elevation: int = 0
+
+    # State overlay
+    overlay_color: Optional[ColorSpec] = None
+    overlay_alpha: float = 0.12
+
+    # Size tokens (derived from SPLIT_BUTTON_SIZE_TOKENS)
+    container_height: int = 40
+    between_space: int = 2
+    outer_corner_radius: float = 20.0
+    inner_corner_radius: float = 4.0
+    inner_corner_hovered_radius: float = 12.0
+    inner_corner_pressed_radius: float = 12.0
+    leading_leading_space: int = 16
+    leading_trailing_space: int = 12
+    trailing_icon_size: int = 22
+    trailing_leading_space: int = 13
+    trailing_trailing_space: int = 13
+    menu_icon_offset: int = -1
+    label_font_size: int = 14
+    icon_size: int = 20
+
+    def copy_with(self, **changes) -> "SplitButtonStyle":
+        """Return a new style with the specified fields replaced.
+
+        Args:
+            **changes: Fields to override.
+
+        Returns:
+            A new :class:`SplitButtonStyle` instance.
+        """
+        return replace(self, **changes)
+
+    @classmethod
+    def filled(cls, size: ButtonSize = "s") -> "SplitButtonStyle":
+        """Create a filled-variant style.
+
+        Uses ``Primary`` as the container colour.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+
+        Returns:
+            A new :class:`SplitButtonStyle` instance.
+        """
+        t = SPLIT_BUTTON_SIZE_TOKENS[size]
+        return cls(
+            background=ColorRole.PRIMARY,
+            foreground=ColorRole.ON_PRIMARY,
+            border_width=0.0,
+            overlay_color=ColorRole.ON_PRIMARY,
+            overlay_alpha=0.12,
+            **t,
+        )
+
+    @classmethod
+    def elevated(cls, size: ButtonSize = "s") -> "SplitButtonStyle":
+        """Create an elevated-variant style.
+
+        Uses ``Surface`` as the container colour with elevation level 1.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+
+        Returns:
+            A new :class:`SplitButtonStyle` instance.
+        """
+        t = SPLIT_BUTTON_SIZE_TOKENS[size]
+        return cls(
+            background=ColorRole.SURFACE_CONTAINER_LOW,
+            foreground=ColorRole.PRIMARY,
+            border_width=0.0,
+            elevation=1,
+            overlay_color=ColorRole.PRIMARY,
+            overlay_alpha=0.08,
+            **t,
+        )
+
+    @classmethod
+    def tonal(cls, size: ButtonSize = "s") -> "SplitButtonStyle":
+        """Create a tonal-variant style.
+
+        Uses ``SecondaryContainer`` as the container colour.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+
+        Returns:
+            A new :class:`SplitButtonStyle` instance.
+        """
+        t = SPLIT_BUTTON_SIZE_TOKENS[size]
+        return cls(
+            background=ColorRole.SECONDARY_CONTAINER,
+            foreground=ColorRole.ON_SECONDARY_CONTAINER,
+            border_width=0.0,
+            overlay_color=ColorRole.ON_SECONDARY_CONTAINER,
+            overlay_alpha=0.12,
+            **t,
+        )
+
+    @classmethod
+    def outlined(cls, size: ButtonSize = "s") -> "SplitButtonStyle":
+        """Create an outlined-variant style.
+
+        Uses a transparent background with an ``Outline``-coloured border.
+
+        Args:
+            size: M3 size token preset (``"xs"``–``"xl"``).
+
+        Returns:
+            A new :class:`SplitButtonStyle` instance.
+        """
+        t = SPLIT_BUTTON_SIZE_TOKENS[size]
+        return cls(
+            background=None,
+            foreground=ColorRole.ON_SURFACE,
+            border_color=ColorRole.OUTLINE,
+            border_width=1.0,
+            overlay_color=ColorRole.PRIMARY,
+            overlay_alpha=0.08,
+            **t,
+        )
+
+
+__all__ = [
+    "SplitButtonSizeTokens",
+    "SPLIT_BUTTON_SIZE_TOKENS",
+    "SplitButtonStyle",
+]

--- a/tests/material/test_split_button.py
+++ b/tests/material/test_split_button.py
@@ -304,15 +304,18 @@ class TestCornerAnimation:
         assert tr == pytest.approx(pressed_r)
         assert br == pytest.approx(pressed_r)
 
-    def test_neighbor_hover_propagation(self):
+    def test_neighbor_hover_does_not_propagate(self):
+        # Hovering one button must NOT animate the neighbor's corners.
+        # Only press events propagate to the neighbor.
         btn = self._make_btn()
         style = btn._trailing_btn._style
-        hovered_r = style.inner_corner_hovered_radius
-        # Simulate leading button hover notification to trailing button
-        btn._trailing_btn._on_neighbor_hover(True)
+        inner_idle = style.inner_corner_radius
+        # Simulate leading button hover — trailing should stay at idle inner radius
+        btn._leading_btn._own_hovered = True
+        btn._leading_btn._update_corner_target()
         tl, tr, br, bl = btn._trailing_btn._compute_target_corners()
-        assert tl == pytest.approx(hovered_r)
-        assert bl == pytest.approx(hovered_r)
+        assert tl == pytest.approx(inner_idle)
+        assert bl == pytest.approx(inner_idle)
 
     def test_pressed_takes_priority_over_hovered(self):
         btn = self._make_btn()

--- a/tests/material/test_split_button.py
+++ b/tests/material/test_split_button.py
@@ -1,0 +1,379 @@
+"""Tests for SplitButton and SplitButtonStyle."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from nuiitivet.input.pointer import PointerEventType
+from nuiitivet.material.split_button import SplitButton
+from nuiitivet.material.styles.split_button_style import SplitButtonStyle, SPLIT_BUTTON_SIZE_TOKENS
+from nuiitivet.observable import Observable
+from tests.helpers.pointer import send_pointer_event_for_test
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mount(widget) -> None:
+    """Simulate mounting a widget and its children."""
+
+    class _FakeApp:
+        def invalidate(self) -> None:
+            pass
+
+        def request_focus(self, node, source=None) -> None:
+            pass
+
+    widget.mount(_FakeApp())
+
+
+def _click(widget) -> None:
+    send_pointer_event_for_test(widget, PointerEventType.PRESS)
+    send_pointer_event_for_test(widget, PointerEventType.RELEASE)
+
+
+# ===========================================================================
+# SplitButtonStyle — factory classmethods
+# ===========================================================================
+
+
+class TestSplitButtonStyle:
+    def test_filled_default_size(self):
+        style = SplitButtonStyle.filled()
+        assert style.container_height == SPLIT_BUTTON_SIZE_TOKENS["s"]["container_height"]
+        assert style.between_space == 2
+        assert style.background is not None
+
+    def test_filled_xs(self):
+        style = SplitButtonStyle.filled("xs")
+        t = SPLIT_BUTTON_SIZE_TOKENS["xs"]
+        assert style.container_height == t["container_height"]
+        assert style.outer_corner_radius == t["outer_corner_radius"]
+        assert style.inner_corner_radius == t["inner_corner_radius"]
+
+    def test_filled_xl(self):
+        style = SplitButtonStyle.filled("xl")
+        t = SPLIT_BUTTON_SIZE_TOKENS["xl"]
+        assert style.container_height == t["container_height"]
+        assert style.trailing_icon_size == t["trailing_icon_size"]
+
+    def test_elevated_has_elevation(self):
+        style = SplitButtonStyle.elevated()
+        assert style.elevation == 1
+
+    def test_tonal_factory(self):
+        style = SplitButtonStyle.tonal()
+        assert style.background is not None
+        assert style.border_width == 0.0
+
+    def test_outlined_has_border(self):
+        style = SplitButtonStyle.outlined()
+        assert style.border_color is not None
+        assert style.border_width == 1.0
+
+    def test_copy_with(self):
+        style = SplitButtonStyle.filled()
+        new_style = style.copy_with(label_font_size=20)
+        assert new_style.label_font_size == 20
+        assert style.label_font_size != 20
+
+    @pytest.mark.parametrize("size", ["xs", "s", "m", "l", "xl"])
+    def test_all_sizes_filled(self, size):
+        style = SplitButtonStyle.filled(size)
+        t = SPLIT_BUTTON_SIZE_TOKENS[size]
+        assert style.container_height == t["container_height"]
+        assert style.between_space == 2
+
+    @pytest.mark.parametrize("size", ["xs", "s", "m", "l", "xl"])
+    def test_inner_corner_hovered_ge_idle(self, size):
+        style = SplitButtonStyle.filled(size)
+        assert style.inner_corner_hovered_radius >= style.inner_corner_radius
+
+    @pytest.mark.parametrize("size", ["xs", "s", "m", "l", "xl"])
+    def test_outer_corner_radius_is_half_height(self, size):
+        style = SplitButtonStyle.filled(size)
+        t = SPLIT_BUTTON_SIZE_TOKENS[size]
+        assert style.outer_corner_radius == pytest.approx(t["outer_corner_radius"])
+
+
+# ===========================================================================
+# SplitButton — initialization
+# ===========================================================================
+
+
+class TestSplitButtonInit:
+    def test_requires_label_or_icon(self):
+        with pytest.raises(ValueError, match="at least one"):
+            SplitButton()
+
+    def test_label_only(self):
+        btn = SplitButton("Action")
+        assert btn is not None
+
+    def test_icon_only(self):
+        btn = SplitButton(icon="star")
+        assert btn is not None
+
+    def test_label_and_icon(self):
+        btn = SplitButton("Action", icon="star")
+        assert btn is not None
+
+    def test_default_menu_open_false(self):
+        btn = SplitButton("Action")
+        _mount(btn)
+        assert btn.menu_open is False
+
+    def test_initial_menu_open_true(self):
+        btn = SplitButton("Action", menu_open=True)
+        _mount(btn)
+        assert btn.menu_open is True
+
+    def test_default_style_is_filled_s(self):
+        btn = SplitButton("Action")
+        _mount(btn)
+        assert btn._trailing_btn._style.container_height == SPLIT_BUTTON_SIZE_TOKENS["s"]["container_height"]
+
+    def test_custom_style_applied(self):
+        style = SplitButtonStyle.tonal("m")
+        btn = SplitButton("Action", style=style)
+        _mount(btn)
+        assert btn._trailing_btn._style.container_height == SPLIT_BUTTON_SIZE_TOKENS["m"]["container_height"]
+
+
+# ===========================================================================
+# SplitButton — behavior
+# ===========================================================================
+
+
+class TestSplitButtonBehavior:
+    def test_leading_click_fires_on_click(self):
+        fired: List[None] = []
+        btn = SplitButton("Action", on_click=lambda: fired.append(None))
+        _mount(btn)
+        _click(btn._leading_btn)
+        assert len(fired) == 1
+
+    def test_leading_click_does_not_fire_on_menu_toggle(self):
+        toggle_calls: List[bool] = []
+        btn = SplitButton("Action", on_menu_toggle=lambda v: toggle_calls.append(v))
+        _mount(btn)
+        _click(btn._leading_btn)
+        assert len(toggle_calls) == 0
+
+    def test_trailing_click_toggles_menu_open(self):
+        btn = SplitButton("Action")
+        _mount(btn)
+        assert btn.menu_open is False
+        _click(btn._trailing_btn)
+        assert btn.menu_open is True
+        _click(btn._trailing_btn)
+        assert btn.menu_open is False
+
+    def test_trailing_click_fires_on_menu_toggle(self):
+        toggle_calls: List[bool] = []
+        btn = SplitButton("Action", on_menu_toggle=lambda v: toggle_calls.append(v))
+        _mount(btn)
+        _click(btn._trailing_btn)
+        assert toggle_calls == [True]
+        _click(btn._trailing_btn)
+        assert toggle_calls == [True, False]
+
+    def test_trailing_click_does_not_fire_on_click(self):
+        fired: List[None] = []
+        btn = SplitButton("Action", on_click=lambda: fired.append(None))
+        _mount(btn)
+        _click(btn._trailing_btn)
+        assert len(fired) == 0
+
+
+# ===========================================================================
+# SplitButton — observable menu_open
+# ===========================================================================
+
+
+class TestSplitButtonObservable:
+    def _make_obs(self, initial: bool):
+        class _Tmp:
+            x = Observable(initial)
+
+        return _Tmp().x
+
+    def test_external_observable_initial_state(self):
+        obs = self._make_obs(False)
+        btn = SplitButton("Action", menu_open=obs)
+        _mount(btn)
+        assert btn.menu_open is False
+
+    def test_external_observable_initial_state_true(self):
+        obs = self._make_obs(True)
+        btn = SplitButton("Action", menu_open=obs)
+        _mount(btn)
+        assert btn.menu_open is True
+
+
+# ===========================================================================
+# Corner animation state
+# ===========================================================================
+
+
+class TestCornerAnimation:
+    def _make_btn(self, size: str = "s") -> SplitButton:
+        btn = SplitButton("Action", style=SplitButtonStyle.filled(size))
+        _mount(btn)
+        return btn
+
+    def test_leading_idle_corners(self):
+        btn = self._make_btn()
+        style = btn._leading_btn._style
+        outer = style.outer_corner_radius
+        inner = style.inner_corner_radius
+        # Expect (outer, inner, inner, outer) at idle
+        tl, tr, br, bl = btn._leading_btn.corner_radius
+        assert tl == pytest.approx(outer)
+        assert tr == pytest.approx(inner)
+        assert br == pytest.approx(inner)
+        assert bl == pytest.approx(outer)
+
+    def test_trailing_idle_corners(self):
+        btn = self._make_btn()
+        style = btn._trailing_btn._style
+        outer = style.outer_corner_radius
+        inner = style.inner_corner_radius
+        # Expect (inner, outer, outer, inner) at idle
+        tl, tr, br, bl = btn._trailing_btn.corner_radius
+        assert tl == pytest.approx(inner)
+        assert tr == pytest.approx(outer)
+        assert br == pytest.approx(outer)
+        assert bl == pytest.approx(inner)
+
+    def test_trailing_selected_corners_are_fully_rounded(self):
+        btn = self._make_btn()
+        style = btn._trailing_btn._style
+        outer = style.outer_corner_radius
+        btn._trailing_btn._set_selected(True)
+        tl, tr, br, bl = btn._trailing_btn._compute_target_corners()
+        assert tl == pytest.approx(outer)
+        assert tr == pytest.approx(outer)
+        assert br == pytest.approx(outer)
+        assert bl == pytest.approx(outer)
+
+    def test_trailing_unselected_corners_use_inner_radius(self):
+        btn = self._make_btn()
+        style = btn._trailing_btn._style
+        inner = style.inner_corner_radius
+        outer = style.outer_corner_radius
+        btn._trailing_btn._set_selected(False)
+        tl, tr, br, bl = btn._trailing_btn._compute_target_corners()
+        assert tl == pytest.approx(inner)
+        assert tr == pytest.approx(outer)
+        assert br == pytest.approx(outer)
+        assert bl == pytest.approx(inner)
+
+    def test_leading_pressed_uses_pressed_inner_radius(self):
+        btn = self._make_btn()
+        style = btn._leading_btn._style
+        pressed_r = style.inner_corner_pressed_radius
+        outer = style.outer_corner_radius
+        btn._leading_btn._own_pressed = True
+        tl, tr, br, bl = btn._leading_btn._compute_target_corners()
+        assert tr == pytest.approx(pressed_r)
+        assert br == pytest.approx(pressed_r)
+        assert tl == pytest.approx(outer)
+        assert bl == pytest.approx(outer)
+
+    def test_leading_hovered_uses_hovered_inner_radius(self):
+        btn = self._make_btn()
+        style = btn._leading_btn._style
+        hovered_r = style.inner_corner_hovered_radius
+        btn._leading_btn._own_hovered = True
+        btn._leading_btn._own_pressed = False
+        tl, tr, br, bl = btn._leading_btn._compute_target_corners()
+        assert tr == pytest.approx(hovered_r)
+        assert br == pytest.approx(hovered_r)
+
+    def test_neighbor_press_propagation(self):
+        btn = self._make_btn()
+        style = btn._leading_btn._style
+        pressed_r = style.inner_corner_pressed_radius
+        # Simulate trailing button press notification to leading button
+        btn._leading_btn._on_neighbor_press(True)
+        tl, tr, br, bl = btn._leading_btn._compute_target_corners()
+        assert tr == pytest.approx(pressed_r)
+        assert br == pytest.approx(pressed_r)
+
+    def test_neighbor_hover_propagation(self):
+        btn = self._make_btn()
+        style = btn._trailing_btn._style
+        hovered_r = style.inner_corner_hovered_radius
+        # Simulate leading button hover notification to trailing button
+        btn._trailing_btn._on_neighbor_hover(True)
+        tl, tr, br, bl = btn._trailing_btn._compute_target_corners()
+        assert tl == pytest.approx(hovered_r)
+        assert bl == pytest.approx(hovered_r)
+
+    def test_pressed_takes_priority_over_hovered(self):
+        btn = self._make_btn()
+        style = btn._leading_btn._style
+        pressed_r = style.inner_corner_pressed_radius
+        btn._leading_btn._own_hovered = True
+        btn._leading_btn._own_pressed = True
+        r = btn._leading_btn._compute_active_inner_radius()
+        assert r == pytest.approx(pressed_r)
+
+    @pytest.mark.parametrize("size", ["xs", "s", "m", "l", "xl"])
+    def test_all_sizes_idle_leading_corners(self, size):
+        btn = SplitButton("Action", style=SplitButtonStyle.filled(size))
+        _mount(btn)
+        style = btn._leading_btn._style
+        outer = style.outer_corner_radius
+        inner = style.inner_corner_radius
+        tl, tr, br, bl = btn._leading_btn.corner_radius
+        assert tl == pytest.approx(outer)
+        assert tr == pytest.approx(inner)
+        assert br == pytest.approx(inner)
+        assert bl == pytest.approx(outer)
+
+
+# ===========================================================================
+# Icon rotation animation
+# ===========================================================================
+
+
+class TestIconRotation:
+    def test_initial_rotation_closed(self):
+        btn = SplitButton("Action")
+        _mount(btn)
+        assert btn._trailing_btn._rotation_anim.value == pytest.approx(0.0)
+
+    def test_initial_rotation_open(self):
+        btn = SplitButton("Action", menu_open=True)
+        _mount(btn)
+        assert btn._trailing_btn._rotation_anim.value == pytest.approx(180.0)
+
+    def test_rotation_target_set_on_select(self):
+        btn = SplitButton("Action")
+        _mount(btn)
+        btn._trailing_btn._set_selected(True)
+        assert btn._trailing_btn._rotation_anim.target == pytest.approx(180.0)
+
+    def test_rotation_target_reset_on_deselect(self):
+        btn = SplitButton("Action", menu_open=True)
+        _mount(btn)
+        btn._trailing_btn._set_selected(False)
+        assert btn._trailing_btn._rotation_anim.target == pytest.approx(0.0)
+
+
+# ===========================================================================
+# Neighbor wiring (on_mount)
+# ===========================================================================
+
+
+class TestNeighborWiring:
+    def test_neighbor_set_after_mount(self):
+        btn = SplitButton("Action")
+        _mount(btn)
+        assert btn._leading_btn._neighbor is btn._trailing_btn
+        assert btn._trailing_btn._neighbor is btn._leading_btn

--- a/tests/material/test_split_button.py
+++ b/tests/material/test_split_button.py
@@ -8,6 +8,7 @@ import pytest
 
 from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.material.split_button import SplitButton
+from nuiitivet.material.styles.button_size import ButtonSize
 from nuiitivet.material.styles.split_button_style import SplitButtonStyle, SPLIT_BUTTON_SIZE_TOKENS
 from nuiitivet.observable import Observable
 from tests.helpers.pointer import send_pointer_event_for_test
@@ -220,7 +221,7 @@ class TestSplitButtonObservable:
 
 
 class TestCornerAnimation:
-    def _make_btn(self, size: str = "s") -> SplitButton:
+    def _make_btn(self, size: ButtonSize = "s") -> SplitButton:
         btn = SplitButton("Action", style=SplitButtonStyle.filled(size))
         _mount(btn)
         return btn

--- a/tests/material/test_split_button.py
+++ b/tests/material/test_split_button.py
@@ -294,19 +294,20 @@ class TestCornerAnimation:
         assert tr == pytest.approx(hovered_r)
         assert br == pytest.approx(hovered_r)
 
-    def test_neighbor_press_propagation(self):
+    def test_neighbor_press_does_not_propagate(self):
+        # Pressing one button must NOT animate the neighbor's corners.
         btn = self._make_btn()
         style = btn._leading_btn._style
-        pressed_r = style.inner_corner_pressed_radius
-        # Simulate trailing button press notification to leading button
-        btn._leading_btn._on_neighbor_press(True)
-        tl, tr, br, bl = btn._leading_btn._compute_target_corners()
-        assert tr == pytest.approx(pressed_r)
-        assert br == pytest.approx(pressed_r)
+        inner_idle = style.inner_corner_radius
+        # Simulate leading button press — trailing should stay at idle inner radius
+        btn._leading_btn._own_pressed = True
+        btn._leading_btn._update_corner_target()
+        tl, tr, br, bl = btn._trailing_btn._compute_target_corners()
+        assert tl == pytest.approx(inner_idle)
+        assert bl == pytest.approx(inner_idle)
 
     def test_neighbor_hover_does_not_propagate(self):
         # Hovering one button must NOT animate the neighbor's corners.
-        # Only press events propagate to the neighbor.
         btn = self._make_btn()
         style = btn._trailing_btn._style
         inner_idle = style.inner_corner_radius
@@ -370,13 +371,13 @@ class TestIconRotation:
 
 
 # ===========================================================================
-# Neighbor wiring (on_mount)
+# Both halves are independent — no cross-propagation
 # ===========================================================================
 
 
-class TestNeighborWiring:
-    def test_neighbor_set_after_mount(self):
+class TestIndependentHalves:
+    def test_leading_and_trailing_mount_independently(self):
         btn = SplitButton("Action")
         _mount(btn)
-        assert btn._leading_btn._neighbor is btn._trailing_btn
-        assert btn._trailing_btn._neighbor is btn._leading_btn
+        assert btn._leading_btn is not None
+        assert btn._trailing_btn is not None


### PR DESCRIPTION
## Summary

Closes #89

Implements the Material Design 3 Expressive `SplitButton` component — a button that combines a main action (leading half) with a menu trigger (trailing half).

## Changes

### New files
- `src/nuiitivet/material/split_button.py` — `SplitButton` widget with two interactive halves
- `src/nuiitivet/material/styles/split_button_style.py` — `SplitButtonStyle` with xs/s/m/l/xl size tokens from the MD3 Expressive spec
- `tests/material/test_split_button.py` — 56 unit tests
- `samples/material_widgets/split_button.py` — interactive demo + PNG render route
- `docs/md3/split-button.md` — collected MD3 Expressive token spec

### Modified files
- `src/nuiitivet/material/__init__.py` — export `SplitButton`, `SplitButtonStyle`
- `scripts/docs/render_layout_images.py` — register `material_widgets_split_button.png`

## Implementation highlights

- **Shape**: Leading button uses corners `(outer, inner, inner, outer)`; trailing button `(inner, outer, outer, inner)`. When the trailing button is selected (menu open), its inner corners animate to fully rounded (`outer_corner_radius`), forming a pill.
- **Animation**: Each half responds only to its own hover/press state. No cross-button propagation, matching the MD3 Expressive spec.
- **Icon rotation**: The `expand_more` icon rotates 180° on open/close via `EXPRESSIVE_DEFAULT_SPATIAL`.
- **Variants**: `filled()`, `elevated()`, `tonal()`, `outlined()` — all 5 sizes (xs/s/m/l/xl).
- **Observable support**: `menu_open` accepts `ObservableProtocol[bool]` for external state binding.

## Testing

```
uv run pytest tests/material/test_split_button.py   # 56 passed
uv run mypy src/nuiitivet/material/split_button.py src/nuiitivet/material/styles/split_button_style.py
uv run flake8 src/nuiitivet/material/split_button.py ...
```