### PR TITLE
feat(buttons): add ExtendedFab with collapse/expand morph

### DIFF
--- a/docs/md3/extended-fab.md
+++ b/docs/md3/extended-fab.md
@@ -1,0 +1,252 @@
+<!-- markdownlint-disable MD060 -->
+
+# Extended FABs MD3 Specs
+
+Source: <https://m3.material.io/components/extended-fab/specs>
+Collected: 2026-05-25
+
+## Summary
+
+- The active Extended FAB token viewer exposes nine expressive token sets: three size sets and six color mappings.
+- Resolved values below use the viewer's default Android / 1P Baseline / Light / Default-contrast context. The viewer also exposes Dark, Medium contrast, and High contrast variants.
+- The expressive size scale is 56dp small, 80dp medium, and 96dp large, with icon sizes of 24dp, 28dp, and 36dp and rounded corner sizes of 16dp, 20dp, and 28dp.
+- Small, medium, and large label text map to `md.sys.typescale.title-medium`, `md.sys.typescale.title-large`, and `md.sys.typescale.headline-small` respectively.
+- All six active color mappings share the same state behavior: enabled, focused, and pressed stay at 6dp elevation; hovered rises to 8dp; hover opacity is 0.08; focus and press opacity are 0.1.
+- The page's Measurements section explicitly states a 16dp outer margin. Other concrete size and padding values are sourced from the live size token sets because the measurement diagrams are image-first.
+
+## Tokens & Specs
+
+Deprecated compatibility rows embedded in the `Extended FAB - Color - Primary`, `Extended FAB - Color - Secondary`, and `Extended FAB - Color - Tertiary` viewers are omitted below.
+
+### Token sets discovered
+
+| Token set                              | Count | Notes                                                           |
+|----------------------------------------|------:|-----------------------------------------------------------------|
+| Extended FAB - Size - Small            |     7 | Expressive small extended FAB size tokens.                      |
+| Extended FAB - Size - Medium           |     7 | Expressive medium extended FAB size tokens.                     |
+| Extended FAB - Size - Large            |     7 | Expressive large extended FAB size tokens.                      |
+| Extended FAB - Color - Tonal primary   |    20 | Primary-container mapping.                                      |
+| Extended FAB - Color - Tonal secondary |    20 | Secondary-container mapping.                                    |
+| Extended FAB - Color - Tonal tertiary  |    20 | Tertiary-container mapping.                                     |
+| Extended FAB - Color - Primary         |    20 | Solid primary mapping; deprecated compatibility rows omitted.   |
+| Extended FAB - Color - Secondary       |    20 | Solid secondary mapping; deprecated compatibility rows omitted. |
+| Extended FAB - Color - Tertiary        |    20 | Solid tertiary mapping; deprecated compatibility rows omitted.  |
+
+### Extended FAB - Size - Small
+
+| Token set                   | Group      | Label                               | Token                                       | Source token                  | Value                                | Notes                                                                        |
+|-----------------------------|------------|-------------------------------------|---------------------------------------------|-------------------------------|--------------------------------------|------------------------------------------------------------------------------|
+| Extended FAB - Size - Small | Layout     | Extended FAB small container height | md.comp.extended-fab.small.container.height |                               | 56dp                                 |                                                                              |
+| Extended FAB - Size - Small | Typography | Extended FAB small label text       | md.comp.extended-fab.small.label-text       | md.sys.typescale.title-medium | Google Sans Text / 500 / 16pt / 24pt | Composite typography token; tracking is not exposed in the resolved payload. |
+| Extended FAB - Size - Small | Layout     | Extended FAB small icon size        | md.comp.extended-fab.small.icon.size        |                               | 24dp                                 |                                                                              |
+| Extended FAB - Size - Small | Shape      | Extended FAB small container shape  | md.comp.extended-fab.small.container.shape  | md.sys.shape.corner.large     | 16dp                                 | Rounded corners.                                                             |
+| Extended FAB - Size - Small | Layout     | Extended FAB small leading space    | md.comp.extended-fab.small.leading-space    |                               | 16dp                                 |                                                                              |
+| Extended FAB - Size - Small | Layout     | Extended FAB small icon label space | md.comp.extended-fab.small.icon-label-space |                               | 8dp                                  |                                                                              |
+| Extended FAB - Size - Small | Layout     | Extended FAB small trailing space   | md.comp.extended-fab.small.trailing-space   |                               | 16dp                                 |                                                                              |
+
+### Extended FAB - Size - Medium
+
+| Token set                    | Group      | Label                                | Token                                        | Source token                        | Value                           | Notes                                                                        |
+|------------------------------|------------|--------------------------------------|----------------------------------------------|-------------------------------------|---------------------------------|------------------------------------------------------------------------------|
+| Extended FAB - Size - Medium | Layout     | Extended FAB medium container height | md.comp.extended-fab.medium.container.height |                                     | 80dp                            |                                                                              |
+| Extended FAB - Size - Medium | Typography | Extended FAB medium label text       | md.comp.extended-fab.medium.label-text       | md.sys.typescale.title-large        | Google Sans / 400 / 22pt / 28pt | Composite typography token; tracking is not exposed in the resolved payload. |
+| Extended FAB - Size - Medium | Layout     | Extended FAB medium icon size        | md.comp.extended-fab.medium.icon.size        |                                     | 28dp                            |                                                                              |
+| Extended FAB - Size - Medium | Shape      | Extended FAB medium container shape  | md.comp.extended-fab.medium.container.shape  | md.sys.shape.corner.large-increased | 20dp                            | Rounded corners.                                                             |
+| Extended FAB - Size - Medium | Layout     | Extended FAB medium leading space    | md.comp.extended-fab.medium.leading-space    |                                     | 26dp                            |                                                                              |
+| Extended FAB - Size - Medium | Layout     | Extended FAB medium icon label space | md.comp.extended-fab.medium.icon-label-space |                                     | 12dp                            |                                                                              |
+| Extended FAB - Size - Medium | Layout     | Extended FAB medium trailing space   | md.comp.extended-fab.medium.trailing-space   |                                     | 26dp                            |                                                                              |
+
+### Extended FAB - Size - Large
+
+| Token set                   | Group      | Label                               | Token                                       | Source token                    | Value                           | Notes                                                                        |
+|-----------------------------|------------|-------------------------------------|---------------------------------------------|---------------------------------|---------------------------------|------------------------------------------------------------------------------|
+| Extended FAB - Size - Large | Layout     | Extended FAB large container height | md.comp.extended-fab.large.container.height |                                 | 96dp                            |                                                                              |
+| Extended FAB - Size - Large | Typography | Extended FAB large label text       | md.comp.extended-fab.large.label-text       | md.sys.typescale.headline-small | Google Sans / 400 / 24pt / 32pt | Composite typography token; tracking is not exposed in the resolved payload. |
+| Extended FAB - Size - Large | Layout     | Extended FAB large icon size        | md.comp.extended-fab.large.icon.size        |                                 | 36dp                            |                                                                              |
+| Extended FAB - Size - Large | Shape      | Extended FAB large container shape  | md.comp.extended-fab.large.container.shape  | md.sys.shape.corner.extra-large | 28dp                            | Rounded corners.                                                             |
+| Extended FAB - Size - Large | Layout     | Extended FAB large leading space    | md.comp.extended-fab.large.leading-space    |                                 | 28dp                            |                                                                              |
+| Extended FAB - Size - Large | Layout     | Extended FAB large icon label space | md.comp.extended-fab.large.icon-label-space |                                 | 16dp                            |                                                                              |
+| Extended FAB - Size - Large | Layout     | Extended FAB large trailing space   | md.comp.extended-fab.large.trailing-space   |                                 | 28dp                            |                                                                              |
+
+### Extended FAB - Color - Tonal primary
+
+| Token set                            | Group   | Label                                                  | Token                                                              | Source token                             | Value   | Notes |
+|--------------------------------------|---------|--------------------------------------------------------|--------------------------------------------------------------------|------------------------------------------|---------|-------|
+| Extended FAB - Color - Tonal primary | Enabled | Extended FAB tonal primary container color             | md.comp.extended-fab.primary-container.container.color             | md.sys.color.primary-container           | #D3E3FD |       |
+| Extended FAB - Color - Tonal primary | Enabled | Extended FAB tonal primary container shadow color      | md.comp.extended-fab.primary-container.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| Extended FAB - Color - Tonal primary | Enabled | Extended FAB tonal primary label text color            | md.comp.extended-fab.primary-container.label-text.color            | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Enabled | Extended FAB tonal primary container icon color        | md.comp.extended-fab.primary-container.icon.color                  | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Hovered | Extended FAB tonal primary hovered state layer color   | md.comp.extended-fab.primary-container.hovered.state-layer.color   | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Hovered | Extended FAB tonal primary hovered label text color    | md.comp.extended-fab.primary-container.hovered.label-text.color    | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Hovered | Extended FAB tonal primary hovered icon color          | md.comp.extended-fab.primary-container.hovered.icon.color          | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Hovered | Extended FAB tonal primary hovered state layer opacity | md.comp.extended-fab.primary-container.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| Extended FAB - Color - Tonal primary | Hovered | Extended FAB tonal primary hovered container elevation | md.comp.extended-fab.primary-container.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| Extended FAB - Color - Tonal primary | Enabled | Extended FAB tonal primary container elevation         | md.comp.extended-fab.primary-container.container.elevation         | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal primary | Pressed | Extended FAB tonal primary pressed container elevation | md.comp.extended-fab.primary-container.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal primary | Pressed | Extended FAB tonal primary pressed state layer color   | md.comp.extended-fab.primary-container.pressed.state-layer.color   | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Pressed | Extended FAB tonal primary pressed state layer opacity | md.comp.extended-fab.primary-container.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| Extended FAB - Color - Tonal primary | Pressed | Extended FAB tonal primary pressed label text color    | md.comp.extended-fab.primary-container.pressed.label-text.color    | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Pressed | Extended FAB tonal primary pressed icon color          | md.comp.extended-fab.primary-container.pressed.icon.color          | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Focused | Extended FAB tonal primary focused container elevation | md.comp.extended-fab.primary-container.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal primary | Focused | Extended FAB tonal primary focused state layer color   | md.comp.extended-fab.primary-container.focused.state-layer.color   | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Focused | Extended FAB tonal primary focused state layer opacity | md.comp.extended-fab.primary-container.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| Extended FAB - Color - Tonal primary | Focused | Extended FAB tonal primary focused label text color    | md.comp.extended-fab.primary-container.focused.label-text.color    | md.sys.color.on-primary-container        | #0842A0 |       |
+| Extended FAB - Color - Tonal primary | Focused | Extended FAB tonal primary focused icon color          | md.comp.extended-fab.primary-container.focused.icon.color          | md.sys.color.on-primary-container        | #0842A0 |       |
+
+### Extended FAB - Color - Tonal secondary
+
+| Token set                              | Group   | Label                                                    | Token                                                                | Source token                             | Value   | Notes |
+|----------------------------------------|---------|----------------------------------------------------------|----------------------------------------------------------------------|------------------------------------------|---------|-------|
+| Extended FAB - Color - Tonal secondary | Enabled | Extended FAB tonal secondary container color             | md.comp.extended-fab.secondary-container.container.color             | md.sys.color.secondary-container         | #C2E7FF |       |
+| Extended FAB - Color - Tonal secondary | Enabled | Extended FAB tonal secondary container elevation         | md.comp.extended-fab.secondary-container.container.elevation         | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal secondary | Enabled | Extended FAB tonal secondary container shadow color      | md.comp.extended-fab.secondary-container.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| Extended FAB - Color - Tonal secondary | Enabled | Extended FAB tonal secondary label text color            | md.comp.extended-fab.secondary-container.label-text.color            | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Enabled | Extended FAB tonal secondary container icon color        | md.comp.extended-fab.secondary-container.icon.color                  | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Hovered | Extended FAB tonal secondary hovered container elevation | md.comp.extended-fab.secondary-container.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| Extended FAB - Color - Tonal secondary | Hovered | Extended FAB tonal secondary hovered state layer color   | md.comp.extended-fab.secondary-container.hovered.state-layer.color   | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Hovered | Extended FAB tonal secondary hovered state layer opacity | md.comp.extended-fab.secondary-container.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| Extended FAB - Color - Tonal secondary | Hovered | Extended FAB tonal secondary hovered label text color    | md.comp.extended-fab.secondary-container.hovered.label-text.color    | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Hovered | Extended FAB tonal secondary hovered icon color          | md.comp.extended-fab.secondary-container.hovered.icon.color          | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Focused | Extended FAB tonal secondary focused container elevation | md.comp.extended-fab.secondary-container.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal secondary | Focused | Extended FAB tonal secondary focused state layer color   | md.comp.extended-fab.secondary-container.focused.state-layer.color   | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Focused | Extended FAB tonal secondary focused state layer opacity | md.comp.extended-fab.secondary-container.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| Extended FAB - Color - Tonal secondary | Focused | Extended FAB tonal secondary focused label text color    | md.comp.extended-fab.secondary-container.focused.label-text.color    | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Focused | Extended FAB tonal secondary focused icon color          | md.comp.extended-fab.secondary-container.focused.icon.color          | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Pressed | Extended FAB tonal secondary pressed container elevation | md.comp.extended-fab.secondary-container.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal secondary | Pressed | Extended FAB tonal secondary pressed state layer color   | md.comp.extended-fab.secondary-container.pressed.state-layer.color   | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Pressed | Extended FAB tonal secondary pressed state layer opacity | md.comp.extended-fab.secondary-container.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| Extended FAB - Color - Tonal secondary | Pressed | Extended FAB tonal secondary pressed label text color    | md.comp.extended-fab.secondary-container.pressed.label-text.color    | md.sys.color.on-secondary-container      | #004A77 |       |
+| Extended FAB - Color - Tonal secondary | Pressed | Extended FAB tonal secondary pressed icon color          | md.comp.extended-fab.secondary-container.pressed.icon.color          | md.sys.color.on-secondary-container      | #004A77 |       |
+
+### Extended FAB - Color - Tonal tertiary
+
+| Token set                             | Group   | Label                                                   | Token                                                               | Source token                             | Value   | Notes |
+|---------------------------------------|---------|---------------------------------------------------------|---------------------------------------------------------------------|------------------------------------------|---------|-------|
+| Extended FAB - Color - Tonal tertiary | Enabled | Extended FAB tonal tertiary container color             | md.comp.extended-fab.tertiary-container.container.color             | md.sys.color.tertiary-container          | #C4EED0 |       |
+| Extended FAB - Color - Tonal tertiary | Enabled | Extended FAB tonal tertiary container elevation         | md.comp.extended-fab.tertiary-container.container.elevation         | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal tertiary | Enabled | Extended FAB tonal tertiary container shadow color      | md.comp.extended-fab.tertiary-container.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| Extended FAB - Color - Tonal tertiary | Enabled | Extended FAB tonal tertiary label text color            | md.comp.extended-fab.tertiary-container.label-text.color            | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Enabled | Extended FAB tonal tertiary container icon color        | md.comp.extended-fab.tertiary-container.icon.color                  | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Hovered | Extended FAB tonal tertiary hovered container elevation | md.comp.extended-fab.tertiary-container.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| Extended FAB - Color - Tonal tertiary | Hovered | Extended FAB tonal tertiary hovered state layer color   | md.comp.extended-fab.tertiary-container.hovered.state-layer.color   | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Hovered | Extended FAB tonal tertiary hovered state layer opacity | md.comp.extended-fab.tertiary-container.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| Extended FAB - Color - Tonal tertiary | Hovered | Extended FAB tonal tertiary hovered label text color    | md.comp.extended-fab.tertiary-container.hovered.label-text.color    | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Hovered | Extended FAB tonal tertiary hovered icon color          | md.comp.extended-fab.tertiary-container.hovered.icon.color          | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Focused | Extended FAB tonal tertiary focused container elevation | md.comp.extended-fab.tertiary-container.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal tertiary | Focused | Extended FAB tonal tertiary focused state layer color   | md.comp.extended-fab.tertiary-container.focused.state-layer.color   | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Focused | Extended FAB tonal tertiary focused state layer opacity | md.comp.extended-fab.tertiary-container.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| Extended FAB - Color - Tonal tertiary | Focused | Extended FAB tonal tertiary focused label text color    | md.comp.extended-fab.tertiary-container.focused.label-text.color    | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Focused | Extended FAB tonal tertiary focused icon color          | md.comp.extended-fab.tertiary-container.focused.icon.color          | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Pressed | Extended FAB tonal tertiary pressed container elevation | md.comp.extended-fab.tertiary-container.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tonal tertiary | Pressed | Extended FAB tonal tertiary pressed state layer color   | md.comp.extended-fab.tertiary-container.pressed.state-layer.color   | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Pressed | Extended FAB tonal tertiary pressed state layer opacity | md.comp.extended-fab.tertiary-container.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| Extended FAB - Color - Tonal tertiary | Pressed | Extended FAB tonal tertiary pressed label text color    | md.comp.extended-fab.tertiary-container.pressed.label-text.color    | md.sys.color.on-tertiary-container       | #0F5223 |       |
+| Extended FAB - Color - Tonal tertiary | Pressed | Extended FAB tonal tertiary pressed icon color          | md.comp.extended-fab.tertiary-container.pressed.icon.color          | md.sys.color.on-tertiary-container       | #0F5223 |       |
+
+### Extended FAB - Color - Primary
+
+| Token set                      | Group   | Label                                            | Token                                                    | Source token                             | Value   | Notes |
+|--------------------------------|---------|--------------------------------------------------|----------------------------------------------------------|------------------------------------------|---------|-------|
+| Extended FAB - Color - Primary | Enabled | Extended FAB primary container color             | md.comp.extended-fab.primary.container.color             | md.sys.color.primary                     | #0B57D0 |       |
+| Extended FAB - Color - Primary | Enabled | Extended FAB primary container elevation         | md.comp.extended-fab.primary.container.elevation         | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Primary | Enabled | Extended FAB primary container shadow color      | md.comp.extended-fab.primary.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| Extended FAB - Color - Primary | Enabled | Extended FAB primary label text color            | md.comp.extended-fab.primary.label-text.color            | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Enabled | Extended FAB primary container icon color        | md.comp.extended-fab.primary.icon.color                  | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Hovered | Extended FAB primary hovered container elevation | md.comp.extended-fab.primary.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| Extended FAB - Color - Primary | Hovered | Extended FAB primary hovered state layer color   | md.comp.extended-fab.primary.hovered.state-layer.color   | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Hovered | Extended FAB primary hovered state layer opacity | md.comp.extended-fab.primary.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| Extended FAB - Color - Primary | Hovered | Extended FAB primary hovered label text color    | md.comp.extended-fab.primary.hovered.label-text.color    | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Hovered | Extended FAB primary hovered icon color          | md.comp.extended-fab.primary.hovered.icon.color          | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Focused | Extended FAB primary focused container elevation | md.comp.extended-fab.primary.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Primary | Focused | Extended FAB primary focused state layer color   | md.comp.extended-fab.primary.focused.state-layer.color   | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Focused | Extended FAB primary focused state layer opacity | md.comp.extended-fab.primary.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| Extended FAB - Color - Primary | Focused | Extended FAB primary focused label text color    | md.comp.extended-fab.primary.focused.label-text.color    | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Focused | Extended FAB primary focused icon color          | md.comp.extended-fab.primary.focused.icon.color          | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Pressed | Extended FAB primary pressed container elevation | md.comp.extended-fab.primary.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Primary | Pressed | Extended FAB primary pressed state layer color   | md.comp.extended-fab.primary.pressed.state-layer.color   | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Pressed | Extended FAB primary pressed state layer opacity | md.comp.extended-fab.primary.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| Extended FAB - Color - Primary | Pressed | Extended FAB primary pressed label text color    | md.comp.extended-fab.primary.pressed.label-text.color    | md.sys.color.on-primary                  | #FFFFFF |       |
+| Extended FAB - Color - Primary | Pressed | Extended FAB primary pressed icon color          | md.comp.extended-fab.primary.pressed.icon.color          | md.sys.color.on-primary                  | #FFFFFF |       |
+
+### Extended FAB - Color - Secondary
+
+| Token set                        | Group   | Label                                              | Token                                                      | Source token                             | Value   | Notes |
+|----------------------------------|---------|----------------------------------------------------|------------------------------------------------------------|------------------------------------------|---------|-------|
+| Extended FAB - Color - Secondary | Enabled | Extended FAB secondary container color             | md.comp.extended-fab.secondary.container.color             | md.sys.color.secondary                   | #00639B |       |
+| Extended FAB - Color - Secondary | Enabled | Extended FAB secondary container elevation         | md.comp.extended-fab.secondary.container.elevation         | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Secondary | Enabled | Extended FAB secondary container shadow color      | md.comp.extended-fab.secondary.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| Extended FAB - Color - Secondary | Enabled | Extended FAB secondary label text color            | md.comp.extended-fab.secondary.label-text.color            | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Enabled | Extended FAB secondary container icon color        | md.comp.extended-fab.secondary.icon.color                  | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Pressed | Extended FAB secondary pressed container elevation | md.comp.extended-fab.secondary.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Secondary | Pressed | Extended FAB secondary pressed state layer color   | md.comp.extended-fab.secondary.pressed.state-layer.color   | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Pressed | Extended FAB secondary pressed state layer opacity | md.comp.extended-fab.secondary.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| Extended FAB - Color - Secondary | Pressed | Extended FAB secondary pressed label text color    | md.comp.extended-fab.secondary.pressed.label-text.color    | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Pressed | Extended FAB secondary pressed icon color          | md.comp.extended-fab.secondary.pressed.icon.color          | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Hovered | Extended FAB secondary hovered container elevation | md.comp.extended-fab.secondary.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| Extended FAB - Color - Secondary | Hovered | Extended FAB secondary hovered state layer color   | md.comp.extended-fab.secondary.hovered.state-layer.color   | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Hovered | Extended FAB secondary hovered state layer opacity | md.comp.extended-fab.secondary.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| Extended FAB - Color - Secondary | Hovered | Extended FAB secondary hovered label text color    | md.comp.extended-fab.secondary.hovered.label-text.color    | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Hovered | Extended FAB secondary hovered icon color          | md.comp.extended-fab.secondary.hovered.icon.color          | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Focused | Extended FAB secondary focused container elevation | md.comp.extended-fab.secondary.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Secondary | Focused | Extended FAB secondary focused state layer color   | md.comp.extended-fab.secondary.focused.state-layer.color   | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Focused | Extended FAB secondary focused state layer opacity | md.comp.extended-fab.secondary.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| Extended FAB - Color - Secondary | Focused | Extended FAB secondary focused label text color    | md.comp.extended-fab.secondary.focused.label-text.color    | md.sys.color.on-secondary                | #FFFFFF |       |
+| Extended FAB - Color - Secondary | Focused | Extended FAB secondary focused icon color          | md.comp.extended-fab.secondary.focused.icon.color          | md.sys.color.on-secondary                | #FFFFFF |       |
+
+### Extended FAB - Color - Tertiary
+
+| Token set                       | Group   | Label                                             | Token                                                     | Source token                             | Value   | Notes |
+|---------------------------------|---------|---------------------------------------------------|-----------------------------------------------------------|------------------------------------------|---------|-------|
+| Extended FAB - Color - Tertiary | Enabled | Extended FAB tertiary container color             | md.comp.extended-fab.tertiary.container.color             | md.sys.color.tertiary                    | #146C2E |       |
+| Extended FAB - Color - Tertiary | Enabled | Extended FAB tertiary container elevation         | md.comp.extended-fab.tertiary.container.elevation         | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tertiary | Enabled | Extended FAB tertiary container shadow color      | md.comp.extended-fab.tertiary.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| Extended FAB - Color - Tertiary | Enabled | Extended FAB tertiary label text color            | md.comp.extended-fab.tertiary.label-text.color            | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Enabled | Extended FAB tertiary container icon color        | md.comp.extended-fab.tertiary.icon.color                  | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Pressed | Extended FAB tertiary pressed container elevation | md.comp.extended-fab.tertiary.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tertiary | Pressed | Extended FAB tertiary pressed state layer color   | md.comp.extended-fab.tertiary.pressed.state-layer.color   | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Pressed | Extended FAB tertiary pressed state layer opacity | md.comp.extended-fab.tertiary.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| Extended FAB - Color - Tertiary | Pressed | Extended FAB tertiary pressed label text color    | md.comp.extended-fab.tertiary.pressed.label-text.color    | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Pressed | Extended FAB tertiary pressed icon color          | md.comp.extended-fab.tertiary.pressed.icon.color          | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Hovered | Extended FAB tertiary hovered container elevation | md.comp.extended-fab.tertiary.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| Extended FAB - Color - Tertiary | Hovered | Extended FAB tertiary hovered state layer color   | md.comp.extended-fab.tertiary.hovered.state-layer.color   | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Hovered | Extended FAB tertiary hovered state layer opacity | md.comp.extended-fab.tertiary.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| Extended FAB - Color - Tertiary | Hovered | Extended FAB tertiary hovered label text color    | md.comp.extended-fab.tertiary.hovered.label-text.color    | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Hovered | Extended FAB tertiary hovered icon color          | md.comp.extended-fab.tertiary.hovered.icon.color          | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Focused | Extended FAB tertiary focused container elevation | md.comp.extended-fab.tertiary.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| Extended FAB - Color - Tertiary | Focused | Extended FAB tertiary focused state layer color   | md.comp.extended-fab.tertiary.focused.state-layer.color   | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Focused | Extended FAB tertiary focused state layer opacity | md.comp.extended-fab.tertiary.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| Extended FAB - Color - Tertiary | Focused | Extended FAB tertiary focused label text color    | md.comp.extended-fab.tertiary.focused.label-text.color    | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| Extended FAB - Color - Tertiary | Focused | Extended FAB tertiary focused icon color          | md.comp.extended-fab.tertiary.focused.icon.color          | md.sys.color.on-tertiary                 | #FFFFFF |       |
+
+## Measurements
+
+| Category | Item                      | Value | Notes                                                       |
+|----------|---------------------------|-------|-------------------------------------------------------------|
+| Margin   | Extended FAB outer margin | 16dp  | Explicitly called out in the Measurements section.          |
+| Small    | Container height          | 56dp  | From the active `Extended FAB - Size - Small` token set.    |
+| Small    | Icon size                 | 24dp  | From the active `Extended FAB - Size - Small` token set.    |
+| Small    | Corner size               | 16dp  | Rounded corners from `md.sys.shape.corner.large`.           |
+| Small    | Leading space             | 16dp  | From the active `Extended FAB - Size - Small` token set.    |
+| Small    | Icon-label space          | 8dp   | From the active `Extended FAB - Size - Small` token set.    |
+| Small    | Trailing space            | 16dp  | From the active `Extended FAB - Size - Small` token set.    |
+| Medium   | Container height          | 80dp  | From the active `Extended FAB - Size - Medium` token set.   |
+| Medium   | Icon size                 | 28dp  | From the active `Extended FAB - Size - Medium` token set.   |
+| Medium   | Corner size               | 20dp  | Rounded corners from `md.sys.shape.corner.large-increased`. |
+| Medium   | Leading space             | 26dp  | From the active `Extended FAB - Size - Medium` token set.   |
+| Medium   | Icon-label space          | 12dp  | From the active `Extended FAB - Size - Medium` token set.   |
+| Medium   | Trailing space            | 26dp  | From the active `Extended FAB - Size - Medium` token set.   |
+| Large    | Container height          | 96dp  | From the active `Extended FAB - Size - Large` token set.    |
+| Large    | Icon size                 | 36dp  | From the active `Extended FAB - Size - Large` token set.    |
+| Large    | Corner size               | 28dp  | Rounded corners from `md.sys.shape.corner.extra-large`.     |
+| Large    | Leading space             | 28dp  | From the active `Extended FAB - Size - Large` token set.    |
+| Large    | Icon-label space          | 16dp  | From the active `Extended FAB - Size - Large` token set.    |
+| Large    | Trailing space            | 28dp  | From the active `Extended FAB - Size - Large` token set.    |
+
+## Implementation Notes
+
+- Treat the baseline extended FAB as deprecated. New work should target the expressive small, medium, and large size sets instead of the legacy baseline configuration.
+- Support six active color mappings: primary-container, secondary-container, tertiary-container, primary, secondary, and tertiary. The spec explicitly allows all six as equivalent contrast-safe styles.
+- Keep state-layer color aligned with the foreground icon and label-text color for the non-default mappings; the spec calls this out in the States guidance.
+- Hover is the only interaction state that changes elevation, rising from 6dp to 8dp. Focused and pressed preserve the base 6dp elevation and vary only the state-layer treatment.
+- Small/medium/large typography scales are materially different, so size changes should switch typography tokens rather than only scaling container dimensions.
+- The live token viewers for the solid primary, secondary, and tertiary mappings still contain deprecated compatibility rows; those values should not be wired into new expressive implementations.

--- a/samples/material_widgets/extended_fab.py
+++ b/samples/material_widgets/extended_fab.py
@@ -1,0 +1,82 @@
+"""Material Widgets - ExtendedFab with collapse/expand.
+
+Every ExtendedFab below toggles its own collapse/expand state when clicked,
+so the morph between the extended pill and the circular FAB can be observed
+directly for each colour mapping and size.
+"""
+
+from __future__ import annotations
+
+from nuiitivet.material import App, ExtendedFab, FabStyle, Text
+from nuiitivet.observable import Observable
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.container import Container
+from nuiitivet.layout.row import Row
+
+
+def _toggling_fab(label: str, icon: str, style: FabStyle) -> ExtendedFab:
+    """Return an ExtendedFab that toggles its own expanded state on click."""
+    expanded = Observable(True)
+    return ExtendedFab(
+        label,
+        icon=icon,
+        style=style,
+        expanded=expanded,
+        on_click=lambda: setattr(expanded, "value", not expanded.value),
+    )
+
+
+def main(png_path: str = "") -> None:
+    content = Container(
+        padding=24,
+        child=Column(
+            gap=16,
+            cross_alignment="start",
+            children=[
+                Text("Tonal color variants (size s) — click to collapse/expand"),
+                Row(
+                    gap=16,
+                    cross_alignment="center",
+                    children=[
+                        _toggling_fab("Compose", "edit", FabStyle.primary()),
+                        _toggling_fab("Share", "share", FabStyle.secondary()),
+                        _toggling_fab("Save", "save", FabStyle.tertiary()),
+                    ],
+                ),
+                Text("Solid color variants (size s) — click to collapse/expand"),
+                Row(
+                    gap=16,
+                    cross_alignment="center",
+                    children=[
+                        _toggling_fab("Compose", "edit", FabStyle.primary_solid()),
+                        _toggling_fab("Share", "share", FabStyle.secondary_solid()),
+                        _toggling_fab("Save", "save", FabStyle.tertiary_solid()),
+                    ],
+                ),
+                Text("Sizes (s / m / l) — click to collapse/expand"),
+                Row(
+                    gap=16,
+                    cross_alignment="center",
+                    children=[
+                        _toggling_fab("Compose", "edit", FabStyle.primary("s")),
+                        _toggling_fab("Compose", "edit", FabStyle.primary("m")),
+                        _toggling_fab("Compose", "edit", FabStyle.primary("l")),
+                    ],
+                ),
+            ],
+        ),
+    )
+    app = App(
+        content=content,
+        title="ExtendedFab",
+        width=660,
+        height=420,
+    )
+    if png_path:
+        app.render_to_png(png_path)
+    else:
+        app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from .divider import Divider
     from .buttons import (
         Button,
+        ExtendedFab,
         Fab,
         IconButton,
         IconToggleButton,
@@ -97,6 +98,7 @@ __all__ = [
     "Button",
     "ToggleButton",
     "Fab",
+    "ExtendedFab",
     "IconButton",
     "IconToggleButton",
     "ButtonStyle",
@@ -191,6 +193,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "Button": ("buttons", "Button"),
     "ToggleButton": ("buttons", "ToggleButton"),
     "Fab": ("buttons", "Fab"),
+    "ExtendedFab": ("buttons", "ExtendedFab"),
     "IconButton": ("buttons", "IconButton"),
     "IconToggleButton": ("buttons", "IconToggleButton"),
     "ButtonStyle": ("styles.button_style", "ButtonStyle"),

--- a/src/nuiitivet/material/buttons.py
+++ b/src/nuiitivet/material/buttons.py
@@ -10,6 +10,7 @@ This module contains the unified Material Design 3 button widgets:
   state tokens.
 - :class:`IconButton`, :class:`IconToggleButton` -- icon-only variants.
 - :class:`Fab` -- Floating Action Button.
+- :class:`ExtendedFab` -- Extended FAB with collapse/expand (icon + label).
 """
 
 from __future__ import annotations
@@ -21,8 +22,9 @@ from nuiitivet.common.logging_once import debug_once, exception_once
 from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
 from nuiitivet.widgeting.callbacks import invoke_event_handler, VoidCallback, BoolCallback
 from nuiitivet.animation import Animatable, LinearMotion, RgbaTupleConverter
-from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL
+from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL, EXPRESSIVE_FAST_SPATIAL
 from nuiitivet.material.styles.button_style import ButtonStyle, IconButtonStyle, IconToggleButtonStyle
+from nuiitivet.material.styles.button_size import EXTENDED_FAB_SIZE_TOKENS, FabSize
 from nuiitivet.material.styles.fab_style import FabStyle
 from nuiitivet.material.styles.toggle_button_style import ToggleButtonStyle
 from nuiitivet.material.theme.color_role import ColorRole
@@ -1043,59 +1045,22 @@ class IconToggleButton(ToggleButtonBase):
         return self._icon_toggle_style.selected if selected else self._icon_toggle_style.unselected
 
 
-class Fab(MaterialButtonBase):
-    """Material Design 3 Floating Action Button (FAB)."""
+class _FabBase(MaterialButtonBase):
+    """Shared behaviour for the FAB family (:class:`Fab`, :class:`ExtendedFab`).
 
-    def __init__(
-        self,
-        icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str],
-        *,
-        on_click: Optional[VoidCallback] = None,
-        disabled: bool | ObservableProtocol[bool] = False,
-        padding: Optional[Union[int, Tuple[int, int, int, int]]] = None,
-        style: Optional[FabStyle] = None,
-    ):
-        """Initialize Fab.
+    Centralises the elevation/state-layer token resolution and the expressive
+    press-scale animation so the public widgets do not duplicate it.
+    """
 
-        Args:
-            icon: Icon for the button.
-            on_click: Callback to be invoked when the button is clicked.
-            disabled: Whether the button is disabled.
-            padding: Padding specification.  When ``None``, ``style.padding``
-                is used.
-            style: FAB style preset.  Defaults to :meth:`FabStyle.primary`
-                (size ``"s"``, 56dp).  Use ``FabStyle.primary("m")`` /
-                ``FabStyle.primary("l")`` for the 80dp / 96dp variants, or
-                ``FabStyle.secondary`` / ``FabStyle.tertiary`` for alternative
-                tonal colour sets.
+    _user_style: FabStyle
+    _user_padding: Optional[Union[int, Tuple[int, int, int, int]]]
+    _user_height: Union[int, float]
+
+    def _setup_press_scale(self) -> None:
+        """Create and wire the expressive press-scale animations.
+
+        Subclasses must call this once at the end of ``__init__``.
         """
-        self._user_style: FabStyle = style if style is not None else FabStyle.primary()
-        self._user_padding = padding
-        size = self._user_style.container_height
-        self._user_height = size
-
-        effective_style = self.style
-        text_color = effective_style.foreground if effective_style else ColorRole.ON_PRIMARY_CONTAINER
-
-        child_widget = build_button_child(
-            None,
-            icon,
-            foreground=text_color,
-            button_height=size,
-            style=effective_style,
-        )
-
-        params = resolve_button_style_params(effective_style, padding, size, disabled)
-
-        super().__init__(
-            child=child_widget,
-            on_click=on_click,
-            width=size,
-            disabled=disabled,
-            **params,
-        )
-        self._sync_state_tokens()
-
         self._press_scale_x_anim: Animatable[float] = Animatable(1.0, motion=EXPRESSIVE_FAST_SPATIAL)
         self._press_scale_y_anim: Animatable[float] = Animatable(1.0, motion=EXPRESSIVE_FAST_SPATIAL)
         self.bind(self._press_scale_x_anim.subscribe(lambda _: self.invalidate()))
@@ -1186,3 +1151,251 @@ class Fab(MaterialButtonBase):
             super().paint(canvas, x, y, width, height)
         finally:
             canvas.restore()
+
+
+_FAB_HEIGHT_TO_SIZE: dict[int, FabSize] = {56: "s", 80: "m", 96: "l"}
+
+
+def _fab_size_from_height(height: int) -> FabSize:
+    """Map a FAB container height (dp) back to its size literal."""
+    return _FAB_HEIGHT_TO_SIZE.get(int(height), "s")
+
+
+class Fab(_FabBase):
+    """Material Design 3 Floating Action Button (FAB)."""
+
+    def __init__(
+        self,
+        icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str],
+        *,
+        on_click: Optional[VoidCallback] = None,
+        disabled: bool | ObservableProtocol[bool] = False,
+        padding: Optional[Union[int, Tuple[int, int, int, int]]] = None,
+        style: Optional[FabStyle] = None,
+    ):
+        """Initialize Fab.
+
+        Args:
+            icon: Icon for the button.
+            on_click: Callback to be invoked when the button is clicked.
+            disabled: Whether the button is disabled.
+            padding: Padding specification.  When ``None``, ``style.padding``
+                is used.
+            style: FAB style preset.  Defaults to :meth:`FabStyle.primary`
+                (size ``"s"``, 56dp).  Use ``FabStyle.primary("m")`` /
+                ``FabStyle.primary("l")`` for the 80dp / 96dp variants, or
+                ``FabStyle.secondary`` / ``FabStyle.tertiary`` for alternative
+                tonal colour sets.
+        """
+        self._user_style: FabStyle = style if style is not None else FabStyle.primary()
+        self._user_padding = padding
+        size = self._user_style.container_height
+        self._user_height = size
+
+        effective_style = self.style
+        text_color = effective_style.foreground if effective_style else ColorRole.ON_PRIMARY_CONTAINER
+
+        child_widget = build_button_child(
+            None,
+            icon,
+            foreground=text_color,
+            button_height=size,
+            style=effective_style,
+        )
+
+        params = resolve_button_style_params(effective_style, padding, size, disabled)
+
+        super().__init__(
+            child=child_widget,
+            on_click=on_click,
+            width=size,
+            disabled=disabled,
+            **params,
+        )
+        self._sync_state_tokens()
+        self._setup_press_scale()
+
+
+class ExtendedFab(_FabBase):
+    """Material Design 3 Extended FAB with a collapse/expand state.
+
+    A pill-shaped FAB carrying a required ``label`` and an optional leading
+    ``icon``.  The ``expanded`` observable morphs the button between the
+    extended pill (icon + label) and a collapsed circular FAB (icon only).
+    The width is content-driven when expanded and animates down to the
+    circular container footprint when collapsed.
+
+    When ``icon`` is omitted the collapse is a no-op: the button stays a
+    label pill because there is nothing to show in the circular footprint.
+    """
+
+    @property
+    def expanded(self) -> bool:
+        """Return whether the button is currently expanded (pill) state."""
+        if self._expanded_external is not None:
+            return bool(self._expanded_external.value)
+        return bool(self._expanded_internal)
+
+    @expanded.setter
+    def expanded(self, new_value: bool) -> None:
+        if self._expanded_external is not None:
+            try:
+                self._expanded_external.value = bool(new_value)
+            except Exception:
+                pass
+        else:
+            self._expanded_internal = bool(new_value)
+        self._update_morph_target()
+
+    def __init__(
+        self,
+        label: str | ReadOnlyObservableProtocol[str],
+        *,
+        icon: "Symbol" | str | ReadOnlyObservableProtocol["Symbol"] | ReadOnlyObservableProtocol[str] | None = None,
+        on_click: Optional[VoidCallback] = None,
+        expanded: bool | ObservableProtocol[bool] = True,
+        disabled: bool | ObservableProtocol[bool] = False,
+        style: Optional[FabStyle] = None,
+    ):
+        """Initialize ExtendedFab.
+
+        Args:
+            label: Required text label (string or observable).
+            icon: Optional leading icon.  When present, the collapsed state
+                shows it as a circular FAB; when absent, collapse is a no-op.
+            on_click: Callback invoked when the button is clicked.
+            expanded: Initial expanded state or external observable.  ``True``
+                (default) shows the icon + label pill; ``False`` collapses to
+                the circular FAB footprint.
+            disabled: Whether the button is disabled.
+            style: FAB style preset selecting the colour mapping and size.
+                Defaults to :meth:`FabStyle.primary` (size ``"s"``, 56dp).
+        """
+        base_style = style if style is not None else FabStyle.primary()
+        size = _fab_size_from_height(base_style.container_height)
+        ext = EXTENDED_FAB_SIZE_TOKENS[size]
+        self._container_height = ext["container_height"]
+
+        effective_style: FabStyle = base_style.copy_with(  # type: ignore[assignment]
+            label_font_size=ext["label_font_size"],
+            icon_size=ext["icon_size"],
+            corner_radius=ext["corner_radius"],
+            container_height=ext["container_height"],
+            spacing=ext["icon_label_space"],
+            padding=(ext["leading_space"], 0, ext["trailing_space"], 0),
+            min_width=ext["container_height"],
+            min_height=ext["container_height"],
+        )
+        self._user_style = effective_style
+        self._user_padding = None
+        self._user_height = self._container_height
+        self._has_icon = icon is not None
+
+        self._expanded_external: ObservableProtocol[bool] | None = None
+        if hasattr(expanded, "subscribe") and hasattr(expanded, "value"):
+            self._expanded_external = cast("ObservableProtocol[bool]", expanded)
+            self._expanded_internal = bool(self._expanded_external.value)
+        else:
+            self._expanded_internal = bool(expanded)
+
+        text_color = effective_style.foreground if effective_style else ColorRole.ON_PRIMARY_CONTAINER
+
+        child_widget = build_button_child(
+            label,
+            icon,
+            foreground=text_color,
+            button_height=self._container_height,
+            icon_position="leading",
+            spacing=ext["icon_label_space"],
+            style=effective_style,
+        )
+
+        params = resolve_button_style_params(effective_style, None, self._container_height, disabled)
+
+        super().__init__(
+            child=child_widget,
+            on_click=on_click,
+            width=None,
+            disabled=disabled,
+            **params,
+        )
+        # Clip the label as the container shrinks toward the circular footprint.
+        self.clip_content = True
+        self._sync_state_tokens()
+        self._setup_press_scale()
+
+        from nuiitivet.widgets.text import TextBase
+
+        self._label_widget: Optional[Widget] = next(
+            (w for w in self._foreground_targets if isinstance(w, TextBase)), None
+        )
+        self._label_base_rgba: Optional[Tuple[int, int, int, int]] = None
+
+        initial_t = 1.0 if self._effective_expanded() else 0.0
+        self._morph_anim: Animatable[float] = Animatable(initial_t, motion=EXPRESSIVE_DEFAULT_SPATIAL)
+        self.bind(self._morph_anim.subscribe(lambda _: self._on_morph_tick()))
+        self._apply_morph_label_alpha()
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        if self._expanded_external is not None:
+            self.observe(self._expanded_external, self._on_expanded_external_change)
+            self._update_morph_target()
+
+    def _on_expanded_external_change(self, _new_value: bool) -> None:
+        self._update_morph_target()
+
+    def _effective_expanded(self) -> bool:
+        """Return the resolved expanded state (collapse is a no-op without an icon)."""
+        return self.expanded or not self._has_icon
+
+    def _update_morph_target(self) -> None:
+        target = 1.0 if self._effective_expanded() else 0.0
+        if abs(self._morph_anim.target - target) > 1e-6:
+            self._morph_anim.target = target
+        self.mark_needs_layout()
+        self.invalidate()
+
+    def _on_morph_tick(self) -> None:
+        self._apply_morph_label_alpha()
+        self.mark_needs_layout()
+        self.invalidate()
+
+    def _apply_foreground_rgba(self, rgba: Tuple[int, int, int, int]) -> None:
+        super()._apply_foreground_rgba(rgba)
+        # Remember the fully-opaque foreground so the morph can re-derive the
+        # faded label colour without compounding the alpha each frame.
+        self._label_base_rgba = rgba
+        self._apply_morph_label_alpha()
+
+    def _apply_morph_label_alpha(self) -> None:
+        """Fade the label colour alpha in step with the collapse/expand morph."""
+        label = getattr(self, "_label_widget", None)
+        base = getattr(self, "_label_base_rgba", None)
+        morph = getattr(self, "_morph_anim", None)
+        if label is None or base is None or morph is None:
+            return
+        t = max(0.0, min(1.0, float(morph.value)))
+        r, g, b, a = base
+        new_color = (int(r), int(g), int(b), int(round(int(a) * t)))
+        try:
+            style: Any = label._style if getattr(label, "_style", None) is not None else label.style
+            label._style = style.copy_with(color=new_color)
+            label.invalidate()
+        except Exception:
+            exception_once(logger, "extended_fab_label_alpha_exc", "Failed to apply ExtendedFab label alpha")
+
+    def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> Tuple[int, int]:
+        # Full pill width (icon + label + leading/trailing space), independent of
+        # the current morph progress, then interpolate toward the circle.
+        full_w, _ = super().preferred_size(max_width=None, max_height=None)
+        circle = int(self._container_height)
+        t = max(0.0, min(1.0, float(self._morph_anim.value)))
+        w = int(round(circle + (int(full_w) - circle) * t))
+        w = max(circle, w)
+        h = circle
+        if max_width is not None:
+            w = min(w, int(max_width))
+        if max_height is not None:
+            h = min(h, int(max_height))
+        return w, h

--- a/src/nuiitivet/material/styles/button_size.py
+++ b/src/nuiitivet/material/styles/button_size.py
@@ -99,6 +99,8 @@ __all__ = [
     "FabSize",
     "FabSizeTokens",
     "FAB_SIZE_TOKENS",
+    "ExtendedFabSizeTokens",
+    "EXTENDED_FAB_SIZE_TOKENS",
 ]
 
 
@@ -202,5 +204,53 @@ FAB_SIZE_TOKENS: dict[FabSize, FabSizeTokens] = {
         "container_width": 96,
         "icon_size": 36,
         "corner_radius": 28,
+    },
+}
+
+
+class ExtendedFabSizeTokens(TypedDict):
+    """Typed view over a single :data:`EXTENDED_FAB_SIZE_TOKENS` row."""
+
+    container_height: int
+    icon_size: int
+    corner_radius: int
+    label_font_size: int
+    leading_space: int
+    icon_label_space: int
+    trailing_space: int
+
+
+# Values from https://m3.material.io/components/extended-fab/specs (expressive
+# small / medium / large size sets).  The baseline (legacy) configuration is
+# deprecated and intentionally excluded.  ``label_font_size`` follows the
+# resolved typescale tokens: title-medium (16) / title-large (22) /
+# headline-small (24).
+EXTENDED_FAB_SIZE_TOKENS: dict[FabSize, ExtendedFabSizeTokens] = {
+    "s": {
+        "container_height": 56,
+        "icon_size": 24,
+        "corner_radius": 16,
+        "label_font_size": 16,
+        "leading_space": 16,
+        "icon_label_space": 8,
+        "trailing_space": 16,
+    },
+    "m": {
+        "container_height": 80,
+        "icon_size": 28,
+        "corner_radius": 20,
+        "label_font_size": 22,
+        "leading_space": 26,
+        "icon_label_space": 12,
+        "trailing_space": 26,
+    },
+    "l": {
+        "container_height": 96,
+        "icon_size": 36,
+        "corner_radius": 28,
+        "label_font_size": 24,
+        "leading_space": 28,
+        "icon_label_space": 16,
+        "trailing_space": 28,
     },
 }

--- a/src/nuiitivet/material/styles/fab_style.py
+++ b/src/nuiitivet/material/styles/fab_style.py
@@ -1,11 +1,15 @@
 """Style preset for the Material Design 3 :class:`Fab` widget.
 
-``FabStyle`` is a thin :class:`ButtonStyle` subclass that exposes the three
-*tonal* color variants defined by the current MD3 spec:
+``FabStyle`` is a thin :class:`ButtonStyle` subclass that exposes the six
+active color mappings defined by the current MD3 spec -- three *tonal*
+container variants and three *solid* variants:
 
 - :meth:`FabStyle.primary` -- ``primary container`` / ``on primary container``
 - :meth:`FabStyle.secondary` -- ``secondary container`` / ``on secondary container``
 - :meth:`FabStyle.tertiary` -- ``tertiary container`` / ``on tertiary container``
+- :meth:`FabStyle.primary_solid` -- ``primary`` / ``on primary``
+- :meth:`FabStyle.secondary_solid` -- ``secondary`` / ``on secondary``
+- :meth:`FabStyle.tertiary_solid` -- ``tertiary`` / ``on tertiary``
 
 Each factory accepts a :data:`FabSize` (``"s"`` / ``"m"`` / ``"l"``) that
 selects container / icon / corner-radius tokens from
@@ -83,6 +87,36 @@ class FabStyle(ButtonStyle):
             background=ColorRole.TERTIARY_CONTAINER,
             foreground=ColorRole.ON_TERTIARY_CONTAINER,
             overlay_color=ColorRole.ON_TERTIARY_CONTAINER,
+            **cls._base(size),
+        )
+
+    @classmethod
+    def primary_solid(cls, size: FabSize = "s") -> "FabStyle":
+        """Return the solid-primary FAB style at the given size."""
+        return cls(
+            background=ColorRole.PRIMARY,
+            foreground=ColorRole.ON_PRIMARY,
+            overlay_color=ColorRole.ON_PRIMARY,
+            **cls._base(size),
+        )
+
+    @classmethod
+    def secondary_solid(cls, size: FabSize = "s") -> "FabStyle":
+        """Return the solid-secondary FAB style at the given size."""
+        return cls(
+            background=ColorRole.SECONDARY,
+            foreground=ColorRole.ON_SECONDARY,
+            overlay_color=ColorRole.ON_SECONDARY,
+            **cls._base(size),
+        )
+
+    @classmethod
+    def tertiary_solid(cls, size: FabSize = "s") -> "FabStyle":
+        """Return the solid-tertiary FAB style at the given size."""
+        return cls(
+            background=ColorRole.TERTIARY,
+            foreground=ColorRole.ON_TERTIARY,
+            overlay_color=ColorRole.ON_TERTIARY,
             **cls._base(size),
         )
 

--- a/src/nuiitivet/widgets/box.py
+++ b/src/nuiitivet/widgets/box.py
@@ -211,8 +211,11 @@ class Box(CachedPaintMixin, Widget):
             rect = self.last_rect
             if rect is None:
                 return None
-            rx, ry, rw, rh = rect
-            if not (rx <= x <= rx + rw and ry <= y <= ry + rh):
+            # ``x``/``y`` arrive in this widget's local coordinate space, so the
+            # clip bounds must be evaluated at the local origin (0, 0) using the
+            # widget's own size -- not ``last_rect``'s parent-relative offset.
+            _, _, rw, rh = rect
+            if not (0 <= x < rw and 0 <= y < rh):
                 return None
         return super().hit_test(x, y)
 

--- a/tests/material/test_extended_fab.py
+++ b/tests/material/test_extended_fab.py
@@ -1,0 +1,175 @@
+"""Unit tests for the ExtendedFab widget."""
+
+import pytest
+
+from nuiitivet.material.buttons import ExtendedFab
+from nuiitivet.material.icon import Icon
+from nuiitivet.material.styles.fab_style import FabStyle
+from nuiitivet.layout.row import Row
+from nuiitivet.observable import Observable
+from nuiitivet.widgets.text import TextBase
+
+
+def test_label_required():
+    """`label` is a required positional argument."""
+    with pytest.raises(TypeError):
+        ExtendedFab()  # type: ignore[call-arg]
+
+
+def test_icon_optional_builds_label_only_child():
+    """Without an icon the child is the bare label text."""
+    fab = ExtendedFab("Compose")
+    assert len(fab.children) == 1
+    assert isinstance(fab.children[0], TextBase)
+
+
+def test_icon_builds_leading_icon_and_label_row():
+    """With an icon the child is a Row of [icon, label]."""
+    fab = ExtendedFab("Compose", icon="edit")
+    assert isinstance(fab.children[0], Row)
+    row = fab.children[0]
+    assert isinstance(row.children[0], Icon)
+    assert isinstance(row.children[1], TextBase)
+
+
+def test_expanded_defaults_to_true():
+    fab = ExtendedFab("Compose", icon="edit")
+    assert fab.expanded is True
+
+
+def test_collapsed_preferred_size_is_circle():
+    """A collapsed ExtendedFab reports the circular container footprint."""
+    fab = ExtendedFab("Compose", icon="edit", expanded=False, style=FabStyle.primary("s"))
+    assert fab.preferred_size() == (56, 56)
+
+
+def test_collapsed_circle_tracks_size_preset():
+    """Collapsed footprint follows the size preset (s/m/l)."""
+    assert ExtendedFab("X", icon="edit", expanded=False, style=FabStyle.primary("m")).preferred_size() == (80, 80)
+    assert ExtendedFab("X", icon="edit", expanded=False, style=FabStyle.primary("l")).preferred_size() == (96, 96)
+
+
+def test_expanded_is_wider_than_collapsed():
+    """The expanded pill is content-driven and wider than the circle."""
+    fab = ExtendedFab("Compose", icon="edit", style=FabStyle.primary("s"))
+    width, height = fab.preferred_size()
+    assert height == 56
+    assert width > 56
+
+
+def test_internal_expanded_setter_retargets_morph():
+    """Toggling the `expanded` property retargets the morph animation."""
+    fab = ExtendedFab("Compose", icon="edit", expanded=True)
+    try:
+        assert fab._morph_anim.target == pytest.approx(1.0)
+        fab.expanded = False
+        assert fab._morph_anim.target == pytest.approx(0.0)
+        fab.expanded = True
+        assert fab._morph_anim.target == pytest.approx(1.0)
+    finally:
+        # Stop the global clock interval started by retargeting the morph.
+        fab._morph_anim.stop()
+
+
+def test_observable_expanded_drives_morph():
+    """An external observable drives collapse/expand after mount."""
+    expanded = Observable(True)
+    fab = ExtendedFab("Compose", icon="edit", expanded=expanded)
+    fab.on_mount()
+    try:
+        assert fab._morph_anim.target == pytest.approx(1.0)
+        expanded.value = False
+        assert fab._morph_anim.target == pytest.approx(0.0)
+        expanded.value = True
+        assert fab._morph_anim.target == pytest.approx(1.0)
+    finally:
+        fab._morph_anim.stop()
+
+
+def test_collapse_then_expand_roundtrips_width():
+    """Toggling the observable collapses, then expands the width back."""
+    expanded = Observable(True)
+    fab = ExtendedFab("Compose", icon="edit", expanded=expanded, style=FabStyle.primary("s"))
+    fab.on_mount()
+    try:
+        expanded_width = fab.preferred_size()[0]
+        assert expanded_width > 56
+
+        # Collapse and drive the morph to completion.
+        expanded.value = False
+        for _ in range(120):
+            fab._morph_anim._tick(1 / 60)
+        assert fab.preferred_size() == (56, 56)
+
+        # Expand again: the pill width must come back.
+        expanded.value = True
+        for _ in range(120):
+            fab._morph_anim._tick(1 / 60)
+        assert fab.preferred_size()[0] == expanded_width
+    finally:
+        fab._morph_anim.stop()
+
+
+def test_collapse_is_noop_without_icon():
+    """Without an icon, collapsing keeps the pill (no circular footprint)."""
+    fab = ExtendedFab("Compose", expanded=False)
+    assert fab._effective_expanded() is True
+    assert fab._morph_anim.value == pytest.approx(1.0)
+    # Preferred width stays content-driven (wider than any circle).
+    assert fab.preferred_size()[0] > 56
+
+
+def test_solid_style_variants_resolve():
+    """The six color mappings (tonal + solid) all construct."""
+    for style in (
+        FabStyle.primary(),
+        FabStyle.secondary(),
+        FabStyle.tertiary(),
+        FabStyle.primary_solid(),
+        FabStyle.secondary_solid(),
+        FabStyle.tertiary_solid(),
+    ):
+        fab = ExtendedFab("Compose", icon="edit", style=style)
+        assert fab.preferred_size()[1] == 56
+
+
+def test_disabled_flag_is_applied():
+    fab = ExtendedFab("Compose", icon="edit", disabled=True)
+    assert fab.disabled is True
+
+
+def test_click_fires_when_offset_inside_layout():
+    """The FAB stays clickable when laid out at a non-zero offset.
+
+    Regression for the clipped-container hit-test: an ExtendedFab nested inside
+    a padded Row must route pointer clicks to ``on_click``.
+    """
+    from nuiitivet.material.app import MaterialApp as App
+    from nuiitivet.layout.row import Row
+    from nuiitivet.layout.container import Container
+    from nuiitivet.runtime.app_events import dispatch_mouse_press, dispatch_mouse_release
+
+    class _FakeCanvas:
+        def __getattr__(self, _name):
+            def _noop(*args, **kwargs):
+                return None
+
+            return _noop
+
+    clicks: list[int] = []
+    fab = ExtendedFab("Compose", icon="edit", on_click=lambda: clicks.append(1))
+    app = App(content=Container(padding=24, child=Row(children=[fab])), title="t", width=400, height=120)
+    app.root.mount(app)
+    try:
+        app.root.layout(400, 120)
+        app.root.clear_needs_layout()
+        app.root.paint(_FakeCanvas(), 0, 0, 400, 120)
+
+        rx, ry, rw, rh = fab.last_rect
+        assert rx > 0  # actually offset from the origin
+        cx, cy = rx + rw // 2, ry + rh // 2
+        dispatch_mouse_press(app, cx, cy)
+        dispatch_mouse_release(app, cx, cy)
+        assert clicks == [1]
+    finally:
+        app.root.unmount()

--- a/tests/modifiers/test_box_clip.py
+++ b/tests/modifiers/test_box_clip.py
@@ -37,6 +37,27 @@ class FakeCanvas:
         self.restored += 1
 
 
+def test_clip_content_hit_test_uses_local_coordinates():
+    """A clipped Box placed at a non-zero offset stays hit-testable.
+
+    ``hit_test`` receives local coordinates, so the clip-bounds check must use
+    the widget's own size at origin (0, 0) -- not ``last_rect``'s parent-relative
+    offset.  Regression test for clipped widgets (e.g. ExtendedFab) becoming
+    unclickable when laid out inside a Row/Column/Container.
+    """
+    box = Box(child=DummyChild(), corner_radius=8)
+    box.clip_content = True
+    # Simulate a layout placing the box far from the origin.
+    box.set_layout_rect(200, 50, 120, 40)
+    box.set_last_rect(200, 50, 120, 40)
+
+    # Local coordinates inside the box must hit; outside must miss.
+    assert box.hit_test(10, 10) is box
+    assert box.hit_test(119, 39) is box
+    assert box.hit_test(-1, 10) is None
+    assert box.hit_test(10, 40) is None
+
+
 def test_box_clip_uses_rrect_for_corner_radius():
     fake_skia = types.SimpleNamespace()
 


### PR DESCRIPTION
## Summary
- Add the MD3 Expressive `ExtendedFab` widget (separate from `Fab`): required `label`, optional leading `icon`, content-driven pill width.
- `expanded: Observable[bool]` morphs between the extended pill and the circular FAB footprint — width animates and the label fades out in step; collapse is a no-op without an icon.
- Share internals with `Fab` via a new `_FabBase` (elevation, state layer, press scale) plus `build_button_child` / `resolve_button_style_params`.
- `FabStyle` gains the three solid color factories so all six active MD3 mappings (tonal + solid) are available; add `EXTENDED_FAB_SIZE_TOKENS`.
- Fix a shared `Box.hit_test` bug: clipped content (`clip_content=True`) was compared against parent-relative `last_rect`, making clipped widgets unclickable when laid out at an offset. Now evaluated in local coordinates.
- Sample under `samples/material_widgets/extended_fab.py` and tests covering rendering, the expand/collapse transition, and offset click routing.

## Test plan
- [x] `uv run pytest` — 1385 passed
- [x] `uv run mypy` — clean on changed files
- [ ] Run `uv run python -m samples.material_widgets.extended_fab` and click each FAB to confirm collapse/expand toggles

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)