### PR TITLE
feat(buttons): add MD3 Expressive FabMenu / FabMenuItem (#235)

### DIFF
--- a/docs/md3/fab-menu.md
+++ b/docs/md3/fab-menu.md
@@ -1,0 +1,220 @@
+<!-- markdownlint-disable MD060 -->
+
+# FAB Menu MD3 Specs
+
+Source: <https://m3.material.io/components/fab-menu/specs>
+Collected: 2026-05-25
+
+## Summary
+
+- The active FAB menu token viewer exposes seven non-deprecated token sets: one shared geometry set, three close-button color sets, and three list-item color sets.
+- Resolved values below use the viewer's default Android / 1P Baseline / Light / Default-contrast context, with Standard motion, Static font, and no iOS dark elevation override.
+- The common set fixes both the close button and menu item height at 56dp, uses fully rounded corners, and sets the menu-item padding rhythm to 24dp leading, 8dp icon-label spacing, 24dp trailing, and 4dp between-item spacing.
+- Close-button color sets use solid `primary`, `secondary`, and `tertiary` fills with `on-*` foreground colors; list-item color sets use the corresponding `*-container` fills with `on-*-container` foreground colors.
+- Hover is the only interaction state that raises elevation to 8dp. Focused and pressed keep 6dp elevation, while state-layer opacities follow the standard MD3 0.08 hover and 0.1 focus/press values.
+- The Measurements section explicitly calls out a 56dp close button, 16dp outer FAB margins, a 40dp opened bottom margin from medium FABs, a 56dp opened bottom margin from large FABs, and a recommended 4dp web gap between the FAB and menu.
+
+## Tokens & Specs
+
+State-layer opacity rows below use the live token viewer's displayed values. The embedded payload preserves the semantic source tokens but omits the resolved numeric opacity in `resolvedValue`.
+
+### Token sets discovered
+
+| Token set                                 | Count | Notes                                                                                  |
+|-------------------------------------------|------:|----------------------------------------------------------------------------------------|
+| FAB menu - Common                         |    15 | Shared geometry, shape, elevation, and typography for the close button and menu items. |
+| FAB menu close button - Color - Primary   |    15 | Solid primary close-button mapping.                                                    |
+| FAB menu close button - Color - Secondary |    15 | Solid secondary close-button mapping.                                                  |
+| FAB menu close button - Color - Tertiary  |    15 | Solid tertiary close-button mapping.                                                   |
+| FAB menu list items - Color - Primary     |    19 | Primary-container list-item mapping.                                                   |
+| FAB menu list items - Color - Secondary   |    19 | Secondary-container list-item mapping.                                                 |
+| FAB menu list items - Color - Tertiary    |    19 | Tertiary-container list-item mapping.                                                  |
+
+### FAB menu - Common
+
+| Token set         | Group        | Label                                     | Token                                             | Source token                  | Value                                | Notes                                                                                             |
+|-------------------|--------------|-------------------------------------------|---------------------------------------------------|-------------------------------|--------------------------------------|---------------------------------------------------------------------------------------------------|
+| FAB menu - Common | Close button | FAB menu close button container height    | md.comp.fab-menu.close-button.container.height    |                               | 56dp                                 |                                                                                                   |
+| FAB menu - Common | Close button | FAB menu close width                      | md.comp.fab-menu.close-button.container.width     |                               | 56dp                                 |                                                                                                   |
+| FAB menu - Common | Close button | FAB menu close button icon size           | md.comp.fab-menu.close-button.icon.size           |                               | 20dp                                 |                                                                                                   |
+| FAB menu - Common | Close button | FAB menu close button container elevation | md.comp.fab-menu.close-button.container.elevation | md.sys.elevation.level3       | 6dp                                  |                                                                                                   |
+| FAB menu - Common | Close button | FAB menu close button container shape     | md.comp.fab-menu.close-button.container.shape     | md.sys.shape.corner.full      | Fully rounded                        |                                                                                                   |
+| FAB menu - Common | Close button | FAB menu close button between space       | md.comp.fab-menu.close-button.between-space       |                               | 8dp                                  |                                                                                                   |
+| FAB menu - Common | List item    | FAB menu - menu item container height     | md.comp.fab-menu.menu-item.container.height       |                               | 56dp                                 |                                                                                                   |
+| FAB menu - Common | List item    | FAB menu - menu item label text           | md.comp.fab-menu.menu-item.label-text             | md.sys.typescale.title-medium | Google Sans Text / 500 / 16pt / 24pt | Composite typography token; tracking is not exposed in the resolved payload.                      |
+| FAB menu - Common | List item    | FAB menu - menu item icon size            | md.comp.fab-menu.menu-item.icon.size              |                               | 24dp                                 |                                                                                                   |
+| FAB menu - Common | List item    | FAB menu - menu item container elevation  | md.comp.fab-menu.menu-item.container.elevation    | md.sys.elevation.level0       | 0dp                                  | Level-0 elevation is serialized without a numeric value in the payload and was normalized to 0dp. |
+| FAB menu - Common | List item    | FAB menu - menu item container shape      | md.comp.fab-menu.menu-item.container.shape        | md.sys.shape.corner.full      | Fully rounded                        |                                                                                                   |
+| FAB menu - Common | List item    | FAB menu - menu item leading space        | md.comp.fab-menu.menu-item.leading-space          |                               | 24dp                                 |                                                                                                   |
+| FAB menu - Common | List item    | FAB menu - menu item icon label space     | md.comp.fab-menu.menu-item.icon-label-space       |                               | 8dp                                  |                                                                                                   |
+| FAB menu - Common | List item    | FAB menu - menu item trailing space       | md.comp.fab-menu.menu-item.trailing-space         |                               | 24dp                                 |                                                                                                   |
+| FAB menu - Common | List item    | FAB menu - menu item between space        | md.comp.fab-menu.menu-item.between-space          |                               | 4dp                                  |                                                                                                   |
+
+### FAB menu close button - Color - Primary
+
+| Token set                               | Group   | Label                                                     | Token                                                             | Source token                             | Value   | Notes |
+|-----------------------------------------|---------|-----------------------------------------------------------|-------------------------------------------------------------------|------------------------------------------|---------|-------|
+| FAB menu close button - Color - Primary | Enabled | FAB menu primary close button container color             | md.comp.fab-menu.primary.close-button.container.color             | md.sys.color.primary                     | #6750A4 |       |
+| FAB menu close button - Color - Primary | Enabled | FAB menu primary close button container shadow color      | md.comp.fab-menu.primary.close-button.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| FAB menu close button - Color - Primary | Enabled | FAB menu primary close button icon color                  | md.comp.fab-menu.primary.close-button.icon.color                  | md.sys.color.on-primary                  | #FFFFFF |       |
+| FAB menu close button - Color - Primary | Focused | FAB menu primary close button focused container elevation | md.comp.fab-menu.primary.close-button.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu close button - Color - Primary | Focused | FAB menu primary close button focused state layer color   | md.comp.fab-menu.primary.close-button.focused.state-layer.color   | md.sys.color.on-primary                  | #FFFFFF |       |
+| FAB menu close button - Color - Primary | Focused | FAB menu primary close button focused state layer opacity | md.comp.fab-menu.primary.close-button.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| FAB menu close button - Color - Primary | Focused | FAB menu primary close button focused icon color          | md.comp.fab-menu.primary.close-button.focused.icon.color          | md.sys.color.on-primary                  | #FFFFFF |       |
+| FAB menu close button - Color - Primary | Hovered | FAB menu primary close button hovered container elevation | md.comp.fab-menu.primary.close-button.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| FAB menu close button - Color - Primary | Hovered | FAB menu primary close button hovered state layer color   | md.comp.fab-menu.primary.close-button.hovered.state-layer.color   | md.sys.color.on-primary                  | #FFFFFF |       |
+| FAB menu close button - Color - Primary | Hovered | FAB menu primary close button hovered state layer opacity | md.comp.fab-menu.primary.close-button.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| FAB menu close button - Color - Primary | Hovered | FAB menu primary close button hovered icon color          | md.comp.fab-menu.primary.close-button.hovered.icon.color          | md.sys.color.on-primary                  | #FFFFFF |       |
+| FAB menu close button - Color - Primary | Pressed | FAB menu primary close button pressed container elevation | md.comp.fab-menu.primary.close-button.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu close button - Color - Primary | Pressed | FAB menu primary close button pressed state layer color   | md.comp.fab-menu.primary.close-button.pressed.state-layer.color   | md.sys.color.on-primary                  | #FFFFFF |       |
+| FAB menu close button - Color - Primary | Pressed | FAB menu primary close button pressed state layer opacity | md.comp.fab-menu.primary.close-button.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| FAB menu close button - Color - Primary | Pressed | FAB menu primary close button pressed icon color          | md.comp.fab-menu.primary.close-button.pressed.icon.color          | md.sys.color.on-primary                  | #FFFFFF |       |
+
+### FAB menu close button - Color - Secondary
+
+| Token set                                 | Group   | Label                                                       | Token                                                               | Source token                             | Value   | Notes |
+|-------------------------------------------|---------|-------------------------------------------------------------|---------------------------------------------------------------------|------------------------------------------|---------|-------|
+| FAB menu close button - Color - Secondary | Enabled | FAB menu secondary close button container color             | md.comp.fab-menu.secondary.close-button.container.color             | md.sys.color.secondary                   | #625B71 |       |
+| FAB menu close button - Color - Secondary | Enabled | FAB menu secondary close button container shadow color      | md.comp.fab-menu.secondary.close-button.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| FAB menu close button - Color - Secondary | Enabled | FAB menu secondary close button icon color                  | md.comp.fab-menu.secondary.close-button.icon.color                  | md.sys.color.on-secondary                | #FFFFFF |       |
+| FAB menu close button - Color - Secondary | Focused | FAB menu secondary close button focused container elevation | md.comp.fab-menu.secondary.close-button.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu close button - Color - Secondary | Focused | FAB menu secondary close button focused state layer color   | md.comp.fab-menu.secondary.close-button.focused.state-layer.color   | md.sys.color.on-secondary                | #FFFFFF |       |
+| FAB menu close button - Color - Secondary | Focused | FAB menu secondary close button focused state layer opacity | md.comp.fab-menu.secondary.close-button.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| FAB menu close button - Color - Secondary | Focused | FAB menu secondary close button focused icon color          | md.comp.fab-menu.secondary.close-button.focused.icon.color          | md.sys.color.on-secondary                | #FFFFFF |       |
+| FAB menu close button - Color - Secondary | Hovered | FAB menu secondary close button hovered container elevation | md.comp.fab-menu.secondary.close-button.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| FAB menu close button - Color - Secondary | Hovered | FAB menu secondary close button hovered state layer color   | md.comp.fab-menu.secondary.close-button.hovered.state-layer.color   | md.sys.color.on-secondary                | #FFFFFF |       |
+| FAB menu close button - Color - Secondary | Hovered | FAB menu secondary close button hovered state layer opacity | md.comp.fab-menu.secondary.close-button.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| FAB menu close button - Color - Secondary | Hovered | FAB menu secondary close button hovered icon color          | md.comp.fab-menu.secondary.close-button.hovered.icon.color          | md.sys.color.on-secondary                | #FFFFFF |       |
+| FAB menu close button - Color - Secondary | Pressed | FAB menu secondary close button pressed container elevation | md.comp.fab-menu.secondary.close-button.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu close button - Color - Secondary | Pressed | FAB menu secondary close button pressed state layer color   | md.comp.fab-menu.secondary.close-button.pressed.state-layer.color   | md.sys.color.on-secondary                | #FFFFFF |       |
+| FAB menu close button - Color - Secondary | Pressed | FAB menu secondary close button pressed state layer opacity | md.comp.fab-menu.secondary.close-button.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| FAB menu close button - Color - Secondary | Pressed | FAB menu secondary close button pressed icon color          | md.comp.fab-menu.secondary.close-button.pressed.icon.color          | md.sys.color.on-secondary                | #FFFFFF |       |
+
+### FAB menu close button - Color - Tertiary
+
+| Token set                                | Group   | Label                                                      | Token                                                              | Source token                             | Value   | Notes |
+|------------------------------------------|---------|------------------------------------------------------------|--------------------------------------------------------------------|------------------------------------------|---------|-------|
+| FAB menu close button - Color - Tertiary | Enabled | FAB menu tertiary close button container color             | md.comp.fab-menu.tertiary.close-button.container.color             | md.sys.color.tertiary                    | #7D5260 |       |
+| FAB menu close button - Color - Tertiary | Enabled | FAB menu tertiary close button container shadow color      | md.comp.fab-menu.tertiary.close-button.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| FAB menu close button - Color - Tertiary | Enabled | FAB menu tertiary close button icon color                  | md.comp.fab-menu.tertiary.close-button.icon.color                  | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| FAB menu close button - Color - Tertiary | Focused | FAB menu tertiary close button focused container elevation | md.comp.fab-menu.tertiary.close-button.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu close button - Color - Tertiary | Focused | FAB menu tertiary close button focused state layer color   | md.comp.fab-menu.tertiary.close-button.focused.state-layer.color   | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| FAB menu close button - Color - Tertiary | Focused | FAB menu tertiary close button focused state layer opacity | md.comp.fab-menu.tertiary.close-button.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| FAB menu close button - Color - Tertiary | Focused | FAB menu tertiary close button focused icon color          | md.comp.fab-menu.tertiary.close-button.focused.icon.color          | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| FAB menu close button - Color - Tertiary | Hovered | FAB menu tertiary close button hovered container elevation | md.comp.fab-menu.tertiary.close-button.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| FAB menu close button - Color - Tertiary | Hovered | FAB menu tertiary close button hovered state layer color   | md.comp.fab-menu.tertiary.close-button.hovered.state-layer.color   | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| FAB menu close button - Color - Tertiary | Hovered | FAB menu tertiary close button hovered state layer opacity | md.comp.fab-menu.tertiary.close-button.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| FAB menu close button - Color - Tertiary | Hovered | FAB menu tertiary close button hovered icon color          | md.comp.fab-menu.tertiary.close-button.hovered.icon.color          | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| FAB menu close button - Color - Tertiary | Pressed | FAB menu tertiary close button pressed container elevation | md.comp.fab-menu.tertiary.close-button.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu close button - Color - Tertiary | Pressed | FAB menu tertiary close button pressed state layer color   | md.comp.fab-menu.tertiary.close-button.pressed.state-layer.color   | md.sys.color.on-tertiary                 | #FFFFFF |       |
+| FAB menu close button - Color - Tertiary | Pressed | FAB menu tertiary close button pressed state layer opacity | md.comp.fab-menu.tertiary.close-button.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| FAB menu close button - Color - Tertiary | Pressed | FAB menu tertiary close button pressed icon color          | md.comp.fab-menu.tertiary.close-button.pressed.icon.color          | md.sys.color.on-tertiary                 | #FFFFFF |       |
+
+### FAB menu list items - Color - Primary
+
+| Token set                             | Group   | Label                                                  | Token                                                                    | Source token                             | Value   | Notes |
+|---------------------------------------|---------|--------------------------------------------------------|--------------------------------------------------------------------------|------------------------------------------|---------|-------|
+| FAB menu list items - Color - Primary | Enabled | FAB menu primary list item container color             | md.comp.fab-menu.primary-container.list-item.container.color             | md.sys.color.primary-container           | #EADDFF |       |
+| FAB menu list items - Color - Primary | Enabled | FAB menu primary list item container shadow color      | md.comp.fab-menu.primary-container.list-item.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| FAB menu list items - Color - Primary | Enabled | FAB menu primary list item icon color                  | md.comp.fab-menu.primary-container.list-item.icon.color                  | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Enabled | FAB menu primary list item label text color            | md.comp.fab-menu.primary-container.list-item.label-text.color            | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Focused | FAB menu primary list item focused container elevation | md.comp.fab-menu.primary-container.list-item.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu list items - Color - Primary | Focused | FAB menu primary list item focused state layer color   | md.comp.fab-menu.primary-container.list-item.focused.state-layer.color   | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Focused | FAB menu primary list item focused state layer opacity | md.comp.fab-menu.primary-container.list-item.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| FAB menu list items - Color - Primary | Focused | FAB menu primary list item focused icon color          | md.comp.fab-menu.primary-container.list-item.focused.icon.color          | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Focused | FAB menu primary list item focused label text color    | md.comp.fab-menu.primary-container.list-item.focused.label-text.color    | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Hovered | FAB menu primary list item hovered container elevation | md.comp.fab-menu.primary-container.list-item.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| FAB menu list items - Color - Primary | Hovered | FAB menu primary list item hovered state layer color   | md.comp.fab-menu.primary-container.list-item.hovered.state-layer.color   | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Hovered | FAB menu primary list item hovered state layer opacity | md.comp.fab-menu.primary-container.list-item.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| FAB menu list items - Color - Primary | Hovered | FAB menu primary list item hovered icon color          | md.comp.fab-menu.primary-container.list-item.hovered.icon.color          | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Hovered | FAB menu primary list item hovered label text color    | md.comp.fab-menu.primary-container.list-item.hovered.label-text.color    | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Pressed | FAB menu primary list item pressed container elevation | md.comp.fab-menu.primary-container.list-item.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu list items - Color - Primary | Pressed | FAB menu primary list item pressed state layer color   | md.comp.fab-menu.primary-container.list-item.pressed.state-layer.color   | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Pressed | FAB menu primary list item pressed state layer opacity | md.comp.fab-menu.primary-container.list-item.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| FAB menu list items - Color - Primary | Pressed | FAB menu primary list item pressed icon color          | md.comp.fab-menu.primary-container.list-item.pressed.icon.color          | md.sys.color.on-primary-container        | #4F378B |       |
+| FAB menu list items - Color - Primary | Pressed | FAB menu primary list item pressed label text color    | md.comp.fab-menu.primary-container.list-item.pressed.label-text.color    | md.sys.color.on-primary-container        | #4F378B |       |
+
+### FAB menu list items - Color - Secondary
+
+| Token set                               | Group   | Label                                                    | Token                                                                      | Source token                             | Value   | Notes |
+|-----------------------------------------|---------|----------------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------|---------|-------|
+| FAB menu list items - Color - Secondary | Enabled | FAB menu secondary list item container color             | md.comp.fab-menu.secondary-container.list-item.container.color             | md.sys.color.secondary-container         | #E8DEF8 |       |
+| FAB menu list items - Color - Secondary | Enabled | FAB menu secondary list item container shadow color      | md.comp.fab-menu.secondary-container.list-item.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| FAB menu list items - Color - Secondary | Enabled | FAB menu secondary list item icon color                  | md.comp.fab-menu.secondary-container.list-item.icon.color                  | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Enabled | FAB menu secondary list item label text color            | md.comp.fab-menu.secondary-container.list-item.label-text.color            | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Focused | FAB menu secondary list item focused container elevation | md.comp.fab-menu.secondary-container.list-item.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu list items - Color - Secondary | Focused | FAB menu secondary list item focused state layer color   | md.comp.fab-menu.secondary-container.list-item.focused.state-layer.color   | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Focused | FAB menu secondary list item focused state layer opacity | md.comp.fab-menu.secondary-container.list-item.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| FAB menu list items - Color - Secondary | Focused | FAB menu secondary list item focused icon color          | md.comp.fab-menu.secondary-container.list-item.focused.icon.color          | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Focused | FAB menu secondary list item focused label text color    | md.comp.fab-menu.secondary-container.list-item.focused.label-text.color    | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Hovered | FAB menu secondary list item hovered container elevation | md.comp.fab-menu.secondary-container.list-item.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| FAB menu list items - Color - Secondary | Hovered | FAB menu secondary list item hovered state layer color   | md.comp.fab-menu.secondary-container.list-item.hovered.state-layer.color   | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Hovered | FAB menu secondary list item hovered state layer opacity | md.comp.fab-menu.secondary-container.list-item.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| FAB menu list items - Color - Secondary | Hovered | FAB menu secondary list item hovered icon color          | md.comp.fab-menu.secondary-container.list-item.hovered.icon.color          | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Hovered | FAB menu secondary list item hovered label text color    | md.comp.fab-menu.secondary-container.list-item.hovered.label-text.color    | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Pressed | FAB menu secondary list item pressed container elevation | md.comp.fab-menu.secondary-container.list-item.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu list items - Color - Secondary | Pressed | FAB menu secondary list item pressed state layer color   | md.comp.fab-menu.secondary-container.list-item.pressed.state-layer.color   | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Pressed | FAB menu secondary list item pressed state layer opacity | md.comp.fab-menu.secondary-container.list-item.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| FAB menu list items - Color - Secondary | Pressed | FAB menu secondary list item pressed icon color          | md.comp.fab-menu.secondary-container.list-item.pressed.icon.color          | md.sys.color.on-secondary-container      | #4A4458 |       |
+| FAB menu list items - Color - Secondary | Pressed | FAB menu secondary list item pressed label text color    | md.comp.fab-menu.secondary-container.list-item.pressed.label-text.color    | md.sys.color.on-secondary-container      | #4A4458 |       |
+
+### FAB menu list items - Color - Tertiary
+
+| Token set                              | Group   | Label                                                   | Token                                                                     | Source token                             | Value   | Notes |
+|----------------------------------------|---------|---------------------------------------------------------|---------------------------------------------------------------------------|------------------------------------------|---------|-------|
+| FAB menu list items - Color - Tertiary | Enabled | FAB menu tertiary list item container color             | md.comp.fab-menu.tertiary-container.list-item.container.color             | md.sys.color.tertiary-container          | #FFD8E4 |       |
+| FAB menu list items - Color - Tertiary | Enabled | FAB menu tertiary list item container shadow color      | md.comp.fab-menu.tertiary-container.list-item.container.shadow-color      | md.sys.color.shadow                      | #000000 |       |
+| FAB menu list items - Color - Tertiary | Enabled | FAB menu tertiary list item icon color                  | md.comp.fab-menu.tertiary-container.list-item.icon.color                  | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Enabled | FAB menu tertiary list item label text color            | md.comp.fab-menu.tertiary-container.list-item.label-text.color            | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Focused | FAB menu tertiary list item focused container elevation | md.comp.fab-menu.tertiary-container.list-item.focused.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu list items - Color - Tertiary | Focused | FAB menu tertiary list item focused state layer color   | md.comp.fab-menu.tertiary-container.list-item.focused.state-layer.color   | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Focused | FAB menu tertiary list item focused state layer opacity | md.comp.fab-menu.tertiary-container.list-item.focused.state-layer.opacity | md.sys.state.focus.state-layer-opacity   | 0.1     |       |
+| FAB menu list items - Color - Tertiary | Focused | FAB menu tertiary list item focused icon color          | md.comp.fab-menu.tertiary-container.list-item.focused.icon.color          | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Focused | FAB menu tertiary list item focused label text color    | md.comp.fab-menu.tertiary-container.list-item.focused.label-text.color    | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Hovered | FAB menu tertiary list item hovered container elevation | md.comp.fab-menu.tertiary-container.list-item.hovered.container.elevation | md.sys.elevation.level4                  | 8dp     |       |
+| FAB menu list items - Color - Tertiary | Hovered | FAB menu tertiary list item hovered state layer color   | md.comp.fab-menu.tertiary-container.list-item.hovered.state-layer.color   | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Hovered | FAB menu tertiary list item hovered state layer opacity | md.comp.fab-menu.tertiary-container.list-item.hovered.state-layer.opacity | md.sys.state.hover.state-layer-opacity   | 0.08    |       |
+| FAB menu list items - Color - Tertiary | Hovered | FAB menu tertiary list item hovered icon color          | md.comp.fab-menu.tertiary-container.list-item.hovered.icon.color          | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Hovered | FAB menu tertiary list item hovered label text color    | md.comp.fab-menu.tertiary-container.list-item.hovered.label-text.color    | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Pressed | FAB menu tertiary list item pressed container elevation | md.comp.fab-menu.tertiary-container.list-item.pressed.container.elevation | md.sys.elevation.level3                  | 6dp     |       |
+| FAB menu list items - Color - Tertiary | Pressed | FAB menu tertiary list item pressed state layer color   | md.comp.fab-menu.tertiary-container.list-item.pressed.state-layer.color   | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Pressed | FAB menu tertiary list item pressed state layer opacity | md.comp.fab-menu.tertiary-container.list-item.pressed.state-layer.opacity | md.sys.state.pressed.state-layer-opacity | 0.1     |       |
+| FAB menu list items - Color - Tertiary | Pressed | FAB menu tertiary list item pressed icon color          | md.comp.fab-menu.tertiary-container.list-item.pressed.icon.color          | md.sys.color.on-tertiary-container       | #633B48 |       |
+| FAB menu list items - Color - Tertiary | Pressed | FAB menu tertiary list item pressed label text color    | md.comp.fab-menu.tertiary-container.list-item.pressed.label-text.color    | md.sys.color.on-tertiary-container       | #633B48 |       |
+
+## Measurements
+
+| Category   | Item                            | Value                                | Notes                                                                                   |
+|------------|---------------------------------|--------------------------------------|-----------------------------------------------------------------------------------------|
+| Geometry   | Close button size               | 56dp                                 | Explicitly called out in Measurements and reinforced by the common token set.           |
+| Geometry   | Close button icon size          | 20dp                                 | From the common token set.                                                              |
+| Geometry   | Close button corner treatment   | Fully rounded                        | From `md.comp.fab-menu.close-button.container.shape`.                                   |
+| Geometry   | Close button between space      | 8dp                                  | From the common token set.                                                              |
+| Geometry   | Menu item height                | 56dp                                 | Menu items share the same measurements as the medium button specs.                      |
+| Typography | Menu item label text            | Google Sans Text / 500 / 16pt / 24pt | Mapped to `md.sys.typescale.title-medium`.                                              |
+| Geometry   | Menu item icon size             | 24dp                                 | From the common token set.                                                              |
+| Geometry   | Menu item corner treatment      | Fully rounded                        | From `md.comp.fab-menu.menu-item.container.shape`.                                      |
+| Geometry   | Menu item base elevation        | 0dp                                  | `md.sys.elevation.level0`, normalized from a unit-only payload entry.                   |
+| Geometry   | Menu item leading space         | 24dp                                 | From the common token set.                                                              |
+| Geometry   | Menu item icon-label space      | 8dp                                  | From the common token set.                                                              |
+| Geometry   | Menu item trailing space        | 24dp                                 | From the common token set.                                                              |
+| Geometry   | Menu item between space         | 4dp                                  | From the common token set.                                                              |
+| Placement  | FAB outer margin                | 16dp                                 | The spec explicitly says the FAB should always have 16dp margins.                       |
+| Placement  | Medium FAB opened bottom margin | 40dp                                 | The opened menu places the close button higher to align with the top of the medium FAB. |
+| Placement  | Large FAB opened bottom margin  | 56dp                                 | The opened menu places the close button higher to align with the top of the large FAB.  |
+| Placement  | Anchor point                    | Top trailing corner                  | The close button and FAB share the same top trailing anchor position.                   |
+| Motion     | Expansion direction             | From the FAB's top trailing edge     | Explicitly called out in Measurements for smooth animation.                             |
+| Web        | Recommended FAB-to-menu gap     | 4dp                                  | The gap can vary on web, but 4dp is recommended.                                        |
+| Web        | Baseline behavior source        | Baseline menu component              | The web FAB menu inherits states and specs from the baseline menu component.            |
+
+- The FAB menu animates from the top trailing edge of the FAB to ensure a smooth animation.
+- Larger FABs will place the FAB menu slightly higher, with larger margins underneath.
+
+## Implementation Notes
+
+- Keep the geometry token set separate from the color token sets in implementation. The spec treats the close button and list-item layout as common across all color variants.
+- Use solid theme colors for the close button and container theme colors for list items. The page's color section and token viewer align on that distinction.
+- Wire hover to `md.sys.elevation.level4` and focus/press to `md.sys.elevation.level3` for both close buttons and list items.
+- Treat menu-item base elevation as `md.sys.elevation.level0` even though the raw payload serializes the value without an explicit numeric component.
+- Preserve the 24dp / 8dp / 24dp menu-item internal spacing and the 4dp between-item gap; those values materially shape the menu's visual rhythm.
+- On web, keep the FAB menu visually tied to the invoking FAB and start from the baseline menu behavior, with a recommended 4dp separation.

--- a/samples/material_widgets/fab_menu.py
+++ b/samples/material_widgets/fab_menu.py
@@ -1,0 +1,45 @@
+"""Material Widgets - FabMenu (MD3 Expressive FAB Menu).
+
+A single ``FabMenu`` drives everything through one ``is_open`` observable: the
+FAB morphs its icon between ``add`` and ``close``, the labelled actions reveal
+with a staggered animation, and tapping outside (or selecting an action)
+dismisses the menu via the shared light-dismiss overlay.
+"""
+
+from __future__ import annotations
+
+from nuiitivet.material import App, FabMenu, FabMenuItem, FabStyle
+from nuiitivet.layout.container import Container
+
+
+def _items() -> list[FabMenuItem]:
+    return [
+        FabMenuItem(icon="edit", label="Compose", on_click=lambda: print("Compose")),
+        FabMenuItem(icon="image", label="Add photo", on_click=lambda: print("Add photo")),
+        FabMenuItem(icon="link", label="Add link", on_click=lambda: print("Add link")),
+        FabMenuItem(icon="videocam", label="Add video", on_click=lambda: print("Add video")),
+    ]
+
+
+def main(png_path: str = "") -> None:
+    # Anchor the FAB at the bottom-trailing corner; the menu expands upward.
+    fab_menu = FabMenu("add", items=_items(), style=FabStyle.primary("m"))
+    content = Container(
+        padding=16,
+        alignment="bottom-right",
+        child=fab_menu,
+    )
+    app = App(
+        content=content,
+        title="FabMenu",
+        width=420,
+        height=520,
+    )
+    if png_path:
+        app.render_to_png(png_path)
+    else:
+        app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nuiitivet/common/logging_once.py
+++ b/src/nuiitivet/common/logging_once.py
@@ -42,6 +42,18 @@ def debug_once(logger: logging.Logger, key: str, msg: str, *args: object) -> Non
         return
 
 
+def warning_once(logger: logging.Logger, key: str, msg: str, *args: object) -> None:
+    """Log a WARNING message once per process for the given key."""
+
+    if not _should_log_once(key):
+        return
+    try:
+        logger.warning(msg, *args)
+    except Exception:
+        # Logging must never raise.
+        return
+
+
 def exception_once(logger: logging.Logger, key: str, msg: str, *args: object) -> None:
     """Log an exception once per process for the given key."""
 

--- a/src/nuiitivet/material/__init__.py
+++ b/src/nuiitivet/material/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         LinearProgressIndicator,
     )
     from .menu import Menu, MenuDivider, MenuItem, SubMenuItem
+    from .fab_menu import FabMenu, FabMenuItem
     from .intents import LoadingIntent
     from .icon import Icon
     from .navigation_rail import NavigationRail, RailItem
@@ -99,6 +100,8 @@ __all__ = [
     "ToggleButton",
     "Fab",
     "ExtendedFab",
+    "FabMenu",
+    "FabMenuItem",
     "IconButton",
     "IconToggleButton",
     "ButtonStyle",
@@ -194,6 +197,8 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "ToggleButton": ("buttons", "ToggleButton"),
     "Fab": ("buttons", "Fab"),
     "ExtendedFab": ("buttons", "ExtendedFab"),
+    "FabMenu": ("fab_menu", "FabMenu"),
+    "FabMenuItem": ("fab_menu", "FabMenuItem"),
     "IconButton": ("buttons", "IconButton"),
     "IconToggleButton": ("buttons", "IconToggleButton"),
     "ButtonStyle": ("styles.button_style", "ButtonStyle"),

--- a/src/nuiitivet/material/fab_menu.py
+++ b/src/nuiitivet/material/fab_menu.py
@@ -1,0 +1,590 @@
+"""Material Design 3 Expressive FAB Menu (:class:`FabMenu` / :class:`FabMenuItem`).
+
+A :class:`FabMenu` is a Floating Action Button that expands into a vertical
+list of labelled actions and morphs its icon between the closed and open
+states.  It is delivered as a single high-level widget so the FAB morph, the
+staggered reveal of items, and the dismissal scrim are all driven by one
+``is_open`` observable.
+
+The widget reuses existing infrastructure:
+
+- The morphing FAB is an internal :class:`~nuiitivet.material.buttons.Fab`
+  whose icon is *bound* to ``is_open`` -- there is no separate toggle state.
+- The overlay (scrim, outside-tap dismissal, anchored positioning) comes from
+  the existing :func:`~nuiitivet.modifiers.popup.light_dismiss` modifier.
+
+Geometry and colour values follow ``docs/md3/fab-menu.md``: the close button
+uses a solid/tonal FAB colour, list items use the matching ``*-container``
+colour set, items are 56dp fully-rounded pills with 24/8/24 internal spacing
+and a 4dp gap between items, and elevation rises to level-4 on hover and
+level-3 on focus/press.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
+
+from nuiitivet.animation import Animatable
+from nuiitivet.common.logging_once import warning_once
+from nuiitivet.layout.measure import preferred_size as _measure_preferred_size
+from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL
+from nuiitivet.material.styles.fab_style import FabStyle
+from nuiitivet.material.symbols import Symbols
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.modifiers.popup import light_dismiss
+from nuiitivet.modifiers.transform import opacity, translate
+from nuiitivet.observable import Observable, ObservableProtocol, ReadOnlyObservableProtocol
+from nuiitivet.observable import runtime
+from nuiitivet.widgeting.callbacks import VoidCallback, invoke_event_handler
+from nuiitivet.widgeting.widget import Widget
+
+if TYPE_CHECKING:
+    from nuiitivet.material.symbols import Symbol
+
+
+logger = logging.getLogger(__name__)
+
+
+IconLike = Union[
+    "Symbol",
+    str,
+    ReadOnlyObservableProtocol["Symbol"],
+    ReadOnlyObservableProtocol[str],
+]
+LabelLike = Union[str, ReadOnlyObservableProtocol[str]]
+
+# Vertical distance (px) each item slides up while fading in.
+_ITEM_REVEAL_RISE = 16.0
+# Per-item stagger between consecutive reveals (seconds).
+_ITEM_REVEAL_STAGGER = 0.05
+
+# The opened FAB-menu close button is always size "s": a 56dp fully-rounded
+# circle, regardless of the closed FAB size.  Larger closed FABs therefore
+# shrink to this size and align their top edge, leaving a larger bottom margin.
+_OPEN_FAB_SIZE = 56.0
+_OPEN_FAB_CORNER = 28.0
+
+# md.comp.fab-menu.close-button.between-space: gap between the close button and
+# the adjacent menu item.
+_CLOSE_BUTTON_BETWEEN_SPACE = 8.0
+# md.comp.fab-menu.menu-item.between-space: gap between consecutive menu items.
+_MENU_ITEM_BETWEEN_SPACE = 4
+
+
+@dataclass(frozen=True)
+class FabMenuItem:
+    """Declarative spec for a single action inside a :class:`FabMenu`.
+
+    Args:
+        icon: Leading icon shown in the menu-item pill.
+        label: Text label rendered next to the icon.
+        on_click: Optional callback invoked when the item is selected.
+        disabled: Whether the item is disabled (non-interactive).
+    """
+
+    icon: IconLike
+    label: LabelLike
+    on_click: Optional[VoidCallback] = None
+    disabled: Union[bool, ObservableProtocol[bool]] = False
+
+
+# MD3 only defines FAB-menu colour sets for the primary / secondary / tertiary
+# families.  A FAB menu of a given family pairs a *solid* close button with
+# *container*-toned list items (e.g. primary uses ``primary`` / ``on-primary``
+# for the close button and ``primary-container`` / ``on-primary-container`` for
+# the items).
+
+# Recover the colour family from a style background (solid or tonal).
+_BACKGROUND_TO_FAMILY: dict = {
+    ColorRole.PRIMARY: "primary",
+    ColorRole.PRIMARY_CONTAINER: "primary",
+    ColorRole.SECONDARY: "secondary",
+    ColorRole.SECONDARY_CONTAINER: "secondary",
+    ColorRole.TERTIARY: "tertiary",
+    ColorRole.TERTIARY_CONTAINER: "tertiary",
+}
+
+# Close button (solid) colour set per family: (container colour, foreground).
+_CLOSE_BUTTON_COLOR_SETS: dict = {
+    "primary": (ColorRole.PRIMARY, ColorRole.ON_PRIMARY),
+    "secondary": (ColorRole.SECONDARY, ColorRole.ON_SECONDARY),
+    "tertiary": (ColorRole.TERTIARY, ColorRole.ON_TERTIARY),
+}
+
+# List item (container) colour set per family: (container colour, foreground).
+_LIST_ITEM_COLOR_SETS: dict = {
+    "primary": (ColorRole.PRIMARY_CONTAINER, ColorRole.ON_PRIMARY_CONTAINER),
+    "secondary": (ColorRole.SECONDARY_CONTAINER, ColorRole.ON_SECONDARY_CONTAINER),
+    "tertiary": (ColorRole.TERTIARY_CONTAINER, ColorRole.ON_TERTIARY_CONTAINER),
+}
+
+
+def _color_family(base_style: FabStyle) -> str:
+    """Return the MD3 FAB-menu colour family for *base_style*.
+
+    Only primary / secondary / tertiary are defined by the spec.  An
+    unsupported style background (e.g. an elevated/outlined or custom style that
+    is not a tonal/solid FAB colour) falls back to ``"primary"`` and logs a
+    one-time warning, since that almost always signals a misuse.
+    """
+    family = _BACKGROUND_TO_FAMILY.get(base_style.background)
+    if family is None:
+        warning_once(
+            logger,
+            f"fab_menu_unsupported_color_family:{base_style.background}",
+            "FabMenu only supports primary/secondary/tertiary colour families; "
+            "style background %s is unsupported and falls back to primary.",
+            base_style.background,
+        )
+        return "primary"
+    return family
+
+
+def _close_button_style(base_style: FabStyle) -> FabStyle:
+    """Derive the solid close-button FAB style from the chosen colour family.
+
+    Per MD3 the FAB-menu close button is a *solid* FAB (``primary`` /
+    ``secondary`` / ``tertiary``), distinct from the tonal list items.
+    """
+    bg, fg = _CLOSE_BUTTON_COLOR_SETS[_color_family(base_style)]
+    return base_style.copy_with(  # type: ignore[return-value]
+        background=bg,
+        foreground=fg,
+        overlay_color=fg,
+    )
+
+
+def _scalar_corner(corner_radius) -> float:
+    """Return a scalar corner radius, taking the first value of a tuple."""
+    if isinstance(corner_radius, (tuple, list)):
+        return float(corner_radius[0]) if corner_radius else 0.0
+    return float(corner_radius)
+
+
+def _list_item_style(base_style: FabStyle) -> FabStyle:
+    """Derive the list-item pill style from the FAB's colour family.
+
+    Applies the MD3 FAB-menu list-item geometry (56dp fully-rounded pill,
+    title-medium label, 24dp leading / 8dp icon-label / 24dp trailing spacing)
+    and the level-0 base / level-4 hover / level-3 focus-press elevation set.
+    """
+    bg, fg = _LIST_ITEM_COLOR_SETS[_color_family(base_style)]
+    return base_style.copy_with(  # type: ignore[return-value]
+        background=bg,
+        foreground=fg,
+        overlay_color=fg,
+        corner_radius=28.0,
+        container_height=56,
+        min_width=56,
+        min_height=56,
+        label_font_size=16,
+        icon_size=24,
+        spacing=8,
+        padding=(24, 0, 24, 0),
+        elevation=0,
+        focused_elevation=3,
+        hovered_elevation=4,
+        pressed_elevation=3,
+        focus_opacity=0.1,
+        hover_opacity=0.08,
+        pressed_opacity=0.1,
+    )
+
+
+def _build_item_row_class() -> type:
+    """Build the internal menu-item row class on top of the private FAB base.
+
+    Done lazily inside a function so ``buttons`` (which imports a number of
+    Material modules) is only touched at first use, avoiding import cycles.
+    """
+    from nuiitivet.material.buttons import _FabBase, build_button_child, resolve_button_style_params
+
+    class _Row(_FabBase):
+        """Tonal pill row used to render a single FAB menu item."""
+
+        def __init__(self, item: FabMenuItem, *, style: FabStyle, on_select: Callable[[], None]) -> None:
+            self._item = item
+            self._on_select = on_select
+            self._user_style = style
+            self._user_padding = None
+            self._user_height = style.container_height
+
+            child_widget = build_button_child(
+                item.label,
+                item.icon,
+                foreground=style.foreground,
+                button_height=style.container_height,
+                icon_position="leading",
+                spacing=int(getattr(style, "spacing", 8) or 8),
+                style=style,
+            )
+            params = resolve_button_style_params(style, None, style.container_height, item.disabled)
+            super().__init__(
+                child=child_widget,
+                on_click=self._handle_click,
+                width=None,
+                disabled=item.disabled,
+                **params,
+            )
+            self._sync_state_tokens()
+
+        def _expressive_press_scale(self) -> Tuple[float, float]:
+            # Wide pills should not squash; rely on the state layer for feedback.
+            return (1.0, 1.0)
+
+        def _handle_click(self) -> None:
+            if self._item.on_click is not None:
+                invoke_event_handler(
+                    self._item.on_click,
+                    error_key="fab_menu_item_on_click",
+                    error_msg="FabMenuItem on_click handler failed",
+                    owner_name="FabMenuItem",
+                )
+            self._on_select()
+
+    return _Row
+
+
+def _build_morph_fab_class() -> type:
+    """Build the internal morphing FAB class (the FAB-menu close button).
+
+    While closed the FAB shows its normal size and rounded-square shape; while
+    open it morphs into the MD3 FAB-menu *close button*: a fixed 56dp (size "s")
+    fully-rounded circle, regardless of the closed size.  A single progress
+    animation drives both the container size and the corner radius, bound to
+    ``is_open``.
+
+    The morph owns the container corner radius and re-asserts it after every
+    theme change, since the base FAB resets the corner to the static style value
+    whenever the theme is (re)applied.
+
+    Built lazily so ``buttons`` is only imported at first use, avoiding cycles.
+    """
+    from nuiitivet.material.buttons import Fab
+
+    class _MorphFab(Fab):
+        """A :class:`Fab` that morphs to a 56dp close button while open."""
+
+        def __init__(
+            self,
+            icon: IconLike,
+            *,
+            on_click: Optional[VoidCallback],
+            style: FabStyle,
+            is_open: Observable[bool],
+            closed_size: float,
+            open_size: float,
+            closed_corner: float,
+            open_corner: float,
+        ) -> None:
+            self._closed_size = float(closed_size)
+            self._open_size = float(open_size)
+            self._closed_corner = float(closed_corner)
+            self._open_corner = float(open_corner)
+            self._morph_corner = float(closed_corner)
+            self._is_open_ref = is_open
+            # Progress: 0.0 = closed (full size), 1.0 = open (56dp circle).
+            self._morph_anim: Animatable = Animatable(0.0, motion=EXPRESSIVE_DEFAULT_SPATIAL)
+            super().__init__(icon, on_click=on_click, style=style)
+
+        def on_mount(self) -> None:
+            super().on_mount()
+            self.bind(self._morph_anim.subscribe(self._on_morph_tick))
+            self._on_morph_tick(self._morph_anim.value)
+            self.observe(self._is_open_ref, self._retarget)
+            self._retarget(bool(self._is_open_ref.value))
+
+        def _retarget(self, is_open_value: bool) -> None:
+            self._morph_anim.target = 1.0 if is_open_value else 0.0
+
+        def _morph_size(self) -> int:
+            t = max(0.0, min(1.0, float(self._morph_anim.value)))
+            size = self._closed_size + (self._open_size - self._closed_size) * t
+            return int(round(size))
+
+        def _morph_corner_value(self) -> float:
+            t = max(0.0, min(1.0, float(self._morph_anim.value)))
+            return self._closed_corner + (self._open_corner - self._closed_corner) * t
+
+        def _on_morph_tick(self, _value: float) -> None:
+            self._morph_corner = self._morph_corner_value()
+            self.corner_radius = self._morph_corner
+            self.mark_needs_layout()
+            self.invalidate()
+
+        def preferred_size(
+            self,
+            max_width: Optional[int] = None,
+            max_height: Optional[int] = None,
+        ) -> Tuple[int, int]:
+            size = self._morph_size()
+            if max_width is not None:
+                size = min(size, int(max_width))
+            if max_height is not None:
+                size = min(size, int(max_height))
+            return (size, size)
+
+        def _on_theme_change(self, theme) -> None:
+            super()._on_theme_change(theme)
+            # The base resets corner_radius to the static style value; re-assert
+            # the current morph corner so the shape state survives theme changes.
+            self.corner_radius = self._morph_corner
+
+    return _MorphFab
+
+
+class _FabMenuList(Widget):
+    """Internal overlay content: a vertical, staggered-reveal list of items.
+
+    The list is mounted by the overlay when the menu opens, which triggers the
+    staggered fade/slide-in of each item starting from the row closest to the
+    FAB.  On unmount the per-item animations snap back to the hidden state so a
+    re-open replays the reveal.
+    """
+
+    def __init__(
+        self,
+        items: List[FabMenuItem],
+        *,
+        item_style: FabStyle,
+        on_select: Callable[[], None],
+        stagger: float = _ITEM_REVEAL_STAGGER,
+    ) -> None:
+        super().__init__()
+        from nuiitivet.layout.column import Column
+
+        row_cls = _build_item_row_class()
+        self._stagger = float(stagger)
+        self._anims: List[Animatable] = []
+        self._pending: List[Callable[[float], None]] = []
+
+        rows: List[Widget] = []
+        for item in items:
+            anim: Animatable = Animatable(0.0, motion=EXPRESSIVE_DEFAULT_SPATIAL)
+            self._anims.append(anim)
+            row = row_cls(item, style=item_style, on_select=on_select)
+            opacity_obs = anim.map(lambda t: max(0.0, min(1.0, float(t))))
+            translate_obs = anim.map(lambda t: (0.0, (1.0 - max(0.0, min(1.0, float(t)))) * _ITEM_REVEAL_RISE))
+            wrapped = row.modifier(translate(translate_obs)).modifier(opacity(opacity_obs))
+            rows.append(wrapped)
+
+        # Right-align items to the FAB's trailing edge; 4dp between-item gap.
+        self._column = Column(rows, gap=_MENU_ITEM_BETWEEN_SPACE, cross_alignment="end")
+        self.add_child(self._column)
+
+    def on_mount(self) -> None:
+        """Replay the staggered reveal each time the overlay is shown."""
+        super().on_mount()
+        self._cancel_pending()
+        count = len(self._anims)
+        for idx, anim in enumerate(self._anims):
+            anim.snap_to(0.0)
+            # The row closest to the FAB (visually bottom) reveals first.
+            rank = count - 1 - idx
+            delay = rank * self._stagger
+
+            def _reveal(_dt: float, _a: Animatable = anim) -> None:
+                _a.target = 1.0
+
+            self._pending.append(_reveal)
+            runtime.clock.schedule_once(_reveal, delay)
+
+    def on_unmount(self) -> None:
+        """Cancel pending reveals and reset to the hidden state."""
+        self._cancel_pending()
+        for anim in self._anims:
+            anim.snap_to(0.0)
+        super().on_unmount()
+
+    def _cancel_pending(self) -> None:
+        for cb in self._pending:
+            runtime.clock.unschedule(cb)
+        self._pending.clear()
+
+    # -- Delegation to the inner column -------------------------------------
+
+    def preferred_size(
+        self,
+        max_width: Optional[int] = None,
+        max_height: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        return _measure_preferred_size(self._column, max_width=max_width, max_height=max_height)
+
+    def layout(self, width: int, height: int) -> None:
+        super().layout(width, height)
+        self._column.layout(width, height)
+        self._column.set_layout_rect(0, 0, width, height)
+
+    def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        rect = self._column.layout_rect
+        if rect is not None:
+            cx, cy, cw, ch = rect
+            self._column.paint(canvas, x + cx, y + cy, cw, ch)
+
+    def hit_test(self, x: int, y: int):
+        hit = self._column.hit_test(x, y)
+        if hit is not None:
+            return hit
+        return super().hit_test(x, y)
+
+
+class FabMenu(Widget):
+    """Material Design 3 Expressive FAB Menu.
+
+    A Floating Action Button that expands into a vertical list of labelled
+    actions.  A single ``is_open`` observable is the source of truth.  On open
+    the FAB morphs into the MD3 *close button*: its icon changes (``icon`` ->
+    ``close_icon``) and it shrinks from its closed size to a fixed 56dp (size
+    "s") fully-rounded circle, regardless of the configured size.  The overlay
+    -- scrim, outside-tap dismissal, and anchored positioning -- is driven
+    through the same observable via
+    :func:`~nuiitivet.modifiers.popup.light_dismiss`.
+
+    The closed-size footprint is reserved for layout stability; the shrinking
+    close button aligns to its top-trailing corner, so larger closed FAB sizes
+    place the menu higher with a larger margin underneath (40dp for medium, 56dp
+    for large per MD3).  The menu expands upward from that top-trailing edge with
+    a 4dp gap and a staggered item reveal.  Selecting an item invokes its
+    ``on_click`` and, by default, closes the menu.
+    """
+
+    def __init__(
+        self,
+        icon: IconLike,
+        items: List[FabMenuItem],
+        *,
+        is_open: Optional[Observable[bool]] = None,
+        auto_close: bool = True,
+        close_icon: Union["Symbol", str] = Symbols.close,
+        style: Optional[FabStyle] = None,
+    ) -> None:
+        """Initialize a FabMenu.
+
+        Args:
+            icon: FAB icon shown while the menu is closed.
+            items: The actions to display when the menu is open.
+            is_open: Optional external ``Observable[bool]`` controlling the
+                open/close state.  When ``None`` an internal one is created and
+                exposed via :attr:`is_open`.
+            auto_close: When ``True`` (default), selecting an item closes the
+                menu after invoking its ``on_click``.
+            close_icon: Icon the FAB morphs to while the menu is open.
+                Defaults to ``Symbols.close``.
+            style: FAB style preset selecting the colour family and size.
+                Defaults to :meth:`FabStyle.primary`.  List items use the
+                matching ``*-container`` colour set.
+        """
+        super().__init__()
+
+        base_style = style if style is not None else FabStyle.primary()
+        self._is_open: Observable[bool] = is_open if is_open is not None else Observable(False)
+        self._auto_close = bool(auto_close)
+
+        # FAB icon is bound to is_open: there is no separate toggle state.
+        def _resolve_icon(is_open_value: bool) -> Union["Symbol", str, IconLike]:
+            return close_icon if is_open_value else icon
+
+        icon_source = self._is_open.map(_resolve_icon)
+
+        # The FAB keeps its normal size/shape while closed and morphs into the
+        # fixed 56dp circular "close button" while open.  The morph is owned by
+        # the FAB and bound to is_open.  The closed footprint is reserved so the
+        # surrounding layout stays stable; the shrinking close button aligns to
+        # the footprint's top-trailing corner, growing the bottom margin.
+        # The close button uses the family's *solid* colour (distinct from the
+        # tonal list items) per MD3.
+        fab_style = _close_button_style(base_style)
+        self._closed_size = float(base_style.container_height)
+        morph_fab_cls = _build_morph_fab_class()
+        self._fab = morph_fab_cls(
+            icon_source,
+            on_click=self._toggle,
+            style=fab_style,
+            is_open=self._is_open,
+            closed_size=self._closed_size,
+            open_size=_OPEN_FAB_SIZE,
+            closed_corner=_scalar_corner(fab_style.corner_radius),
+            open_corner=_OPEN_FAB_CORNER,
+        )
+
+        self._list = _FabMenuList(
+            items,
+            item_style=_list_item_style(base_style),
+            on_select=self._on_item_selected,
+        )
+
+        # Reuse the existing light-dismiss overlay for scrim + outside-tap close.
+        self._inner = self._fab.modifier(
+            light_dismiss(
+                self._list,
+                is_open=self._is_open,
+                alignment="top-right",
+                anchor="bottom-right",
+                offset=(0.0, -_CLOSE_BUTTON_BETWEEN_SPACE),
+            )
+        )
+        self.add_child(self._inner)
+
+    @property
+    def is_open(self) -> Observable[bool]:
+        """Observable that controls (and reflects) the menu's open state."""
+        return self._is_open
+
+    def _toggle(self) -> None:
+        self._is_open.value = not bool(self._is_open.value)
+
+    def _on_item_selected(self) -> None:
+        if self._auto_close:
+            self._is_open.value = False
+
+    # -- Layout: reserve the closed footprint, top-trailing align the FAB ---
+
+    def preferred_size(
+        self,
+        max_width: Optional[int] = None,
+        max_height: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        # Always reserve the closed-size footprint so the surrounding layout is
+        # stable as the FAB shrinks into the smaller close button.
+        size = int(round(self._closed_size))
+        if max_width is not None:
+            size = min(size, int(max_width))
+        if max_height is not None:
+            size = min(size, int(max_height))
+        return (size, size)
+
+    def _fab_box(self, width: int, height: int) -> Tuple[int, int, int, int]:
+        """Return the (x, y, w, h) for the morphing FAB inside the footprint.
+
+        The FAB is aligned to the top-trailing corner, so shrinking it grows the
+        margin underneath (and to the leading side).
+        """
+        fab_w, fab_h = self._inner.preferred_size()
+        fab_w = min(int(fab_w), width)
+        fab_h = min(int(fab_h), height)
+        return (width - fab_w, 0, fab_w, fab_h)
+
+    def layout(self, width: int, height: int) -> None:
+        super().layout(width, height)
+        bx, by, bw, bh = self._fab_box(width, height)
+        self._inner.layout(bw, bh)
+        self._inner.set_layout_rect(bx, by, bw, bh)
+
+    def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
+        self.set_last_rect(x, y, width, height)
+        rect = self._inner.layout_rect
+        if rect is not None:
+            cx, cy, cw, ch = rect
+            self._inner.paint(canvas, x + cx, y + cy, cw, ch)
+
+    def hit_test(self, x: int, y: int):
+        hit = self._inner.hit_test(x, y)
+        if hit is not None:
+            return hit
+        return super().hit_test(x, y)
+
+
+__all__ = ["FabMenu", "FabMenuItem"]

--- a/tests/material/test_fab_menu.py
+++ b/tests/material/test_fab_menu.py
@@ -1,0 +1,363 @@
+"""Unit tests for the FabMenu / FabMenuItem widgets."""
+
+import pytest
+
+from nuiitivet.material.fab_menu import FabMenu, FabMenuItem
+from nuiitivet.material.styles.fab_style import FabStyle
+from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.observable import Observable, runtime
+
+
+class _FakeCanvas:
+    """A no-op canvas used for headless paint passes in tests."""
+
+    def __getattr__(self, _name):
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
+
+
+class _FakeClock:
+    """Deterministic clock capturing scheduled callbacks for assertions."""
+
+    def __init__(self) -> None:
+        self.scheduled: list = []
+        self.intervals: list = []
+
+    def schedule_once(self, fn, delay) -> None:
+        self.scheduled.append((fn, float(delay)))
+
+    def schedule_interval(self, fn, interval) -> None:
+        self.intervals.append((fn, float(interval)))
+
+    def unschedule(self, fn) -> None:
+        self.scheduled = [(f, d) for (f, d) in self.scheduled if f is not fn]
+        self.intervals = [(f, i) for (f, i) in self.intervals if f is not fn]
+
+
+def _menu(**kwargs) -> FabMenu:
+    items = kwargs.pop("items", None) or [
+        FabMenuItem(icon="edit", label="Compose"),
+        FabMenuItem(icon="share", label="Share"),
+        FabMenuItem(icon="save", label="Save"),
+    ]
+    return FabMenu("add", items=items, **kwargs)
+
+
+def _rows(menu: FabMenu) -> list:
+    """Return the internal item-row widgets (unwrapping the transform boxes)."""
+    return [wrapped.children[0] for wrapped in menu._list._column.children]
+
+
+# --- Construction ---------------------------------------------------------
+
+
+def test_items_required_positionally():
+    with pytest.raises(TypeError):
+        FabMenu("add")  # type: ignore[call-arg]
+
+
+def test_default_is_open_is_false():
+    menu = _menu()
+    assert menu.is_open.value is False
+
+
+def test_internal_observable_created_when_none():
+    menu = _menu()
+    assert isinstance(menu.is_open, Observable)
+
+
+def test_external_is_open_is_source_of_truth():
+    state = Observable(False)
+    menu = _menu(is_open=state)
+    assert menu.is_open is state
+    state.value = True
+    assert menu.is_open.value is True
+
+
+def test_one_row_per_item():
+    menu = _menu(
+        items=[
+            FabMenuItem(icon="edit", label="A"),
+            FabMenuItem(icon="share", label="B"),
+        ]
+    )
+    assert len(_rows(menu)) == 2
+
+
+def test_preferred_size_matches_fab_footprint():
+    """FabMenu occupies only the FAB footprint; the menu lives in the overlay."""
+    menu = _menu(style=FabStyle.primary("s"))
+    assert menu.preferred_size() == (56, 56)
+
+
+# --- Open / close state ---------------------------------------------------
+
+
+def test_toggle_flips_is_open():
+    menu = _menu()
+    menu._toggle()
+    assert menu.is_open.value is True
+    menu._toggle()
+    assert menu.is_open.value is False
+
+
+def test_fab_click_toggles_open():
+    """Clicking the morphing FAB flips the single source-of-truth observable."""
+    from nuiitivet.material.app import MaterialApp as App
+    from nuiitivet.layout.container import Container
+    from nuiitivet.runtime.app_events import dispatch_mouse_press, dispatch_mouse_release
+
+    menu = _menu()
+    app = App(content=Container(padding=24, child=menu), title="t", width=300, height=300)
+    app.root.mount(app)
+    try:
+        app.root.layout(300, 300)
+        app.root.clear_needs_layout()
+        app.root.paint(_FakeCanvas(), 0, 0, 300, 300)
+
+        rx, ry, rw, rh = menu._fab.last_rect
+        cx, cy = rx + rw // 2, ry + rh // 2
+        dispatch_mouse_press(app, cx, cy)
+        dispatch_mouse_release(app, cx, cy)
+        assert menu.is_open.value is True
+    finally:
+        app.root.unmount()
+
+
+def test_item_select_invokes_on_click_and_auto_closes():
+    clicks: list = []
+    menu = _menu(
+        items=[FabMenuItem(icon="edit", label="Compose", on_click=lambda: clicks.append(1))],
+    )
+    menu.is_open.value = True
+    _rows(menu)[0]._handle_click()
+    assert clicks == [1]
+    assert menu.is_open.value is False
+
+
+def test_auto_close_false_keeps_menu_open():
+    menu = _menu(
+        items=[FabMenuItem(icon="edit", label="Compose")],
+        auto_close=False,
+    )
+    menu.is_open.value = True
+    _rows(menu)[0]._handle_click()
+    assert menu.is_open.value is True
+
+
+def test_item_without_on_click_does_not_raise():
+    menu = _menu(items=[FabMenuItem(icon="edit", label="Compose")])
+    menu.is_open.value = True
+    _rows(menu)[0]._handle_click()  # should not raise
+    assert menu.is_open.value is False
+
+
+# --- Styling --------------------------------------------------------------
+
+
+def test_list_items_use_container_color_for_each_family():
+    cases = {
+        FabStyle.primary(): (ColorRole.PRIMARY_CONTAINER, ColorRole.ON_PRIMARY_CONTAINER),
+        FabStyle.secondary_solid(): (ColorRole.SECONDARY_CONTAINER, ColorRole.ON_SECONDARY_CONTAINER),
+        FabStyle.tertiary(): (ColorRole.TERTIARY_CONTAINER, ColorRole.ON_TERTIARY_CONTAINER),
+    }
+    for style, (bg, fg) in cases.items():
+        menu = _menu(style=style)
+        row_style = _rows(menu)[0].style
+        assert row_style.background == bg
+        assert row_style.foreground == fg
+
+
+def test_unsupported_color_family_falls_back_to_primary_with_warning(caplog):
+    """An unsupported style background falls back to primary and warns once."""
+    import logging
+
+    from nuiitivet.common.logging_once import _clear_log_once_keys_for_tests
+
+    _clear_log_once_keys_for_tests()
+    # Surface colours are not a valid FAB-menu family.
+    style = FabStyle.primary().copy_with(background=ColorRole.SURFACE)
+    with caplog.at_level(logging.WARNING, logger="nuiitivet.material.fab_menu"):
+        menu = _menu(style=style)
+    assert menu._fab.style.background == ColorRole.PRIMARY
+    assert _rows(menu)[0].style.background == ColorRole.PRIMARY_CONTAINER
+    assert any("falls back to primary" in r.message for r in caplog.records)
+
+
+def test_close_button_uses_solid_color_distinct_from_items():
+    """The close button (FAB) is solid; items are tonal container -- not equal."""
+    cases = {
+        FabStyle.primary(): (ColorRole.PRIMARY, ColorRole.ON_PRIMARY),
+        FabStyle.secondary(): (ColorRole.SECONDARY, ColorRole.ON_SECONDARY),
+        FabStyle.tertiary_solid(): (ColorRole.TERTIARY, ColorRole.ON_TERTIARY),
+    }
+    for style, (bg, fg) in cases.items():
+        menu = _menu(style=style)
+        assert menu._fab.style.background == bg
+        assert menu._fab.style.foreground == fg
+        # The FAB (solid) and the items (container) must differ in colour.
+        assert menu._fab.style.background != _rows(menu)[0].style.background
+
+
+def test_list_item_geometry_follows_md3_tokens():
+    menu = _menu()
+    row_style = _rows(menu)[0].style
+    assert row_style.container_height == 56
+    assert row_style.corner_radius == pytest.approx(28.0)
+    assert row_style.icon_size == 24
+    assert row_style.label_font_size == 16
+    assert row_style.padding == (24, 0, 24, 0)
+
+
+def test_style_variants_resolve():
+    for style in (
+        FabStyle.primary(),
+        FabStyle.secondary(),
+        FabStyle.tertiary(),
+        FabStyle.primary_solid(),
+        FabStyle.secondary_solid(),
+        FabStyle.tertiary_solid(),
+    ):
+        menu = _menu(style=style)
+        assert menu.preferred_size()[1] == 56
+
+
+# --- Shape / size morph ---------------------------------------------------
+
+
+def test_closed_fab_uses_style_size_and_shape():
+    """Closed: the FAB keeps the style's size and rounded-square corner."""
+    menu = _menu(style=FabStyle.primary("m"))
+    fab = menu._fab
+    # MD3 FAB size "m": 80dp container, 20dp corner.
+    assert fab._closed_size == pytest.approx(80.0)
+    assert fab._closed_corner == pytest.approx(20.0)
+    # The opened close button is always size "s": 56dp circle (28dp corner).
+    assert fab._open_size == pytest.approx(56.0)
+    assert fab._open_corner == pytest.approx(28.0)
+    # Progress starts closed.
+    assert fab._morph_anim.value == pytest.approx(0.0)
+    assert fab.preferred_size() == (80, 80)
+
+
+def test_open_close_button_is_always_size_s():
+    """Opened: the close button shrinks to a 56dp circle for every size."""
+    for size, closed in (("s", 56), ("m", 80), ("l", 96)):
+        menu = _menu(style=FabStyle.primary(size))
+        fab = menu._fab
+        assert fab.preferred_size() == (closed, closed)  # closed footprint
+        fab._morph_anim.snap_to(1.0)
+        assert fab.preferred_size() == (56, 56)  # opened close button
+        assert fab._morph_corner_value() == pytest.approx(28.0)
+        fab._morph_anim.snap_to(0.0)
+
+
+def test_morph_retargets_with_open_state():
+    menu = _menu(style=FabStyle.primary("m"))
+    fab = menu._fab
+    try:
+        fab._retarget(True)
+        assert fab._morph_anim.target == pytest.approx(1.0)
+        fab._retarget(False)
+        assert fab._morph_anim.target == pytest.approx(0.0)
+    finally:
+        fab._morph_anim.stop()
+
+
+def test_footprint_stays_closed_size_regardless_of_open_state():
+    """The FabMenu footprint stays the closed size so layout is stable."""
+    menu = _menu(style=FabStyle.primary("m"))
+    assert menu.preferred_size() == (80, 80)
+    menu._fab._morph_anim.snap_to(1.0)
+    assert menu.preferred_size() == (80, 80)
+    menu._fab._morph_anim.stop()
+
+
+def test_open_close_button_aligns_top_trailing():
+    """Opened, the 56dp close button sits at the footprint's top-trailing corner."""
+    menu = _menu(style=FabStyle.primary("m"))
+    menu._fab._morph_anim.snap_to(1.0)
+    # Footprint is 80x80; the 56dp close button is top-right aligned.
+    bx, by, bw, bh = menu._fab_box(80, 80)
+    assert (bw, bh) == (56, 56)
+    assert (bx, by) == (24, 0)  # 24dp leading/bottom margin grows underneath
+    menu._fab._morph_anim.stop()
+
+
+def test_fab_corner_radius_tracks_shape_morph():
+    """The FAB container corner radius follows the shape morph when mounted.
+
+    Mounting matters: the FAB's theme application resets the container corner to
+    the static style value, so the morph subscription must be (re)established
+    after mount to win.
+    """
+    from nuiitivet.material.app import MaterialApp as App
+    from nuiitivet.layout.container import Container
+
+    menu = _menu(style=FabStyle.primary("s"))
+    app = App(content=Container(padding=8, child=menu), title="t", width=200, height=200)
+    app.root.mount(app)
+    try:
+        app.root.layout(200, 200)
+        app.root.clear_needs_layout()
+        app.root.paint(_FakeCanvas(), 0, 0, 200, 200)
+        # Closed: rounded square (16dp).
+        assert float(menu._fab.corner_radius) == pytest.approx(16.0, abs=0.5)
+        # Open: morph toward the circular close button (28dp).
+        menu.is_open.value = True
+        for _ in range(240):
+            menu._fab._morph_anim._tick(1 / 60)
+        assert float(menu._fab.corner_radius) == pytest.approx(28.0, abs=0.5)
+    finally:
+        menu._fab._morph_anim.stop()
+        app.root.unmount()
+
+
+# --- Staggered reveal -----------------------------------------------------
+
+
+def test_reveal_schedules_one_per_item_bottom_first():
+    """Mounting the list schedules a staggered reveal, nearest-FAB item first."""
+    menu = _menu(
+        items=[
+            FabMenuItem(icon="edit", label="A"),
+            FabMenuItem(icon="share", label="B"),
+            FabMenuItem(icon="save", label="C"),
+        ]
+    )
+    fake = _FakeClock()
+    original = runtime.clock
+    runtime.set_clock(fake)
+    try:
+        menu._list.on_mount()
+        delays = [delay for (_fn, delay) in fake.scheduled]
+        assert len(delays) == 3
+        # Scheduled in item order; the visually-bottom (last) item reveals
+        # first (delay 0), so delays decrease across the item order.
+        assert delays == sorted(delays, reverse=True)
+        assert delays[-1] == pytest.approx(0.0)
+        assert min(delays) == pytest.approx(0.0)
+    finally:
+        runtime.set_clock(original)
+
+
+def test_reveal_callback_drives_item_to_visible():
+    menu = _menu(items=[FabMenuItem(icon="edit", label="A")])
+    fake = _FakeClock()
+    original = runtime.clock
+    runtime.set_clock(fake)
+    try:
+        menu._list.on_mount()
+        anim = menu._list._anims[0]
+        assert anim.value == pytest.approx(0.0)
+        # Fire the scheduled reveal, then drive the animation to completion.
+        for fn, _delay in fake.scheduled:
+            fn(0.0)
+        for _ in range(240):
+            anim._tick(1 / 60)
+        assert anim.value == pytest.approx(1.0)
+    finally:
+        anim.stop()
+        runtime.set_clock(original)


### PR DESCRIPTION
## Summary
- Add high-level `FabMenu` / `FabMenuItem` (MD3 Expressive), driven by a single `is_open` observable as the source of truth (closes #235).
- FAB morphs into the MD3 close button on open: icon swaps (`icon` → `close_icon`) and it shrinks from the closed size to a fixed 56dp (size "s") fully-rounded circle, top-trailing aligned within the reserved closed-size footprint (40dp/56dp bottom margin for medium/large).
- Internally reuses the existing `light_dismiss()` overlay for scrim, outside-tap dismissal, and anchored positioning.
- Solid close button paired with tonal `*-container` list items per the FAB-menu colour spec; staggered item reveal, 8dp close-button gap, 4dp between-item gap.
- Unsupported colour families fall back to `primary` with a one-time warning (new `warning_once` helper).

## Test plan
- [x] `pytest tests/material/test_fab_menu.py` (24 tests: open/close, item interaction & auto-close, size/shape morph, solid-vs-container colours, staggered reveal, fallback warning)
- [x] `pytest tests/material` (701 passed)
- [x] `mypy src/nuiitivet/material/fab_menu.py` (Success)
- [x] Sample renders: `samples/material_widgets/fab_menu.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)