### PR TITLE
feat(button_group): standard group adjacent-width interaction + MD3 shape/spacing (#239)

### DIFF
--- a/samples/material_widgets/button_group.py
+++ b/samples/material_widgets/button_group.py
@@ -19,6 +19,7 @@ from nuiitivet.material.styles.button_group_style import (
     ConnectedButtonGroupStyle,
     StandardButtonGroupStyle,
 )
+from nuiitivet.material.styles.button_size import ButtonSize
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.layout.column import Column
@@ -31,7 +32,9 @@ _ALIGN_ICONS = ("format_align_left", "format_align_center", "format_align_right"
 # Size scale content: each row varies icons and label presence (icon-only,
 # label-only, icon + label).  Content-fit widths keep the pressed-width
 # interaction working and avoid narrow vertical pills at large sizes.
-_SIZE_CONTENT: dict[str, list[tuple[str | None, str | None]]] = {
+_SIZES: tuple[ButtonSize, ...] = ("xs", "s", "m", "l", "xl")
+
+_SIZE_CONTENT: dict[ButtonSize, list[tuple[str | None, str | None]]] = {
     "xs": [("format_align_left", None), ("format_align_center", None), ("format_align_right", None)],
     "s": [(None, "Day"), (None, "Week"), (None, "Month")],
     "m": [("calendar_today", "Day"), ("event", "Week"), ("schedule", "Month")],
@@ -87,7 +90,7 @@ def _icon_group(style) -> StandardButtonGroup:
     )
 
 
-def _size_group(size: str) -> StandardButtonGroup:
+def _size_group(size: ButtonSize) -> StandardButtonGroup:
     return StandardButtonGroup(
         [GroupButton(icon=icon, label=label) for icon, label in _SIZE_CONTENT[size]],
         style=StandardButtonGroupStyle.filled(size),
@@ -120,7 +123,7 @@ def main(png_path: str = "") -> None:
 
     sizes = _section(
         "Sizes",
-        *[_labeled(size.upper(), _size_group(size)) for size in ("xs", "s", "m", "l", "xl")],
+        *[_labeled(size.upper(), _size_group(size)) for size in _SIZES],
     )
 
     page = Row(

--- a/samples/material_widgets/button_group.py
+++ b/samples/material_widgets/button_group.py
@@ -1,10 +1,16 @@
-"""Material Widgets - ButtonGroup variants."""
+"""Material Widgets - ButtonGroup showcase.
+
+Showcases the Material 3 button-group family: standard variants
+(filled / tonal / outlined), the per-size pressed-width interaction, and the
+connected single-select group.
+"""
 
 from __future__ import annotations
 
 from nuiitivet.material import (
     App,
     ConnectedButtonGroup,
+    Divider,
     GroupButton,
     StandardButtonGroup,
     Text,
@@ -13,51 +19,123 @@ from nuiitivet.material.styles.button_group_style import (
     ConnectedButtonGroupStyle,
     StandardButtonGroupStyle,
 )
+from nuiitivet.material.styles.text_style import TextStyle
+from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
+from nuiitivet.layout.row import Row
+
+# Icons reused for the tonal icon-only group.
+_ALIGN_ICONS = ("format_align_left", "format_align_center", "format_align_right")
+
+# Size scale content: each row varies icons and label presence (icon-only,
+# label-only, icon + label).  Content-fit widths keep the pressed-width
+# interaction working and avoid narrow vertical pills at large sizes.
+_SIZE_CONTENT: dict[str, list[tuple[str | None, str | None]]] = {
+    "xs": [("format_align_left", None), ("format_align_center", None), ("format_align_right", None)],
+    "s": [(None, "Day"), (None, "Week"), (None, "Month")],
+    "m": [("calendar_today", "Day"), ("event", "Week"), ("schedule", "Month")],
+    "l": [("call", "Call"), ("email", "Mail"), ("map", "Map")],
+    "xl": [("favorite", "Like"), ("bolt", "Boost"), ("movie", "Watch")],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _section_title(text: str) -> Text:
+    return Text(text, style=TextStyle(font_size=18, color=ColorRole.ON_SURFACE))
+
+
+def _caption(text: str) -> Text:
+    return Text(text, style=TextStyle(font_size=12, color=ColorRole.ON_SURFACE_VARIANT))
+
+
+def _labeled(caption: str, widget) -> Column:
+    """A small caption stacked above a button group."""
+    return Column(gap=8, cross_alignment="start", children=[_caption(caption), widget])
+
+
+def _section(title: str, *rows) -> Column:
+    """A titled section grouping related examples.
+
+    A plain ``Column`` (not ``Card``): ``Card`` is a scoped ``WidgetBuilder``
+    that rebuilds — and unmounts — its subtree on every measure, which cancels
+    an in-progress press when a child animates its width and triggers a
+    relayout.  A plain layout container has no such rebuild.
+    """
+    return Column(
+        gap=18,
+        cross_alignment="start",
+        children=[_section_title(title), Divider(), *rows],
+    )
+
+
+def _days_group(style) -> StandardButtonGroup:
+    return StandardButtonGroup(
+        [GroupButton("Day"), GroupButton("Week"), GroupButton("Month")],
+        style=style,
+    )
+
+
+def _icon_group(style) -> StandardButtonGroup:
+    return StandardButtonGroup(
+        [GroupButton(icon=icon) for icon in _ALIGN_ICONS],
+        style=style,
+    )
+
+
+def _size_group(size: str) -> StandardButtonGroup:
+    return StandardButtonGroup(
+        [GroupButton(icon=icon, label=label) for icon, label in _SIZE_CONTENT[size]],
+        style=StandardButtonGroupStyle.filled(size),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Showcase
+# ---------------------------------------------------------------------------
 
 
 def main(png_path: str = "") -> None:
-    content = Container(
-        padding=24,
-        child=Column(
-            gap=12,
-            cross_alignment="start",
-            children=[
-                Text("StandardButtonGroup (filled)"),
-                StandardButtonGroup(
-                    [
-                        GroupButton("Day"),
-                        GroupButton("Week"),
-                        GroupButton("Month"),
-                    ],
-                ),
-                Text("StandardButtonGroup (tonal, icons)"),
-                StandardButtonGroup(
-                    [
-                        GroupButton(icon="format_align_left"),
-                        GroupButton(icon="format_align_center"),
-                        GroupButton(icon="format_align_right"),
-                    ],
-                    style=StandardButtonGroupStyle.tonal(),
-                ),
-                Text("ConnectedButtonGroup (single select)"),
-                ConnectedButtonGroup(
-                    [
-                        GroupButton("Small"),
-                        GroupButton("Medium"),
-                        GroupButton("Large"),
-                    ],
-                    style=ConnectedButtonGroupStyle.outlined(),
-                ),
-            ],
+    standard = _section(
+        "Standard",
+        _labeled("Filled", _days_group(StandardButtonGroupStyle.filled())),
+        _labeled("Tonal", _icon_group(StandardButtonGroupStyle.tonal())),
+        _labeled("Outlined", _days_group(StandardButtonGroupStyle.outlined())),
+    )
+
+    connected = _section(
+        "Connected",
+        _labeled(
+            "Single select",
+            ConnectedButtonGroup(
+                [GroupButton("Small"), GroupButton("Medium"), GroupButton("Large")],
+                style=ConnectedButtonGroupStyle.outlined(),
+            ),
         ),
     )
+
+    sizes = _section(
+        "Sizes",
+        *[_labeled(size.upper(), _size_group(size)) for size in ("xs", "s", "m", "l", "xl")],
+    )
+
+    page = Row(
+        gap=24,
+        cross_alignment="start",
+        children=[
+            Column(gap=24, cross_alignment="start", children=[standard, connected]),
+            sizes,
+        ],
+    )
+
+    content = Container(padding=32, child=page)
     app = App(
         content=content,
         title="ButtonGroup",
-        width=520,
-        height=360,
     )
     if png_path:
         app.render_to_png(png_path)

--- a/src/nuiitivet/animation/motion.py
+++ b/src/nuiitivet/animation/motion.py
@@ -154,12 +154,24 @@ class BezierMotion:
 class SpringMotion:
     """Spring-based motion.
 
+    The integrator is sub-stepped so stiff springs stay stable when the frame
+    rate (and thus ``dt``) drops: a single large semi-implicit Euler step can
+    diverge once ``dt`` approaches ``2 / sqrt(stiffness / mass)`` (e.g. a
+    stiffness of 1400 diverges below ~30 fps).  Each ``step`` splits ``dt`` into
+    fixed-size sub-steps so the result is stable and frame-rate independent.
+
     Args:
         stiffness: Spring stiffness constant.
         damping: Damping coefficient.
         mass: Mass attached to the spring.
         initial_velocity: Initial velocity in units per second.
     """
+
+    # Fixed integration sub-step (~240 Hz) — stable for stiffness up to ~57000
+    # at unit mass.  Larger frames are clamped to avoid a long catch-up after a
+    # stall (e.g. a backgrounded window).
+    _MAX_SUBSTEP = 1.0 / 240.0
+    _MAX_FRAME = 0.25
 
     def __init__(
         self,
@@ -210,18 +222,15 @@ class SpringMotion:
         if dt <= 0.0:
             return state.done
 
-        next_velocity: list[float] = []
-        next_value: list[float] = []
-        for value, target, velocity in zip(state.value, state.target, state.velocity, strict=True):
-            displacement = value - target
-            acceleration = (-self.stiffness * displacement - self.damping * velocity) / self.mass
-            velocity = velocity + acceleration * dt
-            value = value + velocity * dt
-            next_velocity.append(velocity)
-            next_value.append(value)
+        # Integrate in fixed-size sub-steps so a large frame delta cannot make
+        # a stiff spring diverge.  Clamp the total advance to avoid a long
+        # catch-up after a stall.
+        remaining = min(dt, self._MAX_FRAME)
+        while remaining > 1e-9:
+            h = self._MAX_SUBSTEP if remaining > self._MAX_SUBSTEP else remaining
+            self._integrate(state, h)
+            remaining -= h
 
-        state.velocity = next_velocity
-        state.value = next_value
         state.elapsed += dt
 
         velocity_stable = all(abs(v) <= self.tolerance for v in state.velocity)
@@ -234,6 +243,20 @@ class SpringMotion:
             state.done = True
 
         return state.done
+
+    def _integrate(self, state: MotionState, dt: float) -> None:
+        """Advance one semi-implicit Euler sub-step of size ``dt``."""
+        next_velocity: list[float] = []
+        next_value: list[float] = []
+        for value, target, velocity in zip(state.value, state.target, state.velocity, strict=True):
+            displacement = value - target
+            acceleration = (-self.stiffness * displacement - self.damping * velocity) / self.mass
+            velocity = velocity + acceleration * dt
+            value = value + velocity * dt
+            next_velocity.append(velocity)
+            next_value.append(value)
+        state.velocity = next_velocity
+        state.value = next_value
 
 
 class _CubicBezier:

--- a/src/nuiitivet/material/button_group.py
+++ b/src/nuiitivet/material/button_group.py
@@ -24,8 +24,11 @@ from typing import (
 from nuiitivet.animation import Animatable
 from nuiitivet.animation.converter import VectorConverter
 from nuiitivet.input.pointer import PointerEvent
+from nuiitivet.layout.layout_utils import expand_layout_children
+from nuiitivet.layout.metrics import align_offset
+from nuiitivet.layout.row import Row
 from nuiitivet.material.interactive_widget import InteractiveWidget
-from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL
+from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL, STANDARD_BUTTON_GROUP_WIDTH
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
 from nuiitivet.rendering.sizing import Sizing, SizingLike
@@ -152,13 +155,19 @@ class GroupButton(InteractiveWidget):
 
         # Corner animation state
         self._position: ButtonGroupPosition = "only"
-        self._neighbors: Tuple[Optional["GroupButton"], Optional["GroupButton"]] = (None, None)
         self._adjacent_animation: bool = True
         self._persistent_selected_pressed_shape: bool = False
         self._connected_inner_press_only: bool = False
         self._own_pressed: bool = False
-        self._left_neighbor_pressed: bool = False
-        self._right_neighbor_pressed: bool = False
+
+        # Adjacent width-interaction state (Standard groups only).  Each item
+        # exposes only a 0..1 "active" progress and its natural content-fit
+        # width; the parent group layout (``_ButtonGroupRow``) reads these in a
+        # single measure pass to grow the active item and compress its direct
+        # neighbors, keeping the group width conserved (mirrors M3 Compose's
+        # ButtonGroup, which avoids per-child layout jitter).  The width is NOT
+        # animated per item here.
+        self._base_width: float = float(self._style.min_item_width)
 
         # Store child widget refs for colour updates
         self._text_widget: "Optional[Widget]" = None
@@ -182,6 +191,10 @@ class GroupButton(InteractiveWidget):
             motion=None,  # Enabled after first set_position()
         )
 
+        # Active progress 0..1 (motion enabled in set_position()).  Drives the
+        # parent-computed width interaction; ticks only request a re-layout.
+        self._press_progress: "Animatable[float]" = Animatable(0.0, motion=None)
+
         super().__init__(
             child=content,
             on_click=self._handle_click,
@@ -190,7 +203,12 @@ class GroupButton(InteractiveWidget):
             disabled=disabled,
             width=width,
             height=self._style.container_height,
-            padding=(12, 0, 12, 0),
+            # No box padding: the leading/trailing space is reserved via
+            # ``preferred_size`` and rendered by *centering* the content (see
+            # ``_side_space``).  This keeps the icon/label centred so the
+            # pressed-width interaction compresses neighbours symmetrically.
+            padding=0,
+            alignment="center",
             background_color=bg,
             border_color=bc,
             border_width=bw,
@@ -207,7 +225,12 @@ class GroupButton(InteractiveWidget):
     # ------------------------------------------------------------------
 
     def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> Tuple[int, int]:
-        """Return preferred size, enforcing ``min_item_width``.
+        """Return preferred size.
+
+        Connected groups enforce a visual minimum width (M3: 48dp for XS/S
+        segments).  Standard groups are content-fit: their 48dp spec value is an
+        accessible **tap-target** requirement, not a visual width floor, so it
+        is intentionally not applied to the rendered width here.
 
         Args:
             max_width: Available width constraint.
@@ -216,8 +239,27 @@ class GroupButton(InteractiveWidget):
         Returns:
             ``(width, height)`` in pixels.
         """
+        # Content is centred with zero box padding, so ``super`` returns the
+        # bare content width; add the reserved leading + trailing space here so
+        # the idle width still equals content + 2 × side-space.
         w, _h = super().preferred_size(max_width=max_width, max_height=max_height)
-        return (max(w, self._style.min_item_width), self._style.container_height)
+        w += 2 * self._side_space()
+        if not self._adjacent_animation:  # Connected groups only
+            w = max(w, self._style.min_item_width)
+        return (int(w), self._style.container_height)
+
+    def _side_space(self) -> int:
+        """Return the per-side leading/trailing space reserved around the content.
+
+        Sourced from the style's ``inner_padding`` (the MD3 button
+        leading/trailing-space token).  Connected styles do not expose it; fall
+        back to the historical fixed value so their layout is unchanged.
+
+        This space is *not* applied as box padding — it is reserved width that
+        centring turns into symmetric left/right margins, so the content stays
+        centred while neighbours compress during the pressed-width interaction.
+        """
+        return int(getattr(self._style, "inner_padding", 12))
 
     # ------------------------------------------------------------------
     # Position injection (called by container on_mount)
@@ -226,7 +268,6 @@ class GroupButton(InteractiveWidget):
     def set_position(
         self,
         position: ButtonGroupPosition,
-        neighbors: Tuple[Optional["GroupButton"], Optional["GroupButton"]],
         adjacent_animation: bool = True,
     ) -> None:
         """Configure this item's position within its group.
@@ -238,18 +279,21 @@ class GroupButton(InteractiveWidget):
 
         Args:
             position: One of ``"start"``, ``"middle"``, ``"end"``, ``"only"``.
-            neighbors: ``(left_neighbor, right_neighbor)``; either may be ``None``.
-            adjacent_animation: ``True`` for Standard groups (neighbor corners
-                respond); ``False`` for Connected groups.
+            adjacent_animation: ``True`` for Standard groups (the active item's
+                width grows and neighbors compress); ``False`` for Connected.
         """
         self._position = position
-        self._neighbors = neighbors
         self._adjacent_animation = adjacent_animation
         self._own_pressed = False
-        self._left_neighbor_pressed = False
-        self._right_neighbor_pressed = False
 
-        idle = self._compute_target_corners(False, False, False)
+        # Capture the natural content-fit width (the parent layout grows/
+        # compresses around this base).  Arm the MD3-spec spring on the active
+        # progress so press/select transitions are smooth.
+        self._base_width = float(self.preferred_size()[0])
+        self._press_progress.snap_to(0.0)
+        self._press_progress.set_motion(STANDARD_BUTTON_GROUP_WIDTH)
+
+        idle = self._compute_target_corners(False)
 
         # Snap the animation to idle (no motion for position init)
         self._corner_anim.stop()
@@ -282,6 +326,10 @@ class GroupButton(InteractiveWidget):
         # Subscribe to corner animation ticks
         self.bind(self._corner_anim.subscribe(self._on_corner_value_changed))
 
+        # Subscribe to active-progress ticks: request a parent re-layout so the
+        # group recomputes all widths in a single coordinated pass.
+        self.bind(self._press_progress.subscribe(self._on_progress_changed))
+
         # Subscribe to external selected observable if provided
         if self._selected_external is not None:
             sub = self._selected_external.subscribe(lambda v: self._set_selected(bool(v)))
@@ -292,42 +340,20 @@ class GroupButton(InteractiveWidget):
     # ------------------------------------------------------------------
 
     def _handle_press_down(self, event: PointerEvent) -> None:
-        """Start press shape animation and notify adjacent neighbors."""
+        """Start own press shape animation and drive the adjacent width interaction.
+
+        Only this item's own shape morphs on press; neighbors respond by
+        adjusting their **width** (not their corners), per the MD3 spec.
+        """
         self._own_pressed = True
         self._update_corner_target()
-        if self._adjacent_animation:
-            left, right = self._neighbors
-            if left is not None:
-                left._on_neighbor_pressed("right", True)
-            if right is not None:
-                right._on_neighbor_pressed("left", True)
+        self._update_active_progress()
 
     def _handle_press_up(self, event: PointerEvent) -> None:
-        """Restore shape animation on release and notify adjacent neighbors."""
+        """Restore own shape animation on release and refresh the width interaction."""
         self._own_pressed = False
         self._update_corner_target()
-        if self._adjacent_animation:
-            left, right = self._neighbors
-            if left is not None:
-                left._on_neighbor_pressed("right", False)
-            if right is not None:
-                right._on_neighbor_pressed("left", False)
-
-    def _on_neighbor_pressed(self, side: Literal["left", "right"], pressed: bool) -> None:
-        """React to an adjacent item's press state change.
-
-        Animates the junction corner facing the pressed neighbor.
-        Called exclusively from pointer event handlers; never from ``paint()``.
-
-        Args:
-            side: Which side the pressed neighbor is on.
-            pressed: ``True`` when the neighbor becomes pressed; ``False`` on release.
-        """
-        if side == "left":
-            self._left_neighbor_pressed = pressed
-        else:
-            self._right_neighbor_pressed = pressed
-        self._update_corner_target()
+        self._update_active_progress()
 
     def _handle_click(self) -> None:
         """Toggle selected state, fire change and click callbacks."""
@@ -373,6 +399,7 @@ class GroupButton(InteractiveWidget):
         self._apply_foreground(fg)
         self.state.selected = bool(value)
         self._update_corner_target()
+        self._update_active_progress()
         self.invalidate()
 
     # ------------------------------------------------------------------
@@ -381,25 +408,22 @@ class GroupButton(InteractiveWidget):
 
     def _update_corner_target(self) -> None:
         """Recompute and apply the corner animation target."""
-        left_p = self._left_neighbor_pressed if self._adjacent_animation else False
-        right_p = self._right_neighbor_pressed if self._adjacent_animation else False
-        target = self._compute_target_corners(self._own_pressed, left_p, right_p)
+        target = self._compute_target_corners(self._own_pressed)
         self._corner_anim.target = target
 
     def _compute_target_corners(
         self,
         own_pressed: bool,
-        left_neighbor_pressed: bool,
-        right_neighbor_pressed: bool,
     ) -> Tuple[float, float, float, float]:
         """Compute the 4-corner radius tuple for the given interaction state.
 
-        Corner-tuple order: ``(tl, tr, br, bl)``.
+        Corner-tuple order: ``(tl, tr, br, bl)``.  Only this item's own
+        interaction state drives its corners; a neighbor's press never alters
+        them (the MD3 adjacent interaction adjusts neighbor **width**, not
+        shape — see ``_ButtonGroupRow``).
 
         Args:
             own_pressed: Whether this item is currently pressed.
-            left_neighbor_pressed: Whether the left neighbor is pressed.
-            right_neighbor_pressed: Whether the right neighbor is pressed.
 
         Returns:
             Target ``(tl, tr, br, bl)`` corner radii in logical pixels.
@@ -407,7 +431,7 @@ class GroupButton(InteractiveWidget):
         s = self._style
         kinds = _CORNER_KIND[self._position]  # (tl, tr, br, bl) kinds
 
-        def resolve(kind: str, own: bool, neighbor: bool) -> float:
+        def resolve(kind: str, own: bool) -> float:
             if own:
                 if self._connected_inner_press_only:
                     # Connected groups: keep outer corners stable while pressed.
@@ -420,9 +444,11 @@ class GroupButton(InteractiveWidget):
                         return sel if sel > 0 else s.outer_corner_radius
                     return s.pressed_inner_corner_radius
                 return s.pressed_outer_corner_radius if kind == "outer" else s.pressed_inner_corner_radius
-            if neighbor and kind == "inner":
-                return s.pressed_inner_corner_radius
-            # Standard groups: keep a squarer selected shape after release.
+            # Standard groups: keep the pressed (squared) shape on selection.
+            # The MD3 button-group spec defines no separate selected shape for
+            # standard groups, and the official demo shows the selected segment
+            # at the same roundness as a pressed one — so selection reuses the
+            # pressed corners (selection is otherwise conveyed by colour).
             if self._selected and self._persistent_selected_pressed_shape:
                 return s.pressed_outer_corner_radius if kind == "outer" else s.pressed_inner_corner_radius
             # Selected inner corner: fully rounded on inner edges (Connected groups only).
@@ -431,10 +457,10 @@ class GroupButton(InteractiveWidget):
                 return sel if sel > 0 else s.outer_corner_radius
             return s.outer_corner_radius if kind == "outer" else s.inner_corner_radius
 
-        tl = resolve(kinds[0], own_pressed, left_neighbor_pressed)
-        tr = resolve(kinds[1], own_pressed, right_neighbor_pressed)
-        br = resolve(kinds[2], own_pressed, right_neighbor_pressed)
-        bl = resolve(kinds[3], own_pressed, left_neighbor_pressed)
+        tl = resolve(kinds[0], own_pressed)
+        tr = resolve(kinds[1], own_pressed)
+        br = resolve(kinds[2], own_pressed)
+        bl = resolve(kinds[3], own_pressed)
         return (tl, tr, br, bl)
 
     @staticmethod
@@ -454,6 +480,38 @@ class GroupButton(InteractiveWidget):
         """Animation tick callback: apply animated corners to the Box."""
         # Use Box's setter so paint cache is invalidated with every shape update.
         self.corner_radius = v
+        self.invalidate()
+
+    # ------------------------------------------------------------------
+    # Adjacent width interaction (Standard groups)
+    # ------------------------------------------------------------------
+
+    def _update_active_progress(self) -> None:
+        """Retarget the 0..1 active progress; the parent layout reads the value.
+
+        The width expansion is a **transient press** effect (MD3: the only
+        width token is ``pressed``): the item grows to the 15% peak while held
+        and returns to its idle width on release.  Selection is conveyed by
+        colour and corner shape, not by a persistent width change.
+
+        Only Standard groups (``adjacent_animation=True``) participate; for
+        Connected groups this is a no-op so their flex layout is preserved.
+        """
+        if not self._adjacent_animation:
+            return
+        self._press_progress.target = 1.0 if self._own_pressed else 0.0
+
+    def _on_progress_changed(self, _value: float) -> None:
+        """Active-progress tick: re-layout the group and force a repaint.
+
+        ``mark_needs_layout`` flags the tree as needing layout, but it only
+        schedules a repaint on the first dirtying call (the node stays dirty
+        afterwards, so its guarded ``invalidate`` is skipped).  An animation
+        ticks every frame, so we must invalidate explicitly each tick — mirroring
+        the corner animation — otherwise only the first frame would repaint and
+        the width would appear frozen.
+        """
+        self.mark_needs_layout()
         self.invalidate()
 
     # ------------------------------------------------------------------
@@ -496,7 +554,10 @@ class GroupButton(InteractiveWidget):
         from nuiitivet.material.styles.text_style import TextStyle
         from nuiitivet.layout.row import Row
 
-        icon_size = 20
+        # Icon / label / spacing scale with the group size (MD3 button tokens).
+        icon_size = self._style.icon_size
+        label_size = self._style.label_size
+        icon_label_space = self._style.icon_label_space
 
         icon_w: "Optional[Widget]" = None
         text_w: "Optional[Widget]" = None
@@ -508,7 +569,7 @@ class GroupButton(InteractiveWidget):
         if self._label is not None:
             text_w = Text(
                 self._label,
-                style=TextStyle(color=foreground, font_size=14, text_alignment="center"),
+                style=TextStyle(color=foreground, font_size=label_size, text_alignment="center"),
             )
             self._text_widget = text_w
 
@@ -517,7 +578,21 @@ class GroupButton(InteractiveWidget):
         if text_w is not None and icon_w is None:
             return text_w
         assert icon_w is not None and text_w is not None
-        return Row([icon_w, text_w], gap=8, cross_alignment="center")
+        return Row([icon_w, text_w], gap=icon_label_space, cross_alignment="center")
+
+    def _rebuild_content(self) -> None:
+        """Rebuild the content child from the current style.
+
+        Content metrics (icon size, label size, icon/label spacing) are baked
+        into the Icon/Text widgets at build time, so when the containing group
+        assigns a sized style the content must be regenerated to pick up the
+        new sizes.  Called by ``_ButtonGroupBase.on_mount`` before layout.
+        """
+        _bg, fg, _bc, _bw = self._effective_colors()
+        content = self._build_content(fg)
+        self.clear_children()
+        self.add_child(content)
+        self.mark_needs_layout()
 
     def _apply_foreground(self, foreground: ColorSpec) -> None:
         """Update the colour of child text and icon widgets.
@@ -546,6 +621,91 @@ class GroupButton(InteractiveWidget):
             else:
                 self._icon_widget_ref._style = IconStyle(color=foreground)
             self._icon_widget_ref.invalidate()
+
+
+# ---------------------------------------------------------------------------
+# _ButtonGroupRow
+# ---------------------------------------------------------------------------
+
+
+class _ButtonGroupRow(Row):
+    """Row that runs the M3 Standard button-group width interaction.
+
+    In a single layout pass it reads each child's 0..1 active progress and its
+    natural base width, grows each active item and compresses its direct
+    neighbors (bounded by the neighbor's padding so content never clips), then
+    places the children using rounded *boundary* positions.  Computing all
+    widths together in one pass — rather than animating each item's width
+    independently — keeps the group width conserved and prevents the rightmost
+    item from accumulating per-frame rounding jitter.  This mirrors M3 Compose's
+    ``ButtonGroup`` measure policy.
+    """
+
+    def layout(self, width: int, height: int) -> None:
+        """Lay out children, applying the active/neighbor width interaction."""
+        super().layout(width, height)  # establish own geometry + default pass
+        items = [c for c in expand_layout_children(self.children_snapshot()) if isinstance(c, GroupButton)]
+        if len(items) < 2:
+            return
+
+        widths = self._interaction_widths(items)
+
+        l, t, _r, _b = self.padding
+        gap = max(0, int(self.gap))
+        ch = max(0, height - t - _b)
+
+        # Round boundary positions (not individual widths) so cumulative offsets
+        # never drift: each child width is the gap between rounded boundaries.
+        x = float(l)
+        for i, item in enumerate(items):
+            start_edge = round(x)
+            x += widths[i]
+            end_edge = round(x)
+            w = max(0, end_edge - start_edge)
+            ih = self._item_height(item, ch)
+            y = t + align_offset(ch, ih, "center")
+            item.layout(w, ih)
+            item.set_layout_rect(start_edge, y, w, ih)
+            x += gap
+
+    def _interaction_widths(self, items: List["GroupButton"]) -> List[float]:
+        """Return the per-item widths after applying grow/compress (float, conserved)."""
+        bases = [float(it._base_width) for it in items]
+        widths = list(bases)
+        n = len(items)
+        for i, it in enumerate(items):
+            if not it._adjacent_animation:
+                continue
+            p = it._press_progress.value
+            if p <= 0.0:
+                continue
+            p = min(1.0, p)  # clamp any motion overshoot so content never clips
+            ratio = float(getattr(it._style, "pressed_width_multiplier", 0.0))
+            half = ratio * bases[i] / 2.0
+            # Each side's growth is bounded by the *neighbor's* padding, so a
+            # compressed neighbor never loses more than its padding (content
+            # stays intact).  Edge items grow on their single available side.
+            if i > 0:
+                gl = min(half, self._pad(items[i - 1])) * p
+                widths[i] += gl
+                widths[i - 1] -= gl
+            if i < n - 1:
+                gr = min(half, self._pad(items[i + 1])) * p
+                widths[i] += gr
+                widths[i + 1] -= gr
+        return widths
+
+    @staticmethod
+    def _item_height(item: "GroupButton", content_height: int) -> int:
+        dim = item.height_sizing
+        if dim is not None and dim.kind == "fixed":
+            return int(dim.value)
+        return content_height
+
+    @staticmethod
+    def _pad(item: "GroupButton") -> float:
+        """Horizontal inner padding = the maximum a neighbor may be compressed by."""
+        return float(getattr(item._style, "inner_padding", 12))
 
 
 # ---------------------------------------------------------------------------
@@ -593,9 +753,10 @@ class _ButtonGroupBase(Box):
         self._persistent_selected_pressed_shape = persistent_selected_pressed_shape
         self._connected_inner_press_only = connected_inner_press_only
 
-        from nuiitivet.layout.row import Row
-
-        row = Row(
+        # Standard groups use the interaction-aware row (active grows / neighbors
+        # compress in one coordinated pass); Connected groups use a plain Row.
+        row_cls = _ButtonGroupRow if adjacent_animation else Row
+        row = row_cls(
             list(items),
             gap=style.item_gap,
             cross_alignment="center",
@@ -604,6 +765,37 @@ class _ButtonGroupBase(Box):
         )
 
         super().__init__(child=row, width=group_width)
+
+        # Propagate the group's sized style to items now, so the tree measures
+        # correctly even before mount.  Window auto-sizing calls preferred_size
+        # on the *unmounted* content tree; without this each item would still
+        # carry its default style and report too small a width (the height comes
+        # from the group container_height, so only width is affected).
+        self._apply_item_sizing()
+
+    def _apply_item_sizing(self) -> None:
+        """Propagate the group's sized style + content metrics to every item.
+
+        Covers only the properties that affect measurement (style, fixed item
+        height, rebuilt icon/label content, padding) so it is safe to run before
+        mount.  Idempotent: ``on_mount`` calls it again before wiring colours,
+        positions and corner animation.
+        """
+        size_tokens = self._item_size_tokens()
+        for item in self._items:
+            # Items without a user-provided style inherit the full group style;
+            # items with a custom style only receive size tokens so they keep
+            # their custom colours.
+            if not item._has_user_style:
+                item._style = self._style
+            else:
+                item._style = item._style.copy_with(**size_tokens)
+            item.height_sizing = Sizing.fixed(self._style.container_height)
+            # Rebuild content so icon/label sizes reflect the assigned style.
+            item._rebuild_content()
+            # Leading/trailing space is reserved via preferred_size + centring,
+            # not box padding (see GroupButton._side_space).
+            item.padding = 0
 
     def _item_size_tokens(self) -> dict[str, int | float]:
         """Return size tokens to propagate to items with user-provided styles.
@@ -614,15 +806,21 @@ class _ButtonGroupBase(Box):
         """
         return {
             "container_height": self._style.container_height,
+            "icon_size": self._style.icon_size,
+            "label_size": self._style.label_size,
+            "icon_label_space": self._style.icon_label_space,
             "outer_corner_radius": self._style.outer_corner_radius,
+            "pressed_outer_corner_radius": self._style.pressed_outer_corner_radius,
             "pressed_inner_corner_radius": self._style.pressed_inner_corner_radius,
         }
 
     def on_mount(self) -> None:
         """Assign positions, sync size-layout tokens, and set neighbors for all items."""
         super().on_mount()
+        # Re-sync style + content (also done at construction) so any change is
+        # reflected, then wire up the mount-only visuals and interaction state.
+        self._apply_item_sizing()
         n = len(self._items)
-        _size_tokens = self._item_size_tokens()
         for i, item in enumerate(self._items):
             if n == 1:
                 pos: ButtonGroupPosition = "only"
@@ -633,14 +831,6 @@ class _ButtonGroupBase(Box):
             else:
                 pos = "middle"
 
-            # Propagate group style to items.  Items without a user-provided
-            # style inherit the full group style; items with a custom style
-            # only receive size tokens so they keep their custom colours.
-            if not item._has_user_style:
-                item._style = self._style
-            else:
-                item._style = item._style.copy_with(**_size_tokens)
-            item.height_sizing = Sizing.fixed(self._style.container_height)
             # Refresh visual properties that were baked in during __init__.
             bg, fg, bc, bw = item._effective_colors()
             item.bgcolor = bg
@@ -649,14 +839,11 @@ class _ButtonGroupBase(Box):
             item.state_layer_color = item._style.overlay_color or ColorRole.ON_SURFACE
             item._PRESS_OPACITY = item._style.overlay_alpha
             item._HOVER_OPACITY = item._style.overlay_alpha * 2 / 3
-            item._apply_foreground(fg)
             item.mark_needs_layout()
             item._persistent_selected_pressed_shape = self._persistent_selected_pressed_shape
             item._connected_inner_press_only = self._connected_inner_press_only
 
-            left = self._items[i - 1] if i > 0 else None
-            right = self._items[i + 1] if i < n - 1 else None
-            item.set_position(pos, (left, right), adjacent_animation=self._adjacent_animation)
+            item.set_position(pos, adjacent_animation=self._adjacent_animation)
 
 
 def _validate_items(items: Sequence[object]) -> None:
@@ -686,9 +873,12 @@ def _validate_items(items: Sequence[object]) -> None:
 class StandardButtonGroup(_ButtonGroupBase):
     """A ButtonGroup that organises action or toggle segments horizontally.
 
-    Width fits the combined item widths.  Adjacent segments animate their
-    junction corners in response to a neighbor's press (M3 Expressive motion).
-    Item selected states are independent — no group-level enforcement.
+    Width fits the combined item widths.  When a segment is activated (pressed)
+    or selected, the MD3 adjacent interaction runs: the active segment animates
+    its **width**, **shape**, and (via centered content) **padding**, while its
+    direct neighbors shrink to compensate so the group's overall width stays
+    stable.  All transitions use M3 Expressive (``EXPRESSIVE_FAST_SPATIAL``)
+    motion.  Item selected states are independent — no group-level enforcement.
 
     Args:
         items: Between 2 and 5 ``GroupButton`` instances.
@@ -717,12 +907,19 @@ class StandardButtonGroup(_ButtonGroupBase):
         eff_style = style if style is not None else _Std.filled()
         super().__init__(
             items,
-            adjacent_animation=False,
+            adjacent_animation=True,
             persistent_selected_pressed_shape=True,
             connected_inner_press_only=False,
             group_width=None,  # Fits content
             style=eff_style,
         )
+
+    def _item_size_tokens(self) -> dict[str, int | float]:
+        """Include ``inner_padding`` (a real field on Standard style)."""
+        tokens = super()._item_size_tokens()
+        style = cast("StandardButtonGroupStyle", self._style)
+        tokens["inner_padding"] = style.inner_padding
+        return tokens
 
 
 # ---------------------------------------------------------------------------

--- a/src/nuiitivet/material/motion.py
+++ b/src/nuiitivet/material/motion.py
@@ -6,7 +6,9 @@ Durations are in seconds.
 
 from __future__ import annotations
 
-from nuiitivet.animation.motion import BezierMotion, Motion
+import math
+
+from nuiitivet.animation.motion import BezierMotion, Motion, SpringMotion
 
 
 # Expressive spatial
@@ -19,6 +21,17 @@ EXPRESSIVE_FAST_EFFECTS: Motion = BezierMotion(0.31, 0.94, 0.34, 1.00, 0.15)
 EXPRESSIVE_DEFAULT_EFFECTS: Motion = BezierMotion(0.34, 0.80, 0.34, 1.00, 0.20)
 EXPRESSIVE_SLOW_EFFECTS: Motion = BezierMotion(0.34, 0.88, 0.34, 1.00, 0.30)
 
+# Standard button group — pressed item width spring.
+# MD3 token: dampening (ratio) 0.9, stiffness 1400 (all sizes).  The damping
+# coefficient is derived from the ratio with unit mass: c = 2 * ζ * sqrt(k * m).
+_BTN_GROUP_WIDTH_STIFFNESS = 1400.0
+_BTN_GROUP_WIDTH_DAMPING_RATIO = 0.9
+STANDARD_BUTTON_GROUP_WIDTH: Motion = SpringMotion(
+    stiffness=_BTN_GROUP_WIDTH_STIFFNESS,
+    damping=2.0 * _BTN_GROUP_WIDTH_DAMPING_RATIO * math.sqrt(_BTN_GROUP_WIDTH_STIFFNESS),
+    mass=1.0,
+)
+
 
 __all__ = [
     "EXPRESSIVE_FAST_SPATIAL",
@@ -27,4 +40,5 @@ __all__ = [
     "EXPRESSIVE_FAST_EFFECTS",
     "EXPRESSIVE_DEFAULT_EFFECTS",
     "EXPRESSIVE_SLOW_EFFECTS",
+    "STANDARD_BUTTON_GROUP_WIDTH",
 ]

--- a/src/nuiitivet/material/styles/button_group_style.py
+++ b/src/nuiitivet/material/styles/button_group_style.py
@@ -31,32 +31,52 @@ _STANDARD_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
     "xs": {
         "container_height": 32,
         "item_gap": 18,
+        "inner_padding": 12,
+        "icon_size": 20,
+        "label_size": 14,
+        "icon_label_space": 8,
         "outer_corner_radius": 16.0,
-        "pressed_inner_corner_radius": 8.0,
+        "pressed_corner_radius": 12.0,
     },
     "s": {
         "container_height": 40,
         "item_gap": 12,
+        "inner_padding": 16,
+        "icon_size": 20,
+        "label_size": 14,
+        "icon_label_space": 8,
         "outer_corner_radius": 20.0,
-        "pressed_inner_corner_radius": 8.0,
+        "pressed_corner_radius": 12.0,
     },
     "m": {
         "container_height": 56,
         "item_gap": 8,
+        "inner_padding": 24,
+        "icon_size": 24,
+        "label_size": 16,
+        "icon_label_space": 8,
         "outer_corner_radius": 28.0,
-        "pressed_inner_corner_radius": 8.0,
+        "pressed_corner_radius": 16.0,
     },
     "l": {
         "container_height": 96,
         "item_gap": 8,
+        "inner_padding": 48,
+        "icon_size": 32,
+        "label_size": 24,
+        "icon_label_space": 12,
         "outer_corner_radius": 48.0,
-        "pressed_inner_corner_radius": 8.0,
+        "pressed_corner_radius": 28.0,
     },
     "xl": {
         "container_height": 136,
         "item_gap": 8,
+        "inner_padding": 64,
+        "icon_size": 40,
+        "label_size": 32,
+        "icon_label_space": 16,
         "outer_corner_radius": 68.0,
-        "pressed_inner_corner_radius": 8.0,
+        "pressed_corner_radius": 28.0,
     },
 }
 
@@ -64,6 +84,9 @@ _CONNECTED_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
     "xs": {
         "container_height": 32,
         "item_gap": 2,
+        "icon_size": 20,
+        "label_size": 14,
+        "icon_label_space": 8,
         "outer_corner_radius": 16.0,
         "inner_corner_radius": 8.0,
         "pressed_inner_corner_radius": 4.0,
@@ -71,6 +94,9 @@ _CONNECTED_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
     "s": {
         "container_height": 40,
         "item_gap": 2,
+        "icon_size": 20,
+        "label_size": 14,
+        "icon_label_space": 8,
         "outer_corner_radius": 20.0,
         "inner_corner_radius": 8.0,
         "pressed_inner_corner_radius": 4.0,
@@ -78,6 +104,9 @@ _CONNECTED_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
     "m": {
         "container_height": 56,
         "item_gap": 2,
+        "icon_size": 24,
+        "label_size": 16,
+        "icon_label_space": 8,
         "outer_corner_radius": 28.0,
         "inner_corner_radius": 8.0,
         "pressed_inner_corner_radius": 4.0,
@@ -85,6 +114,9 @@ _CONNECTED_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
     "l": {
         "container_height": 96,
         "item_gap": 2,
+        "icon_size": 32,
+        "label_size": 24,
+        "icon_label_space": 12,
         "outer_corner_radius": 48.0,
         "inner_corner_radius": 16.0,
         "pressed_inner_corner_radius": 12.0,
@@ -92,6 +124,9 @@ _CONNECTED_SIZE_TOKENS: dict[str, dict[str, int | float]] = {
     "xl": {
         "container_height": 136,
         "item_gap": 2,
+        "icon_size": 40,
+        "label_size": 32,
+        "icon_label_space": 16,
         "outer_corner_radius": 68.0,
         "inner_corner_radius": 20.0,
         "pressed_inner_corner_radius": 16.0,
@@ -128,13 +163,32 @@ class StandardButtonGroupStyle:
 
     # Sizing
     container_height: int = 40
-    item_gap: int = 12
+    item_gap: int = 12  # between-space: gap between adjacent segments
     min_item_width: int = 48
+    # Per-segment horizontal padding.  Sourced from the MD3 *button*
+    # leading-space / trailing-space tokens (xs=12, s=16, m=24, l=48, xl=64),
+    # NOT the group between-space — each segment is a button and keeps the
+    # button's own side padding.
+    inner_padding: int = 16
 
-    # Shape tokens
+    # Content metrics (scale with size, sourced from the MD3 button tokens)
+    icon_size: int = 20
+    label_size: int = 14
+    icon_label_space: int = 8
+
+    # Shape tokens.  The pressed/selected "squared" shape is the MD3 button
+    # square shape (== "selected container shape round"): xs/s=12, m=16, l/xl=28.
+    # Standard pills are uniform, so outer and inner share this value; a selected
+    # segment keeps the same shape as a pressed one (matching the MD3 demo).
     outer_corner_radius: float = 20.0
-    pressed_outer_corner_radius: float = 8.0
-    pressed_inner_corner_radius: float = 8.0
+    pressed_outer_corner_radius: float = 12.0
+    pressed_inner_corner_radius: float = 12.0
+
+    # Adjacent-interaction motion (M3): while an item is *pressed* it grows by
+    # this fraction of its natural width and its direct neighbors shrink to
+    # compensate; on release the width returns to idle (selection is shown by
+    # colour/shape, not width).  Spec value: 15% for all sizes.
+    pressed_width_multiplier: float = 0.15
 
     # State overlay
     overlay_color: Optional[ColorSpec] = None
@@ -183,8 +237,13 @@ class StandardButtonGroupStyle:
             selected_foreground=ColorRole.ON_PRIMARY,
             container_height=int(t["container_height"]),
             item_gap=int(t["item_gap"]),
+            icon_size=int(t["icon_size"]),
+            label_size=int(t["label_size"]),
+            icon_label_space=int(t["icon_label_space"]),
+            inner_padding=int(t["inner_padding"]),
             outer_corner_radius=float(t["outer_corner_radius"]),
-            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+            pressed_outer_corner_radius=float(t["pressed_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_corner_radius"]),
         )
 
     @classmethod
@@ -205,8 +264,13 @@ class StandardButtonGroupStyle:
             selected_foreground=ColorRole.ON_SECONDARY,
             container_height=int(t["container_height"]),
             item_gap=int(t["item_gap"]),
+            icon_size=int(t["icon_size"]),
+            label_size=int(t["label_size"]),
+            icon_label_space=int(t["icon_label_space"]),
+            inner_padding=int(t["inner_padding"]),
             outer_corner_radius=float(t["outer_corner_radius"]),
-            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+            pressed_outer_corner_radius=float(t["pressed_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_corner_radius"]),
         )
 
     @classmethod
@@ -228,8 +292,13 @@ class StandardButtonGroupStyle:
             selected_foreground=ColorRole.INVERSE_ON_SURFACE,
             container_height=int(t["container_height"]),
             item_gap=int(t["item_gap"]),
+            icon_size=int(t["icon_size"]),
+            label_size=int(t["label_size"]),
+            icon_label_space=int(t["icon_label_space"]),
+            inner_padding=int(t["inner_padding"]),
             outer_corner_radius=float(t["outer_corner_radius"]),
-            pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
+            pressed_outer_corner_radius=float(t["pressed_corner_radius"]),
+            pressed_inner_corner_radius=float(t["pressed_corner_radius"]),
         )
 
     @classmethod
@@ -286,6 +355,11 @@ class ConnectedButtonGroupStyle:
     item_gap: int = 2
     min_item_width: int = 48
 
+    # Content metrics (scale with size, sourced from the MD3 button tokens)
+    icon_size: int = 20
+    label_size: int = 14
+    icon_label_space: int = 8
+
     # Shape tokens (idle)
     outer_corner_radius: float = 20.0
     inner_corner_radius: float = 8.0
@@ -327,6 +401,9 @@ class ConnectedButtonGroupStyle:
             selected_foreground=ColorRole.ON_PRIMARY,
             container_height=int(t["container_height"]),
             item_gap=int(t["item_gap"]),
+            icon_size=int(t["icon_size"]),
+            label_size=int(t["label_size"]),
+            icon_label_space=int(t["icon_label_space"]),
             outer_corner_radius=float(t["outer_corner_radius"]),
             inner_corner_radius=float(t["inner_corner_radius"]),
             pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
@@ -350,6 +427,9 @@ class ConnectedButtonGroupStyle:
             selected_foreground=ColorRole.ON_SECONDARY,
             container_height=int(t["container_height"]),
             item_gap=int(t["item_gap"]),
+            icon_size=int(t["icon_size"]),
+            label_size=int(t["label_size"]),
+            icon_label_space=int(t["icon_label_space"]),
             outer_corner_radius=float(t["outer_corner_radius"]),
             inner_corner_radius=float(t["inner_corner_radius"]),
             pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),
@@ -375,6 +455,9 @@ class ConnectedButtonGroupStyle:
             selected_border_color=ColorRole.OUTLINE,
             container_height=int(t["container_height"]),
             item_gap=int(t["item_gap"]),
+            icon_size=int(t["icon_size"]),
+            label_size=int(t["label_size"]),
+            icon_label_space=int(t["icon_label_space"]),
             outer_corner_radius=float(t["outer_corner_radius"]),
             inner_corner_radius=float(t["inner_corner_radius"]),
             pressed_inner_corner_radius=float(t["pressed_inner_corner_radius"]),

--- a/tests/material/test_button_group.py
+++ b/tests/material/test_button_group.py
@@ -254,8 +254,11 @@ def test_variant_outlined():
 # ===========================================================================
 
 
-def test_standard_no_neighbor_animate_on_press():
-    """Standard group: pressing an item does NOT affect adjacent item corners."""
+def test_standard_neighbor_corners_unaffected_on_press():
+    """Standard group: pressing an item must NOT alter a neighbor's corners.
+
+    Per MD3, the adjacent interaction adjusts neighbor **width**, not shape.
+    """
     items = _make_items(3)
     group = StandardButtonGroup(items)
     _mount_group(group)
@@ -264,21 +267,214 @@ def test_standard_no_neighbor_animate_on_press():
     middle_item = items[1]  # "middle"
     s = middle_item._style
 
-    # Press start item
+    # Press start item — its corners morph, but the middle neighbor's corners
+    # stay at idle.
     send_pointer_event_for_test(start_item, PointerEventType.PRESS)
 
-    # Middle should remain at idle corners
     tl, tr, br, bl = middle_item._corner_anim.target
     assert tl == s.inner_corner_radius
-    assert bl == s.inner_corner_radius
     assert tr == s.inner_corner_radius
     assert br == s.inner_corner_radius
+    assert bl == s.inner_corner_radius
 
-    # Release
+    # Release — still idle.
     send_pointer_event_for_test(start_item, PointerEventType.RELEASE)
-    tl2, tr2, br2, bl2 = middle_item._corner_anim.target
-    assert tl2 == s.inner_corner_radius
-    assert bl2 == s.inner_corner_radius
+    assert middle_item._corner_anim.target == (
+        s.inner_corner_radius,
+        s.inner_corner_radius,
+        s.inner_corner_radius,
+        s.inner_corner_radius,
+    )
+
+
+# ===========================================================================
+# StandardButtonGroup — adjacent width interaction
+# ===========================================================================
+
+
+def _make_wide_items(n: int) -> List[GroupButton]:
+    """Items sharing a wide, identical-width label so their base widths match.
+
+    Equal base widths keep the growth/shrink arithmetic exact: the per-neighbor
+    shrink room equals the active item's growth share, so no capping kicks in.
+    """
+    return [_make_item("Wide Label") for _ in range(n)]
+
+
+def _group_row(group):
+    """Return the group's interaction-aware row (Standard groups only)."""
+    from nuiitivet.material.button_group import _ButtonGroupRow
+
+    for child in group.children:
+        if isinstance(child, _ButtonGroupRow):
+            return child
+    raise AssertionError("interaction row not found")
+
+
+def _computed_widths(group):
+    """Run the parent's single-pass width computation for the current progress."""
+    row = _group_row(group)
+    return row._interaction_widths(list(group._items))
+
+
+def _set_active(item, active: bool = True) -> None:
+    """Force an item's active progress (bypassing animation) to 0 or 1."""
+    item._press_progress.snap_to(1.0 if active else 0.0)
+
+
+def _side_growth(active, neighbor) -> float:
+    """Expected per-side growth: half the multiplier, capped by neighbor padding."""
+    half = active._style.pressed_width_multiplier * active._base_width / 2.0
+    pad = float(getattr(neighbor._style, "inner_padding", 12))
+    return min(half, pad)
+
+
+def test_standard_press_sets_active_progress():
+    """Pressing an item drives its active progress toward 1.0."""
+    items = _make_wide_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    item = items[1]  # middle
+    send_pointer_event_for_test(item, PointerEventType.PRESS)
+    assert item._press_progress.target == pytest.approx(1.0)
+    # Releasing without selecting returns toward 0.0 (independent action item).
+
+
+def test_standard_active_item_grows():
+    """An active item's computed width grows by both-side growth."""
+    items = _make_wide_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    start, middle, end = items
+    _set_active(middle)
+
+    widths = _computed_widths(group)
+    expected = middle._base_width + _side_growth(middle, start) + _side_growth(middle, end)
+    assert widths[1] == pytest.approx(expected)
+    assert widths[1] > middle._base_width
+
+
+def test_standard_neighbors_compress_to_compensate():
+    """An active middle item compresses both neighbors by its per-side growth."""
+    items = _make_wide_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    start, middle, end = items
+    _set_active(middle)
+
+    widths = _computed_widths(group)
+    assert widths[0] == pytest.approx(start._base_width - _side_growth(middle, start))
+    assert widths[2] == pytest.approx(end._base_width - _side_growth(middle, end))
+    # Total width is conserved (no group bulge).
+    assert sum(widths) == pytest.approx(sum(it._base_width for it in items))
+
+
+def test_standard_edge_item_compresses_single_neighbor():
+    """An edge item grows only on its one available side, compressing one neighbor."""
+    items = _make_wide_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    start, middle, end = items
+    _set_active(start)
+
+    widths = _computed_widths(group)
+    g = _side_growth(start, middle)
+    assert widths[0] == pytest.approx(start._base_width + g)
+    assert widths[1] == pytest.approx(middle._base_width - g)
+    assert widths[2] == pytest.approx(end._base_width)
+
+
+def test_standard_width_expands_on_press_only():
+    """Width grows only while pressed; on release it returns to idle width.
+
+    MD3 defines only a *pressed* width token — selection is conveyed by colour
+    and corner shape, not by a persistent width change.
+    """
+    items = _make_wide_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    item = items[1]
+    # Press → peak expansion.
+    send_pointer_event_for_test(item, PointerEventType.PRESS)
+    assert item._press_progress.target == pytest.approx(1.0)
+    # Release (click) → selected, but width returns to idle.
+    send_pointer_event_for_test(item, PointerEventType.RELEASE)
+    assert item._selected is True
+    assert item._press_progress.target == pytest.approx(0.0)
+
+
+def test_standard_selected_item_rests_at_idle_width():
+    """Selecting / deselecting never leaves a persistent width expansion."""
+    items = _make_wide_items(3)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    middle = items[1]
+    _click(middle)  # select
+    assert middle._selected is True
+    assert middle._press_progress.target == pytest.approx(0.0)
+
+    _click(middle)  # deselect
+    assert middle._selected is False
+    assert middle._press_progress.target == pytest.approx(0.0)
+
+    # With progress settled at 0 (no active item), computed widths equal bases.
+    for it in items:
+        _set_active(it, False)
+    widths = _computed_widths(group)
+    assert widths == pytest.approx([it._base_width for it in items])
+
+
+def test_standard_side_space_reserved_via_centering():
+    """Standard items reserve side space as centred margin, not box padding.
+
+    The MD3 button leading/trailing-space (m → 24dp) is reserved in the item's
+    preferred width and rendered by centring the content (box padding stays 0),
+    so the pressed-width interaction compresses neighbours symmetrically.
+    """
+    items = _make_items(2)
+    group = StandardButtonGroup(items, style=StandardButtonGroupStyle.filled("m"))
+    _mount_group(group)
+
+    item = items[0]
+    # No box padding: the space is centred margin, not an inset inner rect.
+    assert item.padding == (0, 0, 0, 0)
+    # Preferred width reserves 2 × 24dp around the bare content width.
+    content_w = item.children[0].preferred_size()[0]
+    assert item.preferred_size()[0] == content_w + 2 * 24
+
+
+def test_standard_content_centered_in_item():
+    """Content sits centred in the item, with equal left/right margins."""
+    items = _make_items(2)
+    group = StandardButtonGroup(items, style=StandardButtonGroupStyle.filled("m"))
+    _mount_group(group)
+
+    item = items[0]
+    iw, ih = item.preferred_size()
+    item.layout(iw, ih)
+    cx, _cy, cw, _ch = item.children[0].layout_rect
+    left_margin = cx
+    right_margin = iw - (cx + cw)
+    assert left_margin == pytest.approx(right_margin, abs=1)
+
+
+def test_connected_width_interaction_disabled():
+    """Connected group: pressing an item leaves neighbor widths untouched."""
+    items = _make_items(3)
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+
+    start, middle, end = items
+    # Connected items keep flex sizing; the width animation must not engage.
+    send_pointer_event_for_test(middle, PointerEventType.PRESS)
+    assert start.width_sizing.kind == "flex"
+    assert end.width_sizing.kind == "flex"
 
 
 def test_standard_item_selected_independent():
@@ -298,7 +494,13 @@ def test_standard_item_selected_independent():
 
 
 def test_standard_selected_keeps_squarer_shape_after_release() -> None:
-    """Standard item keeps selected shape (does not snap back to idle rounded)."""
+    """Standard item keeps the pressed (squared) shape while selected.
+
+    The MD3 button-group spec defines no separate selected shape for standard
+    groups, and the official demo shows a selected segment at the same roundness
+    as a pressed one, so selection reuses the pressed corners (it does not snap
+    back to the idle rounded pill).
+    """
     items = _make_items(3)
     group = StandardButtonGroup(items)
     _mount_group(group)
@@ -339,11 +541,72 @@ def test_standard_unselected_returns_to_idle_rounded_shape() -> None:
 
 
 def test_standard_preferred_size():
-    """Group height matches container_height; item width respects min_item_width."""
-    item = _make_item()
-    _h = item._style.container_height
-    assert item.preferred_size()[1] == _h
+    """Standard item height matches container_height; width is content-fit.
+
+    The 48dp spec value is a tap-target requirement, not a visual width floor,
+    so a Standard item is free to be narrower than ``min_item_width``.
+    """
+    items = _make_items(2)
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+    item = items[0]
+    assert item.preferred_size()[1] == item._style.container_height
+    # Content-fit: a short label may render narrower than min_item_width.
+    assert item.preferred_size()[0] == item._base_width
+
+
+def test_standard_preferred_size_correct_before_mount():
+    """A group reports its sized width before mount (window auto-sizing).
+
+    Window auto-sizing measures the unmounted content tree.  The group must
+    propagate its size-specific style to items at construction so a larger size
+    is not under-measured at the default ("s") size (regression: only width was
+    affected because height comes from container_height).
+    """
+    items = [GroupButton(icon="event", label="Week") for _ in range(3)]
+    group = StandardButtonGroup(items, style=StandardButtonGroupStyle.filled("l"))
+
+    pre = group.preferred_size()
+    _mount_group(group)
+    post = group.preferred_size()
+
+    assert pre == post
+    # Larger size really is wider than the default "s" group of the same labels.
+    s_items = [GroupButton(icon="event", label="Week") for _ in range(3)]
+    s_group = StandardButtonGroup(s_items, style=StandardButtonGroupStyle.filled("s"))
+    assert pre[0] > s_group.preferred_size()[0]
+
+
+def test_connected_preferred_size_enforces_min_width():
+    """Connected items still enforce the 48dp visual minimum width."""
+    items = _make_items(2)
+    group = ConnectedButtonGroup(items)
+    _mount_group(group)
+    item = items[0]
     assert item.preferred_size()[0] >= item._style.min_item_width
+
+
+def test_standard_group_width_preserved_with_short_labels():
+    """Short-label / icon-only segments must not bulge the group on press.
+
+    The parent computes all widths in one pass: the active item's growth is
+    exactly the neighbors' compression, so the summed width is conserved and the
+    rightmost item cannot accumulate jitter.
+    """
+    items = _make_items(3)  # short labels "0","1","2"
+    group = StandardButtonGroup(items)
+    _mount_group(group)
+
+    initial_total = sum(it._base_width for it in items)
+
+    _set_active(items[1])  # middle active
+    widths = _computed_widths(group)
+
+    # Active grows, both neighbors compress, total unchanged (no bulge).
+    assert sum(widths) == pytest.approx(initial_total)
+    assert widths[1] > items[1]._base_width
+    assert widths[0] < items[0]._base_width
+    assert widths[2] < items[2]._base_width
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- **Adjacent-width interaction**: a pressed standard-group item grows by 15% and its direct neighbours compress to keep the group width conserved (single coordinated layout pass in `_ButtonGroupRow`).
- **MD3 width spring**: add `STANDARD_BUTTON_GROUP_WIDTH` (stiffness 1400, damping ratio 0.9) and sub-step `SpringMotion` so stiff springs stay stable and frame-rate independent.
- **Per-segment spacing**: leading/trailing space now follows the MD3 button leading/trailing-space tokens (xs=12, s=16, m=24, l=48, xl=64), reserved via `preferred_size` and centred so icon/label stays centred and neighbours compress symmetrically.
- **Shape morph**: pressed and selected morph to the MD3 square shape (xs/s=12, m=16, l/xl=28); selection reuses the pressed corners (matching the official demo).
- **Auto-sizing fix**: propagate the group's sized style to items at construction (`_apply_item_sizing`) so window auto-sizing measures the correct width on the unmounted tree.
- Update the showcase sample and tests.

## Test plan
- [x] `pytest tests/` — 1421 passed
- [x] `mypy` — no issues found in 541 source files
- [x] Pre/post-mount `preferred_size` match for all sizes (auto-size width correct)
- [x] Visual check: icon+label centred; selected ≈ pressed roundness, scaling by size
- [ ] Manual: run `samples/material_widgets/button_group.py`, press/select segments across sizes

Closes #239