### PR TITLE
fix(widget_builder): make measure side-effect-free and render_scope idempotent (#244)

### DIFF
--- a/src/nuiitivet/layout/for_each.py
+++ b/src/nuiitivet/layout/for_each.py
@@ -192,8 +192,16 @@ class ForEach(ComposableWidget):
                 )
                 self._entries_by_token[info.token] = entry
             else:
+                # Reusing an existing scope (same token). Scoped fragments now
+                # rebuild only when explicitly invalidated, so a changed value
+                # must be signalled rather than relying on unconditional re-entry.
+                # Update the entry first: invalidation may flush synchronously
+                # (unmounted host) and rebuild from entry.value immediately.
+                value_changed = not self._values_equal(entry.value, info.value)
                 entry.index = info.index
                 entry.value = info.value
+                if value_changed and entry.scope_id:
+                    self.invalidate_scope_id(entry.scope_id)
             fragment = self._ensure_fragment(entry)
             if fragment is not None:
                 next_children.append(fragment)

--- a/src/nuiitivet/widgeting/widget_builder.py
+++ b/src/nuiitivet/widgeting/widget_builder.py
@@ -364,6 +364,10 @@ class BuilderHostMixin:
         self._active_scope_ids: Set[str] = set()
         self._scope_metadata: Dict[str, ScopeMetadata] = {}
         self._dependency_scope_index: Dict[str, Set[str]] = {}
+        # Scopes whose inputs were invalidated and must be rebuilt on the next
+        # render. A scope rebuilds only when it is new, unbuilt, or dirty — not
+        # whenever the host's build() re-runs (idempotent recomposition).
+        self._dirty_scopes: Set[str] = set()
 
     @property
     def built_child(self) -> Optional["Widget"]:
@@ -478,6 +482,7 @@ class BuilderHostMixin:
         self._active_scope_ids.clear()
         self._scope_metadata.clear()
         self._dependency_scope_index.clear()
+        self._dirty_scopes.clear()
 
     # --- Lifecycle & Rendering (Mixin overrides) --------------------------
     def on_mount(self) -> None:
@@ -535,9 +540,18 @@ class BuilderHostMixin:
         if self._built:
             return measure_preferred_size(self._built, max_width=max_width, max_height=max_height)
 
-        # Unmounted composables still need intrinsic sizing (e.g. App auto
-        # window sizing before mount). Evaluate build once and measure the
-        # returned subtree directly.
+        # Measuring must be side-effect-free (issue #244). When mounted, the live
+        # subtree already exists — either as ``_built`` (handled above) or, for
+        # widgets whose ``build()`` returns ``self`` (e.g. Card), as mounted
+        # children. Measure those directly; never call ``build()`` here, since
+        # rebuilding a scoped fragment would unmount the subtree and cancel an
+        # in-progress pointer gesture.
+        if getattr(self, "_app", None) is not None:
+            return super().preferred_size(max_width=max_width, max_height=max_height)  # type: ignore
+
+        # Unmounted composables still need intrinsic sizing (e.g. App auto window
+        # sizing before mount). There is no live subtree to harm, so evaluate
+        # build once and measure the returned subtree directly.
         try:
             built = self.evaluate_build()
         except Exception:
@@ -571,6 +585,14 @@ class BuilderHostMixin:
 
     # --- Scope helpers ----------------------------------------------------
     def render_scope(self, name: str, factory: Callable[[], "Widget"]) -> "Widget":
+        """Render ``factory`` inside a named, independently-recomposable scope.
+
+        Recomposition is idempotent: the scope's subtree is rebuilt only when the
+        scope is invalidated (``invalidate_scope_id`` / a tracked dependency), not
+        merely because the host's ``build()`` re-runs. Callers that mutate the
+        factory's inputs must invalidate the scope; relying on a host rebuild to
+        refresh an un-invalidated scope will not work.
+        """
         ctx = self._build_ctx
         if ctx is None:
             return _require_widget_instance(factory())
@@ -600,16 +622,26 @@ class BuilderHostMixin:
         if fragment is None:
             fragment = ScopedFragment(scope_id=scope_id, factory=normalized_factory)
             self._scope_nodes[scope_id] = fragment
+            needs_build = True
         else:
+            # Always refresh the stored factory so a later invalidation rebuilds
+            # against current host state, even when we skip rebuilding now.
             fragment.update_factory(normalized_factory)
-        try:
-            fragment.rebuild()
-        except Exception:
-            exception_once(
-                _logger,
-                "widget_builder_scope_fragment_rebuild_exc",
-                "Scoped fragment rebuild raised",
-            )
+            # Idempotent recomposition (issue #244): rebuild only when the scope
+            # was explicitly invalidated or has no built subtree yet. Re-entering
+            # build() (e.g. on every measure) must not tear down the live subtree.
+            needs_build = scope_id in self._dirty_scopes or fragment.built_child is None
+
+        if needs_build:
+            try:
+                fragment.rebuild()
+            except Exception:
+                exception_once(
+                    _logger,
+                    "widget_builder_scope_fragment_rebuild_exc",
+                    "Scoped fragment rebuild raised",
+                )
+            self._dirty_scopes.discard(scope_id)
         self._capture_scope_metadata(scope_id, factory, fragment)
         return fragment
 
@@ -628,6 +660,7 @@ class BuilderHostMixin:
         stale = [scope_id for scope_id in self._scope_nodes.keys() if scope_id not in active]
         for scope_id in stale:
             fragment = self._scope_nodes.pop(scope_id)
+            self._dirty_scopes.discard(scope_id)
             try:
                 fragment.unmount()
             except Exception:
@@ -673,6 +706,9 @@ class BuilderHostMixin:
     def _schedule_scope_recomposition(self, scope_id: str) -> bool:
         if scope_id not in self._scope_nodes:
             return False
+        # Single funnel for every scope invalidation: mark the scope dirty so the
+        # next render (in-line or via _perform_scope_rebuild) rebuilds it.
+        self._dirty_scopes.add(scope_id)
         first_insert = _queue_scope_recomposition(self, scope_id)
         if first_insert:
             invalidate = getattr(self, "invalidate", None)
@@ -715,6 +751,7 @@ class BuilderHostMixin:
                 "Scoped fragment rebuild raised in _perform_scope_rebuild",
             )
             return False
+        self._dirty_scopes.discard(scope_id)
         factory: Optional[Callable[[], "Widget"]]
         metadata = self._scope_metadata.get(scope_id)
         if metadata is not None:

--- a/tests/layout/test_for_each_rebuild.py
+++ b/tests/layout/test_for_each_rebuild.py
@@ -75,6 +75,28 @@ def test_value_change_in_place_invalidates_scope():
     assert calls == [(1, 42)]
 
 
+class _FakeApp:
+    def invalidate(self, immediate: bool = False) -> None:
+        pass
+
+
+def test_count_change_with_reused_value_rebuilds_when_mounted():
+    # A reused scope (same token) whose value changed must rebuild even on a
+    # mounted host, where scope invalidation queues instead of flushing. The
+    # in-line render in _sync_entries_from_tokens keeps this synchronous.
+    s = _make_obs([1, 2, 3])
+
+    def builder(item, idx):
+        return DummyWidget(10, 5, tag=item)
+
+    fe = ForEach(s, builder)
+    fe.mount(_FakeApp())
+    assert _child_tags(fe) == [1, 2, 3]
+    # Count shrinks 3 -> 1 and the reused idx0 entry's value changes 1 -> 42.
+    s.value = [42]
+    assert _child_tags(fe) == [42]
+
+
 def test_builder_invalid_entries_fallback_to_spacer():
     items = [1, 2, 3, 4]
 

--- a/tests/material/test_card.py
+++ b/tests/material/test_card.py
@@ -77,7 +77,7 @@ def test_set_child_replaces_scoped_fragment():
     assert second.last_rect == (0, 0, 50, 50)
 
 
-def test_callable_child_spec_is_evaluated_per_build():
+def test_callable_child_spec_cached_until_invalidated():
     builds = []
 
     def builder():
@@ -88,7 +88,45 @@ def test_callable_child_spec_is_evaluated_per_build():
     container = Card(builder, padding=0)
     container.evaluate_build()
     container.evaluate_build()
+    # Idempotent recomposition: re-evaluating build() (e.g. on every measure)
+    # reuses the cached scoped child instead of re-running the factory.
+    assert len(builds) == 1
+
+    # Explicit content invalidation re-evaluates the factory.
+    container.set_child(builder)
     assert len(builds) == 2
+
+
+class TrackingChild(Widget):
+    def __init__(self):
+        super().__init__()
+        self.unmount_count = 0
+
+    def preferred_size(self):
+        return (10, 10)
+
+    def on_unmount(self):
+        self.unmount_count += 1
+        super().on_unmount()
+
+    def paint(self, canvas, x, y, w, h):
+        self.set_last_rect(x, y, w, h)
+
+
+def test_measure_does_not_unmount_live_child():
+    # Regression for issue #244: measuring a mounted Card must not tear down
+    # (unmount) its live child subtree. Doing so cancels in-progress pointer
+    # gestures, so clicks on interactive children inside a Card never fire.
+    child = TrackingChild()
+    card = Card(child, padding=0)
+    card.mount(object())
+    assert child.unmount_count == 0
+
+    # Each measure pass re-evaluates Card.build() (Card._built is always None,
+    # since build() returns self). It must preserve the mounted subtree.
+    card.preferred_size()
+    card.preferred_size()
+    assert child.unmount_count == 0
 
 
 def test_elevated_card_reports_shadow_outsets():


### PR DESCRIPTION
## Summary
- Fixes #244: an interactive widget inside a `Card` lost its in-progress pointer gesture when a press triggered a relayout, so the click never fired.
- **Measure is now side-effect-free**: `preferred_size()` never calls `build()` for a mounted widget. It measures the existing subtree (`_built`, or the mounted children via `super()`); `build()` runs only when unmounted (intrinsic pre-mount sizing).
- **`render_scope` recomposition is now idempotent**: a scope rebuilds only when it is new, unbuilt, or explicitly invalidated (`_dirty_scopes`, funneled through `_schedule_scope_recomposition`) — not whenever the host's `build()` re-runs.
- **ForEach path 2** (count/token change) no longer relies on unconditional re-entry to pick up in-place value changes on reused scopes; it now signals them via `invalidate_scope_id`, preserving synchronous update timing.

## Root cause
`Card.build()` returns `self`, so `_built` is always `None`. Every measure re-evaluated `build()` → `_render_scope_entry` unconditionally called `fragment.rebuild()` → unmounted the live subtree → `cancel_all_for` dispatched a pointer CANCEL → the release was rejected.

## Contract change
Host-level invalidation no longer auto-rebuilds child scopes; a scope rebuilds only when *it* is invalidated. Only `Card` and `ForEach` use `render_scope` and both are updated. Documented in the `render_scope` docstring.

## Test plan
- [x] `python -m pytest tests/` — 1423 passed
- [x] `python -m mypy src/nuiitivet/widgeting/widget_builder.py src/nuiitivet/layout/for_each.py` — clean
- [x] New/updated regression tests fail without the fix (verified by reverting each change)
- [ ] Manual: a Standard button group inside a `Card` grows the active item on press and toggles selection on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)