### PR TITLE
docs(design): document measure purity and idempotent recomposition contracts (#247)

### DIFF
--- a/docs/design/LAYOUT.md
+++ b/docs/design/LAYOUT.md
@@ -60,7 +60,7 @@ How the allocated room is used (intrinsic or full fill) is decided by the child 
 Example: To fill a cell, explicitly specify `Sizing.flex(1)`.
 
 ```python
-cell = MaterialContainer(
+cell = Card(
     Text("Cell"),
     width=Sizing.flex(1),
     height=Sizing.flex(1),

--- a/docs/design/RENDERING_PIPELINE.md
+++ b/docs/design/RENDERING_PIPELINE.md
@@ -16,9 +16,10 @@ The phase where the Widget tree is constructed and incremental updates are perfo
 ### Scoped Rendering Optimization
 
 * **Fine-grained Updates**: Dynamic child elements are wrapped using `render_scope` blocks to prevent the regeneration of high-cost Widgets when a parent is rebuilt.
-* **Dedicated Scopes**: Core Widgets like `ForEach` and `MaterialContainer` have dedicated scopes to isolate list items or decorative content.
+* **Dedicated Scopes**: Core Widgets like `ForEach` and `Card` have dedicated scopes to isolate list items or decorative content.
 * **Dependency Tracking**: Scope metadata records `_layout_dependencies` and `_paint_dependencies` for each child, ensuring proper routing of binding invalidations.
-* **Batching**: Binding and scope recomposition queues are flushed together, and unmounted Widgets are rebuilt immediately.
+* **Idempotent Recomposition**: A scope is rebuilt only when it is new, unbuilt, or explicitly invalidated (tracked via `_dirty_scopes`); merely re-running the host's `build()` does **not** rebuild un-invalidated scopes. See [Widget Optimization › Recompose Scope API](WIDGET_ARCHITECTURE.md#1-recompose-scope-api).
+* **Batching**: Binding and scope recomposition queues are flushed together. For an unmounted host there is no pending frame to await, so invalidating a scope flushes its rebuild synchronously rather than deferring it.
 
 ## 2. Layout Phase
 
@@ -39,11 +40,15 @@ All `Widget`s adhere to the following protocol:
         4. Clear the `_needs_layout` flag.
     * **Forbidden**: Issuing draw commands or state changes with side effects (except for storing layout results).
 
-2. **`_layout_rect` Property**
+2. **`preferred_size()` Method**
+    * Reports the Widget's intrinsic size so the parent can allocate room during `layout()`.
+    * **Forbidden (measure purity)**: `preferred_size()` must be free of side effects, the same constraint that applies to `layout()`. In particular, measuring a mounted composable must **not** call `build()` and unmount/rebuild the live subtree — doing so discards focus, scroll position, animation state, and pointer capture, and cancels in-progress gestures. Measurement reads the existing subtree only.
+
+3. **`_layout_rect` Property**
     * Holds the relative position and size `(x, y, w, h)` as seen from the parent Widget, calculated during `layout()`.
     * The `paint()` method reads this value to perform rendering.
 
-3. **`mark_needs_layout()` Method**
+4. **`mark_needs_layout()` Method**
     * Called when a property affecting layout (e.g., `width`, `padding`, addition/removal of children) is changed.
     * Sets its own `_needs_layout` flag and propagates it recursively to the parent Widget.
     * This ensures that only necessary parts of the tree are re-laid out in the next frame.

--- a/docs/design/WIDGET_ARCHITECTURE.md
+++ b/docs/design/WIDGET_ARCHITECTURE.md
@@ -154,6 +154,10 @@ To achieve high performance in Python, the framework implements caching and scop
   - `RecomposeScope` allows wrapping a subtree in a named scope.
   - `ScopeHandle` provides methods (`invalidate()`, `invalidate_scope_id()`) to trigger rebuilds only for that specific scope.
   - Binding invalidations are routed through `_lookup_scope_ids_for_dependency()`, ensuring that only the affected scopes are rebuilt.
+- **Idempotent Recomposition Contract** (issue #244):
+  - A scope's subtree is rebuilt only when it is **new, unbuilt, or explicitly invalidated**. Invalidation is tracked in `_dirty_scopes`, and `_schedule_scope_recomposition()` is the single funnel through which a scope is marked dirty.
+  - Re-evaluating the host's `build()` does **not** rebuild scopes that were not invalidated. Re-entering `build()` on every measure must never tear down a live subtree (which would discard focus, scroll, animation, and pointer state).
+  - Callers own the responsibility to invalidate a scope when the inputs of its `render_scope` factory change. For example, `ForEach` fires `invalidate_scope_id` for an item's scope when that item's value changes. Relying on a host rebuild to refresh an un-invalidated scope will not work.
 
 ### 2. Layout & Dimension Caching
 


### PR DESCRIPTION
## Summary
- Document the **idempotent recomposition contract** in `WIDGET_ARCHITECTURE.md` (Recompose Scope API): a scope rebuilds only when new, unbuilt, or explicitly invalidated (`_dirty_scopes` / `_schedule_scope_recomposition`); a host `build()` re-run does not rebuild un-invalidated scopes; callers must invalidate on input change.
- Document the **measure-purity invariant** in `RENDERING_PIPELINE.md` (Layout Protocol): `preferred_size()` must be side-effect-free and must not `build()`/unmount the live subtree, which would discard focus, scroll, animation, and pointer state and cancel in-progress gestures.
- Fix stale text in `RENDERING_PIPELINE.md` (Scoped Rendering Optimization): replace `MaterialContainer` with `Card`, add an idempotent-recomposition note, and align the batching wording with synchronous flush for unmounted hosts.
- Replace the remaining `MaterialContainer` example in `LAYOUT.md` with `Card` so no `MaterialContainer` references remain in docs.

Closes #247

## Test plan
- [ ] `grep -r MaterialContainer docs/` returns empty
- [ ] `render_scope` docstring (PR #246) and the design docs are consistent
- [ ] Three documentation items from the issue are reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)