### PR TITLE
fix(pyglet): negate scroll_x on macOS to fix reversed horizontal scrolling (#251)

### DIFF
--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -739,14 +739,18 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
     def _normalize_scroll_delta(scroll_x: float, scroll_y: float) -> tuple[float, float]:
         """Normalize Pyglet raw scroll values to the app convention.
 
-        Convention: positive scroll_y = move content downward (offset increases).
-        On macOS the OS already adjusts values for the Natural Scrolling
-        preference, so pass through unchanged.  On Windows and Linux, Pyglet
-        reports scroll_y > 0 for wheel-forward (up), which is opposite to the
-        app convention.
+        Convention: positive scroll_y = move content downward (offset increases),
+        positive scroll_x = move content rightward (offset increases).
+
+        On macOS, Pyglet negates AppKit's ``deltaY`` so vertical values already
+        match the app convention, but ``deltaX`` is passed through with AppKit's
+        native sign, which is opposite to the app convention.  Negate scroll_x to
+        compensate while leaving scroll_y unchanged.  On Windows and Linux,
+        Pyglet reports scroll_y > 0 for wheel-forward (up), which is opposite to
+        the app convention, so both axes are negated.
         """
         if sys.platform == "darwin":
-            return scroll_x, scroll_y
+            return -scroll_x, scroll_y
         # Windows and Linux: negate to match app convention
         return -scroll_x, -scroll_y
 


### PR DESCRIPTION
## Summary
- Negate `scroll_x` in the darwin branch of `_normalize_scroll_delta` so horizontal wheel/trackpad scrolling matches the content scroll direction on macOS
- Document the `scroll_x` convention and the AppKit `deltaX`/`deltaY` sign asymmetry in the docstring

Closes #251

## Root cause
pyglet's macOS implementation negates `deltaY` but passes `deltaX` through with AppKit's native sign, opposite to the app convention. `_normalize_scroll_delta` never compensated, so only horizontal scrolling was reversed.

## Test plan
- [ ] On macOS, horizontal gesture direction matches content scroll direction
- [ ] Vertical scrolling behavior is unaffected
- [ ] Windows/Linux unchanged (Windows `scroll_x` is always 0; Linux tracked in #252)

🤖 Generated with [Claude Code](https://claude.com/claude-code)