### PR TITLE
feat(scroll): replace Scroller with axis-specific Scrollable widgets

### DIFF
--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -41,7 +41,7 @@ Refer to the following guides based on what you want to create.
 | Partitioning like header/sidebar | [layout_grid.md](layout_grid.md) | `Grid` |
 | Overlay elements (Badges, backgrounds, etc.) | [layout_extras.md](layout_extras.md) | `Stack` |
 | Create wrapping lists (Tag lists, etc.) | [layout_extras.md](layout_extras.md) | `Flow` |
-| Make scrollable | [layout_overflow.md](layout_overflow.md) | `Scroller` |
+| Make scrollable | [layout_overflow.md](layout_overflow.md) | `VerticalScrollable` / `HorizontalScrollable` |
 | Create tab switching | [layout_extras.md](layout_extras.md) | `Deck` |
 
 ## More Details

--- a/docs/guide/layout_overflow.md
+++ b/docs/guide/layout_overflow.md
@@ -58,37 +58,39 @@ md.Card(
 
 ![Clipped overflow example](../assets/layout_overflow_clipped.png)
 
-## Making Scrollable (Scroller)
+## Making Scrollable (VerticalScrollable / HorizontalScrollable)
 
-To view the overflowing part by scrolling, use the `Scroller` widget.
-Wrap `Column` or `Row` with `Scroller` to create a scrollable area.
+To view the overflowing part by scrolling, wrap `Column` or `Row` with an
+axis-specific scrollable: `VerticalScrollable` or `HorizontalScrollable`.
 
 ```python
 import nuiitivet as nv
 import nuiitivet.material as md
-from nuiitivet.layout.scroller import Scroller
 
 # Even with many items, you can scroll within the specified height (300px)
 nv.Container(
     height=300,
-    child=Scroller(
+    child=nv.VerticalScrollable(
         child=nv.Column(
             children=[md.Text(f"Item {i}") for i in range(50)],
             gap=8,
             padding=16,
         ),
-        direction="vertical",
-        scrollbar_enabled=True,
     ),
 )
 ```
 
 ![Scrollable example](../assets/layout_overflow_scrollable.png)
 
+The scroll axis is chosen by the class (`VerticalScrollable` /
+`HorizontalScrollable`) — there is no `direction` argument.
+
 | Argument | Description |
 | --- | --- |
-| `direction` | Scroll direction (`"vertical"` or `"horizontal"`) |
-| `scrollbar_enabled` | Whether to display scrollbar (`True`/`False`) |
+| `scrollbar_visible` | Whether to display the scrollbar (`bool` or `Observable[bool]`) |
+| `style` | Scrollbar appearance via `ScrollbarStyle(thickness, min_thumb_length, inset)` |
+| `behavior` | Scrollbar interaction via `ScrollbarBehavior(auto_hide, …)` |
+| `controller` | A `ScrollController` carrying scroll `physics` and `scroll_multiplier` |
 
 ## Next Steps
 

--- a/docs/md3/date-pickers.md
+++ b/docs/md3/date-pickers.md
@@ -248,7 +248,7 @@ Collected: 2026-03-12
 | Header row       | Month label (month-menu active)                | dropdown icon ▾  | Shows `Month ▾`; grayed-out year label alongside.                                          |
 | Header row       | Year label (year-menu active)                  | dropdown icon ▾  | Shows `Year ▾`; grayed-out month label alongside.                                          |
 | Header row       | Gap between back-chevron and labels            | 16dp             |                                                                                            |
-| Scroller padding | Left, Right                                    | (15, 20)         | `padding=(15, 0, 20, 0)` on the Scroller.                                                  |
+| Scrollable padding | Left, Right                                    | (15, 20)         | `padding=(15, 0, 20, 0)` on the VerticalScrollable.                                                  |
 | List item        | Height                                         | 48dp             | From `md.comp.date-picker.docked.menu.list-item.container.height`.                         |
 | List item        | Padding-start (before check icon)              | 16dp             | `padding=(0, 16, 0, 0)` (left-aligned row with leading space).                             |
 | List item        | Check icon size                                | 24dp             | From `md.comp.date-picker.docked.menu.list-item.selected.leading-icon.size`. Selected only. |
@@ -282,7 +282,7 @@ Collected: 2026-03-12
 | Year chip grid    | UniformFlow main_gap                         | 30dp               |                                                                                            |
 | Year chip grid    | UniformFlow cross_gap                        | 30dp               |                                                                                            |
 | Year chip grid    | UniformFlow inner padding                    | 30dp               |                                                                                            |
-| Year chip grid    | Scroller padding (left, right)               | (15, 4)            | `padding=(15, 12, 4, 12)` on the Scroller.                                                 |
+| Year chip grid    | Scrollable padding (left, right)               | (15, 4)            | `padding=(15, 12, 4, 12)` on the VerticalScrollable.                                                 |
 | Action row        | Padding (left, top, right, bottom)           | (4, 12, 12, 12)    |                                                                                            |
 | Action row        | Button gap                                   | 16dp               |                                                                                            |
 

--- a/samples/layout_overflow/scrollable_list.py
+++ b/samples/layout_overflow/scrollable_list.py
@@ -1,20 +1,17 @@
 import nuiitivet as nv
 import nuiitivet.material as md
-from nuiitivet.layout.scroller import Scroller
 
 
 def main(png: str = ""):
     # Even with many items, keep a 300px viewport and scroll within it.
     widget = nv.Container(
         height=300,
-        child=Scroller(
+        child=nv.VerticalScrollable(
             child=nv.Column(
                 children=[md.Text(f"Item {i}") for i in range(50)],
                 gap=8,
                 padding=16,
             ),
-            direction="vertical",
-            scrollbar_enabled=True,
         ),
     )
 

--- a/scripts/debug/instrument_and_render.py
+++ b/scripts/debug/instrument_and_render.py
@@ -101,7 +101,7 @@ TARGETS = [
     ("nuiitivet.layout", "Row", ("preferred_size", "paint")),
     ("nuiitivet.layout", "Container", ("preferred_size", "paint")),
     ("nuiitivet.layout.for_each", "ForEach", ("_rebuild", "preferred_size", "paint")),
-    ("nuiitivet.layout.scroller", "Scroller", ("preferred_size", "paint")),
+    ("nuiitivet.layout.scrollable", "VerticalScrollable", ("preferred_size", "paint")),
     ("nuiitivet.widgets.text", "Text", ("preferred_size", "paint")),
     ("nuiitivet.widgets.icon", "Icon", ("preferred_size", "paint")),
     ("nuiitivet.material.selection_controls", "Checkbox", ("preferred_size", "paint")),

--- a/scripts/debug/my_widget.py
+++ b/scripts/debug/my_widget.py
@@ -16,7 +16,6 @@ from nuiitivet.material.styles import IconStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.modifiers import shadow
 from nuiitivet.observable import Observable
-from nuiitivet.scrolling import ScrollDirection
 from nuiitivet.layout.column import Column
 
 # flow removed
@@ -24,7 +23,7 @@ from nuiitivet.layout.uniform_flow import UniformFlow
 from nuiitivet.material.card import Card
 from nuiitivet.material.styles.card_style import CardStyle
 from nuiitivet.layout.row import Row
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.material.symbols import Symbols
 from nuiitivet.material.buttons import Fab, Button
@@ -217,7 +216,7 @@ class MyWidget(ComposableWidget):
                             gap=8,
                             cross_alignment="center",
                         ),
-                        Scroller(
+                        VerticalScrollable(
                             Column.builder(
                                 self.model.column_items,
                                 lambda item, idx: Text(item),
@@ -247,15 +246,14 @@ class MyWidget(ComposableWidget):
                             gap=8,
                             cross_alignment="center",
                         ),
-                        Scroller(
+                        HorizontalScrollable(
                             Row.builder(
                                 self.model.row_items,
                                 lambda item, idx: Text(item),
                                 gap=8,
                                 cross_alignment="center",
                             ),
-                            scrollbar=ScrollbarBehavior(auto_hide=False),
-                            direction=ScrollDirection.HORIZONTAL,
+                            behavior=ScrollbarBehavior(auto_hide=False),
                             height=50,
                         ),
                     ],

--- a/scripts/dev/repo/probe_scroller.py
+++ b/scripts/dev/repo/probe_scroller.py
@@ -1,5 +1,5 @@
-# Probe script: inspect Scroller viewport_rect and scrollbar config
-from nuiitivet.layout.scroller import Scroller
+# Probe script: inspect Scrollable viewport_rect and scrollbar config
+from nuiitivet.layout.scrollable import _ScrollableBase
 from nuiitivet.widgets import text as text_mod
 from nuiitivet.layout import scroll_viewport as sv_mod
 from nuiitivet.widgets import scrollbar as sb_mod
@@ -13,7 +13,7 @@ def find_scrollers(widget):
     except Exception:
         children = []
     for c in children:
-        if isinstance(c, Scroller):
+        if isinstance(c, _ScrollableBase):
             out.append(c)
         out.extend(find_scrollers(c))
     return out
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     for i, s in enumerate(scrollers):
         cfg = getattr(s, "_scrollbar_config", None)
         hdim = s.height_sizing.kind if hasattr(s, "height_sizing") else None
-        print(f"Scroller[{i}] direction={s.direction} height={hdim}")
+        print(f"Scrollable[{i}] direction={s.direction} height={hdim}")
         print("  scrollbar_config.auto_hide=", getattr(cfg, "auto_hide", None))
 
     # pick the horizontal scroller (direction HORIZONTAL)

--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -15,6 +15,7 @@ from nuiitivet.layout.spacer import Spacer
 from nuiitivet.layout.cross_aligned import CrossAligned
 from nuiitivet.layout.deck import Deck
 from nuiitivet.layout.collapsible import Collapsible
+from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 
 # Primitives / Widgets
 from nuiitivet.rendering.sizing import Sizing
@@ -44,6 +45,8 @@ __all__: list[str] = [
     "Border",
     "Deck",
     "Collapsible",
+    "VerticalScrollable",
+    "HorizontalScrollable",
     "Sizing",
     "Widget",
     "ComposableWidget",

--- a/src/nuiitivet/layout/column.py
+++ b/src/nuiitivet/layout/column.py
@@ -23,7 +23,7 @@ class Column(Widget):
     - overflow: 'visible'|'clip'|'scroll' - how to handle children that overflow the container
         - 'visible' (default): children may extend beyond container (Phase 1 behavior)
         - 'clip': children are clipped to container bounds
-        - 'scroll': requires Scroller wrapper (Phase 3)
+        - 'scroll': requires VerticalScrollable / HorizontalScrollable wrapper (Phase 3)
     """
 
     # Hint for ancestor-based layout resolution (used by ForEach and others)

--- a/src/nuiitivet/layout/scroll_viewport.py
+++ b/src/nuiitivet/layout/scroll_viewport.py
@@ -1,4 +1,4 @@
-"""ScrollViewport: clipped scrolling surface for Scroller and related widgets."""
+"""ScrollViewport: clipped scrolling surface for Scrollable and related widgets."""
 
 from __future__ import annotations
 

--- a/src/nuiitivet/layout/scrollable.py
+++ b/src/nuiitivet/layout/scrollable.py
@@ -1,14 +1,28 @@
-"""Scroller: 子widgetをスクロール可能にするレイアウトwidget"""
+"""Scrollable: axis-specific containers that make a child scrollable.
+
+Public API:
+
+* :class:`VerticalScrollable` — scrolls its child along the vertical axis.
+* :class:`HorizontalScrollable` — scrolls its child along the horizontal axis.
+
+Both share :class:`_ScrollableBase`, which holds the direction-parameterized
+layout / paint / gesture logic. The scroll *engine* configuration (``physics``
+and ``scroll_multiplier``) lives on :class:`~nuiitivet.scrolling.ScrollController`;
+scrollbar appearance is configured via
+:class:`~nuiitivet.scrolling.ScrollbarStyle` and scrollbar
+interaction via :class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
+"""
 
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple, Union
+from typing import ClassVar, Optional, Tuple, Union
 
 from nuiitivet.common.logging_once import exception_once
+from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
 
 from ..widgeting.widget import Widget
-from ..scrolling import ScrollController, ScrollDirection, ScrollPhysics
+from ..scrolling import ScrollController, ScrollDirection, ScrollPhysics, ScrollbarStyle
 from ..rendering.sizing import Sizing, SizingLike
 from ..input.pointer import PointerEvent, PointerEventType
 from ..widgets.scrollbar import Scrollbar, ScrollbarBehavior
@@ -17,75 +31,83 @@ from .scroll_viewport import ScrollViewport
 logger = logging.getLogger(__name__)
 
 
-class Scroller(Widget):
-    """(Advanced) Low-level scroll container.
+ScrollbarVisibleLike = Union[bool, ReadOnlyObservableProtocol[bool]]
 
-    Warning:
-        This API is **provisional** and subject to change in future versions.
-        Specifically, parameters related to scrollbars may be consolidated or moved.
 
-    Note:
-        Prefer using the `.scroll()` modifier. This widget is exposed for
-        advanced customization.
+def _read_bool(value: ScrollbarVisibleLike) -> bool:
+    if isinstance(value, ReadOnlyObservableProtocol):
+        try:
+            return bool(value.value)
+        except Exception:
+            exception_once(logger, "scrollable_read_visible_exc", "Failed to read scrollbar_visible observable")
+            return True
+    return bool(value)
 
-    Makes a child widget scrollable if it exceeds the viewport.
-    Supports mouse wheel and scrollbar interactions.
+
+class _ScrollableBase(Widget):
+    """(Internal) Direction-parameterized scroll container.
+
+    Not part of the public API. Use :class:`VerticalScrollable` or
+    :class:`HorizontalScrollable`, which fix the scroll axis via ``_direction``.
+
+    Makes a child widget scrollable if it exceeds the viewport. Supports mouse
+    wheel, drag, and scrollbar interactions.
     """
+
+    #: Scroll axis fixed by each concrete subclass.
+    _direction: ClassVar[ScrollDirection]
 
     def __init__(
         self,
         child: Widget,
         *,
-        scroll_controller: Optional[ScrollController] = None,
-        direction: ScrollDirection | str = ScrollDirection.VERTICAL,
-        physics: ScrollPhysics | str = ScrollPhysics.CLAMP,
-        scrollbar: Optional[ScrollbarBehavior] = None,
-        scrollbar_padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 2,
-        scrollbar_enabled: bool = True,
-        scrollbar_thickness: int | None = None,
-        scrollbar_min_thumb_length: int | None = None,
-        scroll_multiplier: float = 20.0,
-        padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
+        controller: Optional[ScrollController] = None,
+        scrollbar_visible: ScrollbarVisibleLike = True,
         width: SizingLike = None,
         height: SizingLike = None,
-    ):
-        """Scroller を初期化
+        padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
+        behavior: Optional[ScrollbarBehavior] = None,
+        style: Optional[ScrollbarStyle] = None,
+    ) -> None:
+        """Initialize the scrollable.
 
         Args:
-            child: スクロール対象のwidget
-            scroll_controller: 外部制御用のScrollController（省略時は自動生成）
-            direction: スクロール方向（:class:`ScrollDirection`）
-            physics: スクロール物理演算（:class:`ScrollPhysics`）
-        scrollbar: スクロールバーの振る舞い設定（動作のみ）。レイアウト系は `scrollbar_padding` で指定します。
-            scroll_multiplier: マウスホイール1ステップあたりのスクロール量（ピクセル）
-            padding: viewport内側の余白
+            child: The widget to make scrollable.
+            controller: External :class:`ScrollController` (auto-created when
+                omitted). ``physics`` and ``scroll_multiplier`` are read from it.
+            scrollbar_visible: Whether the scrollbar is shown. Accepts a ``bool``
+                or an ``Observable[bool]`` for reactive visibility.
+            width: Width sizing override.
+            height: Height sizing override.
+            padding: Inner padding of the viewport (scrolled area).
+            behavior: Scrollbar interaction behavior (auto-hide, track clicks…).
+            style: Scrollbar appearance (thickness, min thumb length, inset).
         """
         super().__init__(width=width, height=height)
 
         if child is None:
-            raise ValueError("Scroller requires a child widget")
+            raise ValueError("Scrollable requires a child widget")
 
         self._child = child
-        self.direction = direction if isinstance(direction, ScrollDirection) else ScrollDirection(direction)
+        self.direction = self._direction
         self._apply_axis_sizing_defaults()
 
-        if scroll_controller is None:
+        if controller is None:
             self._controller = ScrollController(axes=(self.direction,), primary_axis=self.direction)
             self._owns_controller = True
         else:
-            if not scroll_controller.has_axis(self.direction):
+            if not controller.has_axis(self.direction):
                 raise ValueError(f"ScrollController does not support required axis {self.direction}")
-            self._controller = scroll_controller
+            self._controller = controller
             self._owns_controller = False
-        self.physics = physics if isinstance(physics, ScrollPhysics) else ScrollPhysics(physics)
-        self.scroll_multiplier = float(scroll_multiplier)
 
-        # Behavior object (contains interaction/auto-hide settings)
-        from ..widgets.scrollbar import ScrollbarBehavior as _SB
+        # Scroll-engine configuration is owned by the controller.
+        self.physics = self._controller.physics
+        self.scroll_multiplier = self._controller.scroll_multiplier
 
-        self._scrollbar_behavior = scrollbar or _SB()
-        self._scrollbar_enabled = bool(scrollbar_enabled)
-        self._scrollbar_padding = scrollbar_padding
+        self._scrollbar_behavior = behavior or ScrollbarBehavior()
+        self._scrollbar_style = style or ScrollbarStyle()
+        self._scrollbar_visible: ScrollbarVisibleLike = scrollbar_visible
 
         self._viewport = ScrollViewport(
             child=child,
@@ -95,59 +117,42 @@ class Scroller(Widget):
         )
         self.add_child(self._viewport)
 
-        self._scrollbar: Optional[Scrollbar]
-        if not self._scrollbar_enabled:
-            self._scrollbar = None
-        else:
-            # resolve optional thickness/min_thumb overrides (fallback to Scrollbar defaults)
-            thickness_val = int(scrollbar_thickness) if scrollbar_thickness is not None else None
-            min_thumb_val = int(scrollbar_min_thumb_length) if scrollbar_min_thumb_length is not None else None
-            # build kwargs conditionally to avoid passing None to Scrollbar
-            # Pass explicit keyword arguments to keep mypy happy (avoid **dict with Any)
-            if thickness_val is None and min_thumb_val is None:
-                self._scrollbar = Scrollbar(
-                    self._controller,
-                    behavior=self._scrollbar_behavior,
-                    direction=self.direction,
-                    padding=self._scrollbar_padding,
-                )
-            else:
-                self._scrollbar = Scrollbar(
-                    self._controller,
-                    behavior=self._scrollbar_behavior,
-                    direction=self.direction,
-                    thickness=thickness_val or 8,
-                    min_thumb_length=min_thumb_val or 24,
-                    padding=self._scrollbar_padding,
-                )
-            self.add_child(self._scrollbar)
+        self._scrollbar = Scrollbar(
+            self._controller,
+            behavior=self._scrollbar_behavior,
+            direction=self.direction,
+            thickness=self._scrollbar_style.thickness,
+            min_thumb_length=self._scrollbar_style.min_thumb_length,
+            padding=self._scrollbar_style.inset,
+        )
+        self.add_child(self._scrollbar)
 
-            # Allow the scrollbar to coordinate with this container (e.g. cancel
-            # an active content drag when the user begins dragging the thumb).
-            try:
-                setattr(self._scrollbar, "_scroll_container", self)
-            except Exception:
-                exception_once(logger, "scroller_set_scroll_container_exc", "Failed to set scrollbar._scroll_container")
+        # Allow the scrollbar to coordinate with this container (e.g. cancel an
+        # active content drag when the user begins dragging the thumb).
+        try:
+            setattr(self._scrollbar, "_scroll_container", self)
+        except Exception:
+            exception_once(logger, "scrollable_set_scroll_container_exc", "Failed to set scrollbar._scroll_container")
 
-        # ドラッグスクロール用の状態
+        # Drag-scroll state
         self._is_dragging = False
         self._drag_start_pos = 0.0
         self._drag_start_offset = 0.0
         self._content_pointer_id: Optional[int] = None
 
-        # スクロールバーの領域（hit-test用）
+        # Scrollbar regions (for hit-testing)
         self._scrollbar_rect: Optional[Tuple[int, int, int, int]] = None
         self._scrollbar_thumb_rect: Optional[Tuple[int, int, int, int]] = None
 
-        # リスナー解除用 (may be a Disposable or a callable)
+        # Listener disposal handle (may be a Disposable or a callable)
         self._scroll_unsubscribe: Optional[object] = None
 
-    # --- ライフサイクル ---
+    # --- Lifecycle ---
 
     def on_mount(self) -> None:
-        """mount時にスクロール変更をリッスン"""
+        """Listen for scroll changes on mount."""
 
-        # スクロール変更時は App.invalidate() を呼ぶ（tests の MockApp と互換）
+        # Call App.invalidate() on scroll change (compatible with the tests' MockApp)
         def _offset_cb(_val):
             # Notify the app to redraw content positions
             try:
@@ -156,15 +161,23 @@ class Scroller(Widget):
             except Exception:
                 exception_once(
                     logger,
-                    "scroller_offset_invalidate_exc",
+                    "scrollable_offset_invalidate_exc",
                     "App.invalidate failed on scroll offset change",
                 )
 
         axis_state = self._controller.axis_state(self.direction)
         self._scroll_unsubscribe = axis_state.offset.subscribe(_offset_cb)
 
+        # Reactive scrollbar visibility: relayout / repaint when it changes.
+        if isinstance(self._scrollbar_visible, ReadOnlyObservableProtocol):
+            self.observe(self._scrollbar_visible, self._on_scrollbar_visible_changed)
+
+    def _on_scrollbar_visible_changed(self, _value: bool) -> None:
+        self.mark_needs_layout()
+        self.invalidate()
+
     def on_unmount(self) -> None:
-        """unmount時にリスナー解除"""
+        """Dispose listeners on unmount."""
         if self._scroll_unsubscribe:
             try:
                 # Expect a Disposable with dispose(); call it and clear.
@@ -174,13 +187,13 @@ class Scroller(Widget):
                     except Exception:
                         exception_once(
                             logger,
-                            "scroller_scroll_unsubscribe_dispose_exc",
+                            "scrollable_scroll_unsubscribe_dispose_exc",
                             "Failed to dispose scroll subscription",
                         )
             finally:
                 self._scroll_unsubscribe = None
 
-    # --- サイズ計算 ---
+    # --- Sizing ---
 
     def preferred_size(self, max_width: Optional[int] = None, max_height: Optional[int] = None) -> Tuple[int, int]:
         """Explicit sizes take priority, otherwise delegate to viewport"""
@@ -225,25 +238,23 @@ class Scroller(Widget):
         viewport_width = int(width)
         viewport_height = int(height)
 
-        wants_scrollbar = (self._scrollbar is not None) and self.physics is not ScrollPhysics.NEVER
+        wants_scrollbar = self._wants_scrollbar()
         reserve_always = bool(wants_scrollbar and (not bool(self._scrollbar_behavior.auto_hide)))
 
         if wants_scrollbar and reserve_always:
             if self.direction is ScrollDirection.VERTICAL:
-                pad_r = self._scrollbar.padding[2] if self._scrollbar is not None else 0
-                thickness = self._scrollbar.thickness if self._scrollbar is not None else 0
+                pad_r = self._scrollbar.padding[2]
+                thickness = self._scrollbar.thickness
                 viewport_width = max(0, viewport_width - thickness - pad_r)
             elif self.direction is ScrollDirection.HORIZONTAL:
-                pad_b = self._scrollbar.padding[3] if self._scrollbar is not None else 0
-                thickness = self._scrollbar.thickness if self._scrollbar is not None else 0
+                pad_b = self._scrollbar.padding[3]
+                thickness = self._scrollbar.thickness
                 viewport_height = max(0, viewport_height - thickness - pad_b)
 
         self._viewport.layout(viewport_width, viewport_height)
         self._viewport.set_layout_rect(0, 0, viewport_width, viewport_height)
 
         scrollbar = self._scrollbar
-        if scrollbar is None:
-            return
 
         if wants_scrollbar and self._should_show_scrollbar():
             if self.direction is ScrollDirection.VERTICAL:
@@ -266,108 +277,86 @@ class Scroller(Widget):
             scrollbar.layout(0, 0)
             scrollbar.set_layout_rect(0, 0, 0, 0)
 
-    # --- 描画 ---
+    # --- Painting ---
 
     def paint(self, canvas, x: int, y: int, width: int, height: int):
         """
-        1. 子のpreferred_sizeを取得し、controllerに記録
-        2. viewport領域をクリップ
-        3. スクロールオフセットを適用して子を描画
-        4. スクロールバーを描画
+        1. Measure the child's preferred size and record it on the controller.
+        2. Clip to the viewport region.
+        3. Apply the scroll offset and paint the child.
+        4. Paint the scrollbar.
         """
         # Auto-layout fallback for tests or direct paint calls.
         try:
             if self._viewport.layout_rect is None:
                 self.layout(width, height)
         except Exception:
-            exception_once(logger, "scroller_auto_layout_exc", "Auto layout failed in paint")
+            exception_once(logger, "scrollable_auto_layout_exc", "Auto layout failed in paint")
 
-        # 描画領域を記録（hit-test用）
+        # Record the painted rect (for hit-testing)
         self.set_last_rect(x, y, width, height)
 
         viewport_width = width
         viewport_height = height
 
-        wants_scrollbar = (self._scrollbar is not None) and self.physics is not ScrollPhysics.NEVER
+        wants_scrollbar = self._wants_scrollbar()
 
         # Phase 1 behaviour:
         # - if scrollbar.auto_hide is True -> overlay: do NOT reserve space (draw on top)
         # - if scrollbar.auto_hide is False -> reserve-always: always reserve space for the scrollbar
-        reserve_always = False
-        if wants_scrollbar:
-            reserve_always = not bool(self._scrollbar_behavior.auto_hide)
+        reserve_always = bool(wants_scrollbar and (not bool(self._scrollbar_behavior.auto_hide)))
 
         # If we must reserve space (auto_hide == False) subtract thickness regardless
         if wants_scrollbar and reserve_always:
             if self.direction is ScrollDirection.VERTICAL:
-                if self._scrollbar is not None:
-                    pad_r = self._scrollbar.padding[2]
-                    viewport_width = max(0, viewport_width - self._scrollbar.thickness - pad_r)
-                else:
-                    viewport_width = viewport_width
+                pad_r = self._scrollbar.padding[2]
+                viewport_width = max(0, viewport_width - self._scrollbar.thickness - pad_r)
             elif self.direction is ScrollDirection.HORIZONTAL:
-                if self._scrollbar is not None:
-                    pad_b = self._scrollbar.padding[3]
-                    viewport_height = max(0, viewport_height - self._scrollbar.thickness - pad_b)
-                else:
-                    viewport_height = viewport_height
+                pad_b = self._scrollbar.padding[3]
+                viewport_height = max(0, viewport_height - self._scrollbar.thickness - pad_b)
 
         self._viewport.paint(canvas, x, y, viewport_width, viewport_height)
 
         # Then: paint other children (e.g., scrollbar) on top
         if wants_scrollbar and self._should_show_scrollbar():
             viewport_rect = self._viewport.viewport_rect or (x, y, viewport_width, viewport_height)
+            scrollbar = self._scrollbar
             if self.direction is ScrollDirection.VERTICAL:
-                if self._scrollbar is not None:
-                    pad_r = self._scrollbar.padding[2]
-                    bar_x = x + width - self._scrollbar.thickness - pad_r
-                    bar_y = viewport_rect[1]
-                    bar_w = self._scrollbar.thickness
-                    bar_h = viewport_rect[3]
-                else:
-                    bar_x = x + width
-                    bar_y = viewport_rect[1]
-                    bar_w = 0
-                    bar_h = viewport_rect[3]
-
-                # set scrollbar last_rect so hit-testing works via Widget.hit_test
-                scrollbar = self._scrollbar
-                if scrollbar is not None:
-                    try:
-                        scrollbar.set_last_rect(bar_x, bar_y, bar_w, bar_h)
-                        # also forward paint to the child via its paint API
-                        scrollbar.paint(canvas, bar_x, bar_y, bar_w, bar_h)
-                        # record rects for backward-compat / tests
-                        self._scrollbar_rect = getattr(scrollbar, "bar_rect", None)
-                        self._scrollbar_thumb_rect = getattr(scrollbar, "thumb_rect", None)
-                    except Exception:
-                        exception_once(logger, "scroller_scrollbar_paint_exc", "Scrollbar paint failed")
+                pad_r = scrollbar.padding[2]
+                bar_x = x + width - scrollbar.thickness - pad_r
+                bar_y = viewport_rect[1]
+                bar_w = scrollbar.thickness
+                bar_h = viewport_rect[3]
+                try:
+                    scrollbar.set_last_rect(bar_x, bar_y, bar_w, bar_h)
+                    scrollbar.paint(canvas, bar_x, bar_y, bar_w, bar_h)
+                    self._scrollbar_rect = getattr(scrollbar, "bar_rect", None)
+                    self._scrollbar_thumb_rect = getattr(scrollbar, "thumb_rect", None)
+                except Exception:
+                    exception_once(logger, "scrollable_scrollbar_paint_exc", "Scrollbar paint failed")
             elif self.direction is ScrollDirection.HORIZONTAL:
-                if self._scrollbar is not None:
-                    pad_b = self._scrollbar.padding[3]
-                    bar_x = viewport_rect[0]
-                    bar_y = y + height - self._scrollbar.thickness - pad_b
-                    bar_w = viewport_rect[2]
-                    bar_h = self._scrollbar.thickness
-                else:
-                    bar_x = viewport_rect[0]
-                    bar_y = y + height
-                    bar_w = viewport_rect[2]
-                    bar_h = 0
+                pad_b = scrollbar.padding[3]
+                bar_x = viewport_rect[0]
+                bar_y = y + height - scrollbar.thickness - pad_b
+                bar_w = viewport_rect[2]
+                bar_h = scrollbar.thickness
+                try:
+                    scrollbar.set_last_rect(bar_x, bar_y, bar_w, bar_h)
+                    scrollbar.paint(canvas, bar_x, bar_y, bar_w, bar_h)
+                    self._scrollbar_rect = getattr(scrollbar, "bar_rect", None)
+                    self._scrollbar_thumb_rect = getattr(scrollbar, "thumb_rect", None)
+                except Exception:
+                    exception_once(logger, "scrollable_scrollbar_paint_h_exc", "Scrollbar paint failed (horizontal)")
 
-                scrollbar = self._scrollbar
-                if scrollbar is not None:
-                    try:
-                        scrollbar.set_last_rect(bar_x, bar_y, bar_w, bar_h)
-                        scrollbar.paint(canvas, bar_x, bar_y, bar_w, bar_h)
-                        self._scrollbar_rect = getattr(scrollbar, "bar_rect", None)
-                        self._scrollbar_thumb_rect = getattr(scrollbar, "thumb_rect", None)
-                    except Exception:
-                        exception_once(logger, "scroller_scrollbar_paint_h_exc", "Scrollbar paint failed (horizontal)")
+    def _wants_scrollbar(self) -> bool:
+        """Whether a scrollbar should participate in layout / paint at all."""
+        return _read_bool(self._scrollbar_visible) and self.physics is not ScrollPhysics.NEVER
 
     def _should_show_scrollbar(self) -> bool:
-        """スクロールバーを表示すべきか判定（確定版）"""
+        """Whether the scrollbar should currently be shown."""
         if self.physics is ScrollPhysics.NEVER:
+            return False
+        if not _read_bool(self._scrollbar_visible):
             return False
         return self._controller.axis_max_extent(self.direction) > 0
 
@@ -375,16 +364,15 @@ class Scroller(Widget):
         etype = event.type
 
         scrollbar = self._scrollbar
-        if scrollbar is not None:
-            dragging_id = getattr(scrollbar, "_active_pointer_id", None)
-            if getattr(scrollbar, "_dragging", False) and dragging_id == event.id:
-                # Fallback: when running without an App (no pointer capture manager),
-                # ensure drag sequences still reach the scrollbar.
-                try:
-                    return bool(scrollbar.dispatch_pointer_event(event))
-                except Exception:
-                    exception_once(logger, "scroller_scrollbar_dispatch_exc", "scrollbar.dispatch_pointer_event failed")
-                    return False
+        dragging_id = getattr(scrollbar, "_active_pointer_id", None)
+        if getattr(scrollbar, "_dragging", False) and dragging_id == event.id:
+            # Fallback: when running without an App (no pointer capture manager),
+            # ensure drag sequences still reach the scrollbar.
+            try:
+                return bool(scrollbar.dispatch_pointer_event(event))
+            except Exception:
+                exception_once(logger, "scrollable_scrollbar_dispatch_exc", "scrollbar.dispatch_pointer_event failed")
+                return False
 
         if etype == PointerEventType.SCROLL:
             return self._handle_scroll(event)
@@ -430,11 +418,11 @@ class Scroller(Widget):
         if not self._point_in_viewport(event.x, event.y):
             return False
         scrollbar = self._scrollbar
-        if scrollbar is not None and getattr(scrollbar, "_dragging", False):
+        if getattr(scrollbar, "_dragging", False):
             try:
                 scrollbar.cancel_drag()
             except Exception:
-                exception_once(logger, "scroller_scrollbar_cancel_drag_exc", "scrollbar.cancel_drag failed")
+                exception_once(logger, "scrollable_scrollbar_cancel_drag_exc", "scrollbar.cancel_drag failed")
         self._is_dragging = True
         self._content_pointer_id = event.id
         self._drag_start_pos = self._pointer_axis_value(event)
@@ -442,7 +430,7 @@ class Scroller(Widget):
         try:
             self.capture_pointer(event)
         except Exception:
-            exception_once(logger, "scroller_capture_pointer_exc", "capture_pointer failed")
+            exception_once(logger, "scrollable_capture_pointer_exc", "capture_pointer failed")
         return True
 
     def _handle_drag(self, event: PointerEvent) -> bool:
@@ -465,7 +453,7 @@ class Scroller(Widget):
                 else:
                     self.release_pointer(pointer_id)
             except Exception:
-                exception_once(logger, "scroller_release_pointer_exc", "release/cancel pointer failed")
+                exception_once(logger, "scrollable_release_pointer_exc", "release/cancel pointer failed")
         return True
 
     def _cancel_content_drag(self) -> None:
@@ -490,34 +478,39 @@ class Scroller(Widget):
             return float(event.x)
         return float(event.y)
 
-    # --- 便利メソッド（widget経由でもアクセス可能） ---
+    # --- Convenience methods (also accessible via the widget) ---
 
     def scroll_to(self, offset: float) -> None:
-        """指定位置にスクロール（内部Controllerに委譲）"""
+        """Scroll to the given offset (delegates to the controller)."""
         self._controller.scroll_to(offset, axis=self.direction)
 
     def scroll_to_end(self) -> None:
-        """末尾にスクロール"""
+        """Scroll to the end."""
         self._controller.scroll_to_end(axis=self.direction)
 
     def scroll_to_start(self) -> None:
-        """先頭にスクロール"""
+        """Scroll to the start."""
         self._controller.scroll_to_start(axis=self.direction)
 
     @property
     def scroll_offset(self) -> float:
-        """現在のスクロール位置"""
+        """Current scroll offset."""
         return self._controller.get_offset(self.direction)
 
     @property
     def max_scroll_extent(self) -> float:
-        """最大スクロール距離"""
+        """Maximum scroll extent."""
         return self._controller.axis_max_extent(self.direction)
 
     @property
     def scrollbar_behavior(self) -> ScrollbarBehavior:
         """Return the immutable scrollbar behavior configuration."""
         return self._scrollbar_behavior
+
+    @property
+    def scrollbar_style(self) -> ScrollbarStyle:
+        """Return the immutable scrollbar visual style."""
+        return self._scrollbar_style
 
     def _apply_axis_sizing_defaults(self) -> None:
         """Ensure the scroll axis stretches to parent constraints by default."""
@@ -527,3 +520,18 @@ class Scroller(Widget):
         elif self.direction is ScrollDirection.HORIZONTAL:
             if self.width_sizing.kind == "auto":
                 self.width_sizing = Sizing.flex()
+
+
+class VerticalScrollable(_ScrollableBase):
+    """Scrolls its child along the vertical axis."""
+
+    _direction = ScrollDirection.VERTICAL
+
+
+class HorizontalScrollable(_ScrollableBase):
+    """Scrolls its child along the horizontal axis."""
+
+    _direction = ScrollDirection.HORIZONTAL
+
+
+__all__ = ["VerticalScrollable", "HorizontalScrollable"]

--- a/src/nuiitivet/material/date_picker.py
+++ b/src/nuiitivet/material/date_picker.py
@@ -24,7 +24,7 @@ from nuiitivet.animation import Animatable
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable
 from nuiitivet.layout.uniform_flow import UniformFlow
 from nuiitivet.scrolling import ScrollController, ScrollDirection
 from nuiitivet.material.buttons import Button, IconButton
@@ -521,14 +521,14 @@ class _YearChipGrid(ComposableWidget):
     Mirrors the docked year list (:class:`_YearList`) continuous-scroll model
     but renders 72×36dp pill chips in a 3-column grid per the MD3 modal
     year-selection measurement: ``UniformFlow`` with 3 columns, 30dp main/cross
-    gaps and 30dp inner padding, wrapped in a ``Scroller`` padded
+    gaps and 30dp inner padding, wrapped in a ``VerticalScrollable`` padded
     ``(12, 15, 12, 4)`` with the scrollbar hidden. The selected year's row is
     centred in the viewport on open.
 
     Args:
         selected_year: Currently selected year.
         on_select: Callback invoked with the selected year.
-        list_height: Pixel height for the :class:`Scroller` viewport.
+        list_height: Pixel height for the :class:`VerticalScrollable` viewport.
         style: DatePickerStyle.
     """
 
@@ -588,10 +588,10 @@ class _YearChipGrid(ComposableWidget):
             viewport_height=self._list_height,
         )
 
-        return Scroller(
+        return VerticalScrollable(
             grid,
-            scroll_controller=controller,
-            scrollbar_enabled=False,
+            controller=controller,
+            scrollbar_visible=False,
             width=int(style.container_width),
             height=self._list_height,
             padding=(12, 15, 12, 4),
@@ -716,7 +716,7 @@ class _MonthList(ComposableWidget):
     Args:
         current_month: Currently selected month (1–12).
         on_select: Callback invoked with the selected month number.
-        list_height: Pixel height for the :class:`Scroller` viewport.
+        list_height: Pixel height for the :class:`VerticalScrollable` viewport.
         item_width: Width of each list item (inner container width).
         style: DatePickerStyle.
     """
@@ -758,9 +758,9 @@ class _MonthList(ComposableWidget):
             item_height=int(style.menu_list_item_height),
             viewport_height=self._list_height,
         )
-        return Scroller(
+        return VerticalScrollable(
             Column(items, gap=0, width=int(item_w)),
-            scroll_controller=controller,
+            controller=controller,
             width=int(item_w),
             height=self._list_height,
         )
@@ -774,7 +774,7 @@ class _YearList(ComposableWidget):
     Args:
         current_year: Currently selected year.
         on_select: Callback invoked with the selected year.
-        list_height: Pixel height for the :class:`Scroller` viewport.
+        list_height: Pixel height for the :class:`VerticalScrollable` viewport.
         item_width: Width of each list item (inner container width).
         style: DatePickerStyle.
     """
@@ -819,9 +819,9 @@ class _YearList(ComposableWidget):
             item_height=int(style.menu_list_item_height),
             viewport_height=self._list_height,
         )
-        return Scroller(
+        return VerticalScrollable(
             Column(items, gap=0, width=int(item_w)),
-            scroll_controller=controller,
+            controller=controller,
             width=int(item_w),
             height=self._list_height,
         )

--- a/src/nuiitivet/scrolling/__init__.py
+++ b/src/nuiitivet/scrolling/__init__.py
@@ -1,11 +1,13 @@
 """Scrolling domain primitives."""
 
 from .controller import ScrollAxisState, ScrollController
+from .scrollbar_style import ScrollbarStyle
 from .types import ScrollDirection, ScrollPhysics
 
 __all__ = [
     "ScrollAxisState",
     "ScrollController",
+    "ScrollbarStyle",
     "ScrollDirection",
     "ScrollPhysics",
 ]

--- a/src/nuiitivet/scrolling/controller.py
+++ b/src/nuiitivet/scrolling/controller.py
@@ -1,7 +1,7 @@
 """ScrollController: multi-axis scroll state manager.
 
-Jetpack Compose の ScrollState を参考にした設計で、
-単軸だけでなく複数軸のスクロール状態を一元管理できるようにする。
+Inspired by Jetpack Compose's ScrollState, this centralizes scroll state for
+multiple axes, not just a single axis.
 """
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from typing import Dict, Iterable, Mapping, Tuple
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.observable import Observable
 
-from .types import ScrollDirection
+from .types import ScrollDirection, ScrollPhysics
 
 
 _logger = logging.getLogger(__name__)
@@ -48,25 +48,27 @@ class ScrollAxisState:
 
 
 class ScrollController:
-    """スクロール状態を管理し、操作メソッドを提供する
+    """Manages scroll state and provides scroll operations.
 
-    ScrollController は Scroller widget と組み合わせて使用する。
-    外部から渡さない場合、Scroller が内部で自動生成する。
+    ScrollController is used together with VerticalScrollable /
+    HorizontalScrollable. When one is not supplied, those widgets create one
+    internally. Scroll behavior (``physics``) and wheel sensitivity
+    (``scroll_multiplier``) are held by the controller.
 
     Examples:
-        基本的な使い方（内部生成）:
-            Scroller(child=Column([...] ))
+        Basic usage (auto-created):
+            VerticalScrollable(child=Column([...]))
 
-        外部から制御:
+        Controlled externally:
             controller = ScrollController()
-            Scroller(child=..., scroll_controller=controller)
+            VerticalScrollable(child=..., controller=controller)
             controller.scroll_to_end()
 
-        スクロール位置の監視:
+        Observing the scroll position:
             controller = ScrollController()
             axis = controller.axis_state(controller.primary_axis)
             axis.offset.subscribe(lambda pos: print(f"At {pos}"))
-            Scroller(child=..., scroll_controller=controller)
+            VerticalScrollable(child=..., controller=controller)
     """
 
     def __init__(
@@ -75,13 +77,17 @@ class ScrollController:
         axes: Iterable[ScrollDirection] | None = None,
         primary_axis: ScrollDirection | None = None,
         initial_offsets: Mapping[ScrollDirection, float] | None = None,
+        physics: ScrollPhysics | str = ScrollPhysics.CLAMP,
+        scroll_multiplier: float = 20.0,
     ):
-        """ScrollController を初期化
+        """Initialize the ScrollController.
 
         Args:
-            axes: 管理対象の軸集合（省略時は縦スクロールのみ）
-            primary_axis: get_offset()/is_at_start などの helper が参照する軸
-            initial_offsets: 軸ごとの初期オフセット指定
+            axes: The set of managed axes (defaults to vertical only).
+            primary_axis: The axis referenced by helpers like get_offset()/is_at_start.
+            initial_offsets: Per-axis initial offset overrides.
+            physics: Scroll behavior (clamp / disabled). See :class:`ScrollPhysics`.
+            scroll_multiplier: Scroll amount in pixels per mouse-wheel step.
         """
         axis_list: Tuple[ScrollDirection, ...]
         if axes is None:
@@ -103,6 +109,8 @@ class ScrollController:
 
         self._axes: Tuple[ScrollDirection, ...] = axis_list
         self._primary_axis: ScrollDirection = primary_axis
+        self._physics: ScrollPhysics = physics if isinstance(physics, ScrollPhysics) else ScrollPhysics(physics)
+        self._scroll_multiplier: float = float(scroll_multiplier)
 
         offsets: Dict[ScrollDirection, float] = {}
         if initial_offsets:
@@ -120,6 +128,16 @@ class ScrollController:
     @property
     def primary_axis(self) -> ScrollDirection:
         return self._primary_axis
+
+    @property
+    def physics(self) -> ScrollPhysics:
+        """Scroll behavior (clamp / disabled)."""
+        return self._physics
+
+    @property
+    def scroll_multiplier(self) -> float:
+        """Scroll amount in pixels per mouse-wheel step."""
+        return self._scroll_multiplier
 
     def has_axis(self, axis: ScrollDirection) -> bool:
         return axis in self._axis_states
@@ -140,10 +158,10 @@ class ScrollController:
 
     @property
     def max_extent(self) -> float:
-        """スクロール可能な最大距離（ピクセル）
+        """Maximum scrollable distance in pixels.
 
-        content_size - viewport_size で計算される。
-        Scroller が自動的に更新する。
+        Computed as content_size - viewport_size. Updated automatically by the
+        scrollable widget.
         """
         return self._primary_axis_state().max_extent.value
 
@@ -152,7 +170,7 @@ class ScrollController:
 
     @property
     def viewport_size(self) -> int:
-        """表示領域のサイズ（ピクセル）"""
+        """Viewport size in pixels."""
         return self._primary_axis_state().viewport_size.value
 
     def axis_viewport_size(self, axis: ScrollDirection) -> int:
@@ -160,7 +178,7 @@ class ScrollController:
 
     @property
     def content_size(self) -> int:
-        """コンテンツの全体サイズ（ピクセル）"""
+        """Total content size in pixels."""
         return self._primary_axis_state().content_size.value
 
     def axis_content_size(self, axis: ScrollDirection) -> int:
@@ -178,12 +196,12 @@ class ScrollController:
         return self._resolve_axis(axis).offset.value
 
     def scroll_to(self, offset: float, *, axis: ScrollDirection | None = None) -> None:
-        """指定位置にスクロール
+        """Scroll to the given offset.
 
-        offset は 0 〜 max_extent の範囲にクランプされる。
+        The offset is clamped to the range 0 .. max_extent.
 
         Args:
-            offset: スクロール先の位置（ピクセル）
+            offset: Target scroll position in pixels.
         """
         axis_state = self._resolve_axis(axis)
         max_extent = getattr(axis_state.max_extent, "value", 0.0)
@@ -201,7 +219,7 @@ class ScrollController:
                 )
 
     def scroll_by(self, delta: float, *, axis: ScrollDirection | None = None) -> None:
-        """現在位置から相対的にスクロール"""
+        """Scroll relative to the current position."""
         axis_state = self._resolve_axis(axis)
         self.scroll_to(axis_state.offset.value + delta, axis=axis_state.axis)
 
@@ -244,7 +262,7 @@ class ScrollController:
         *,
         axis: ScrollDirection | None = None,
     ) -> None:
-        """スクロールメトリクスを更新（Scroller 専用）"""
+        """Update scroll metrics (for the scrollable widget only)."""
         state = self._resolve_axis(axis)
         try:
             state.max_extent.value = float(max_extent)

--- a/src/nuiitivet/scrolling/scrollbar_style.py
+++ b/src/nuiitivet/scrolling/scrollbar_style.py
@@ -1,0 +1,44 @@
+"""Scrollbar style definitions.
+
+Lives in the framework-common ``scrolling`` package (not under ``material``):
+the scrollbar is a generic widget, and this style carries no design-system
+dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from nuiitivet.rendering.padding import PaddingLike
+
+
+@dataclass(frozen=True)
+class ScrollbarStyle:
+    """Immutable visual style for the scrollbar of a ``Scrollable``.
+
+    Holds only static appearance/layout. Dynamic visibility is controlled by
+    the ``scrollbar_visible`` parameter of the scrollable widget, and
+    interaction behavior (auto-hide, track clicks, etc.) lives in
+    :class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
+
+    Attributes:
+        thickness: Scrollbar thickness in pixels. Defaults to ``8``.
+        min_thumb_length: Minimum thumb length in pixels. Defaults to ``24``.
+        inset: Offset of the scrollbar from the viewport edge. Accepts a single
+            int or a padding tuple. Defaults to ``2``.
+    """
+
+    thickness: int = 8
+    min_thumb_length: int = 24
+    inset: PaddingLike = 2
+
+    def copy_with(self, **changes) -> "ScrollbarStyle":
+        """Return a copy of this style with the given fields overridden.
+
+        Args:
+            **changes: Fields to override.
+
+        Returns:
+            A new :class:`ScrollbarStyle` with the specified changes applied.
+        """
+        return replace(self, **changes)

--- a/src/nuiitivet/widgets/scrollbar.py
+++ b/src/nuiitivet/widgets/scrollbar.py
@@ -2,7 +2,7 @@
 
 This is a minimal, reusable implementation that supports vertical scrollbars.
 It derives colors from the current Theme (ColorRole.ON_SURFACE) and exposes
-handle_event/draw APIs so containers (like Scroller) can delegate behavior.
+handle_event/draw APIs so containers (like Scrollable) can delegate behavior.
 """
 
 from __future__ import annotations

--- a/tests/layout/test_for_each_scrollable_integration.py
+++ b/tests/layout/test_for_each_scrollable_integration.py
@@ -3,7 +3,7 @@ from nuiitivet.runtime.pointer import PointerCaptureManager
 from nuiitivet.scrolling import ScrollDirection
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.layout.column import Column
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable
 
 
 class DummyCanvas:
@@ -59,7 +59,7 @@ def test_scroller_reports_extent_with_transient_foreach_items():
         return DummyCell(tag=item)
 
     column = Column.builder(transient, builder, gap=2, cross_alignment="start")
-    scroller = Scroller(column, height=80)
+    scroller = VerticalScrollable(column, height=80)
     app = MockApp()
     scroller.mount(app)
     try:

--- a/tests/layout/test_scrollable.py
+++ b/tests/layout/test_scrollable.py
@@ -1,14 +1,15 @@
-"""Tests for Scroller widget and ScrollController."""
+"""Tests for VerticalScrollable / HorizontalScrollable and ScrollController."""
 
 import pytest
 from nuiitivet.runtime.app import App
 from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.scrolling import ScrollController, ScrollDirection, ScrollPhysics
 from nuiitivet.widgeting.widget import Widget
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 from nuiitivet.layout.scroll_viewport import ScrollViewport
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
+from nuiitivet.scrolling import ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
 from nuiitivet.widgets.scrollbar import Scrollbar, ScrollbarBehavior
 from tests.helpers.pointer import send_pointer_event_for_test
@@ -62,6 +63,19 @@ def test_scroll_controller_supports_multiple_axes():
     assert controller.get_offset() == 25.0
     assert controller.axis_state(ScrollDirection.VERTICAL).offset.value == 0.0
     assert controller.get_offset(ScrollDirection.HORIZONTAL) == 25.0
+
+
+def test_scroll_controller_physics_and_multiplier_defaults():
+    """ScrollController should own physics / scroll_multiplier with sane defaults."""
+    controller = ScrollController()
+    assert controller.physics is ScrollPhysics.CLAMP
+    assert controller.scroll_multiplier == 20.0
+
+
+def test_scroll_controller_physics_and_multiplier_overrides():
+    controller = ScrollController(physics="never", scroll_multiplier=30.0)
+    assert controller.physics is ScrollPhysics.NEVER
+    assert controller.scroll_multiplier == 30.0
 
 
 def test_scroll_controller_scroll_to():
@@ -131,69 +145,67 @@ def test_scroll_controller_update_metrics():
     assert controller.content_size == 600
 
 
-def test_scroller_basic_creation():
-    """Scroller should be created with a child widget."""
+def test_scrollable_basic_creation():
+    """VerticalScrollable should be created with a child widget."""
     child = Column([Text("Item 1"), Text("Item 2")])
-    scroller = Scroller(child=child)
-    assert scroller._child is child
-    assert scroller._controller is not None
-    assert scroller._owns_controller is True
+    scrollable = VerticalScrollable(child=child)
+    assert scrollable._child is child
+    assert scrollable._controller is not None
+    assert scrollable._owns_controller is True
+    assert scrollable.direction is ScrollDirection.VERTICAL
 
 
-def test_scroller_with_external_controller():
-    """Scroller should accept external ScrollController."""
+def test_scrollable_with_external_controller():
+    """VerticalScrollable should accept external ScrollController."""
     controller = ScrollController()
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, scroll_controller=controller)
-    assert scroller._controller is controller
-    assert scroller._owns_controller is False
+    scrollable = VerticalScrollable(child=child, controller=controller)
+    assert scrollable._controller is controller
+    assert scrollable._owns_controller is False
 
 
-def test_scroller_requires_child():
-    """Scroller should raise ValueError if child is None."""
+def test_scrollable_requires_child():
+    """Scrollable should raise ValueError if child is None."""
     with pytest.raises(ValueError, match="requires a child"):
-        Scroller(child=None)
+        VerticalScrollable(child=None)
 
 
-def test_scroller_preferred_size():
-    """Scroller preferred_size should include padding."""
+def test_scrollable_preferred_size():
+    """Scrollable preferred_size should include padding."""
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, padding=10)
+    scrollable = VerticalScrollable(child=child, padding=10)
     child_w, child_h = child.preferred_size()
-    scroller_w, scroller_h = scroller.preferred_size()
-    assert scroller_w == child_w + 20
-    assert scroller_h == child_h + 20
+    scrollable_w, scrollable_h = scrollable.preferred_size()
+    assert scrollable_w == child_w + 20
+    assert scrollable_h == child_h + 20
 
 
-def test_scroller_direction():
-    """Scroller should accept direction parameter."""
+def test_scrollable_axis_is_fixed_by_class():
+    """Axis is encoded in the concrete class, not a parameter."""
+    assert VerticalScrollable(child=Column([Text("Item")])).direction is ScrollDirection.VERTICAL
+    assert HorizontalScrollable(child=Row([Text("Item")])).direction is ScrollDirection.HORIZONTAL
+
+
+def test_scrollable_defaults_to_axis_stretch_vertical():
     child = Column([Text("Item")])
-    scroller_v = Scroller(child=child, direction=ScrollDirection.VERTICAL)
-    assert scroller_v.direction is ScrollDirection.VERTICAL
-    scroller_h = Scroller(child=child, direction=ScrollDirection.HORIZONTAL)
-    assert scroller_h.direction is ScrollDirection.HORIZONTAL
+    scrollable = VerticalScrollable(child=child)
+    assert scrollable.height_sizing.kind == "flex"
 
 
-def test_scroller_defaults_to_axis_stretch_vertical():
-    child = Column([Text("Item")])
-    scroller = Scroller(child=child)
-    assert scroller.height_sizing.kind == "flex"
-
-
-def test_scroller_defaults_to_axis_stretch_horizontal():
+def test_scrollable_defaults_to_axis_stretch_horizontal():
     child = Row([Text("Item")])
-    scroller = Scroller(child=child, direction=ScrollDirection.HORIZONTAL)
-    assert scroller.width_sizing.kind == "flex"
+    scrollable = HorizontalScrollable(child=child)
+    assert scrollable.width_sizing.kind == "flex"
 
 
-def test_scroller_respects_explicit_sizing_override():
+def test_scrollable_respects_explicit_sizing_override():
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, height=120)
-    assert scroller.height_sizing.kind == "fixed"
-    assert int(scroller.height_sizing.value) == 120
+    scrollable = VerticalScrollable(child=child, height=120)
+    assert scrollable.height_sizing.kind == "fixed"
+    assert int(scrollable.height_sizing.value) == 120
 
 
-def test_scroller_updates_metrics_without_explicit_height():
+def test_scrollable_updates_metrics_without_explicit_height():
 
     class TallWidget(Widget):
 
@@ -203,16 +215,16 @@ def test_scroller_updates_metrics_without_explicit_height():
         def paint(self, canvas, x, y, w, h):
             del canvas, x, y, w, h
 
-    scroller = Scroller(child=TallWidget())
+    scrollable = VerticalScrollable(child=TallWidget())
     canvas = DummyCanvas()
-    scroller.paint(canvas, 0, 0, 120, 150)
-    axis_state = scroller._controller.axis_state(ScrollDirection.VERTICAL)
+    scrollable.paint(canvas, 0, 0, 120, 150)
+    axis_state = scrollable._controller.axis_state(ScrollDirection.VERTICAL)
     assert axis_state.viewport_size.value == 150
     assert axis_state.content_size.value == 400
     assert axis_state.max_extent.value == 250
 
 
-def test_scroller_updates_horizontal_metrics_without_explicit_width():
+def test_scrollable_updates_horizontal_metrics_without_explicit_width():
 
     class WideWidget(Widget):
 
@@ -222,116 +234,120 @@ def test_scroller_updates_horizontal_metrics_without_explicit_width():
         def paint(self, canvas, x, y, w, h):
             del canvas, x, y, w, h
 
-    scroller = Scroller(child=WideWidget(), direction=ScrollDirection.HORIZONTAL)
+    scrollable = HorizontalScrollable(child=WideWidget())
     canvas = DummyCanvas()
-    scroller.paint(canvas, 0, 0, 180, 80)
-    axis_state = scroller._controller.axis_state(ScrollDirection.HORIZONTAL)
+    scrollable.paint(canvas, 0, 0, 180, 80)
+    axis_state = scrollable._controller.axis_state(ScrollDirection.HORIZONTAL)
     assert axis_state.viewport_size.value == 180
     assert axis_state.content_size.value == 360
     assert axis_state.max_extent.value == 180
 
 
-def test_scroller_rejects_controller_without_required_axis():
+def test_scrollable_rejects_controller_without_required_axis():
     child = Row([Text("Item")])
-    controller = ScrollController()
+    controller = ScrollController()  # vertical-only
     with pytest.raises(ValueError, match="required axis"):
-        Scroller(child=child, direction=ScrollDirection.HORIZONTAL, scroll_controller=controller)
+        HorizontalScrollable(child=child, controller=controller)
 
 
-def test_scroller_scrollbar_config():
-    """Scroller should accept scrollbar configuration."""
+def test_scrollable_accepts_behavior_and_style():
+    """Scrollable should accept behavior + style configuration objects."""
     child = Column([Text("Item")])
     behavior = ScrollbarBehavior(auto_hide=False)
-    scroller = Scroller(child=child, scrollbar=behavior, scrollbar_padding=4, scrollbar_enabled=False)
-    assert scroller.scrollbar_behavior is behavior
-    assert scroller._scrollbar_enabled is False
+    style = ScrollbarStyle(thickness=12, inset=4)
+    scrollable = VerticalScrollable(child=child, behavior=behavior, style=style)
+    assert scrollable.scrollbar_behavior is behavior
+    assert scrollable.scrollbar_style is style
+    assert scrollable._scrollbar.thickness == 12
+    assert scrollable._scrollbar.padding[2] == 4
 
 
-def test_scroller_registers_children_in_store():
+def test_scrollable_registers_children_in_store():
     """Child widget and scrollbar should be registered via ChildContainerMixin."""
     child = Column([Text("Item")])
-    scroller = Scroller(child=child)
-    viewport = next((c for c in scroller.children if isinstance(c, ScrollViewport)), None)
+    scrollable = VerticalScrollable(child=child)
+    viewport = next((c for c in scrollable.children if isinstance(c, ScrollViewport)), None)
     assert viewport is not None
     assert child in viewport.children
-    assert any((isinstance(c, Scrollbar) for c in scroller.children))
+    assert any((isinstance(c, Scrollbar) for c in scrollable.children))
 
 
-def test_scroller_scrollbar_disabled_removes_widget():
-    """ScrollbarConfig.disabled should omit scrollbar child."""
+def test_scrollable_scrollbar_visible_false_suppresses_display():
+    """scrollbar_visible=False keeps the scrollbar from participating in layout/paint."""
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, scrollbar_enabled=False)
-    viewport = next((c for c in scroller.children if isinstance(c, ScrollViewport)), None)
-    assert viewport is not None
-    assert child in viewport.children
-    assert all((not isinstance(c, Scrollbar) for c in scroller.children))
+    scrollable = VerticalScrollable(child=child, scrollbar_visible=False)
+    # The scrollbar widget is still mounted as a child...
+    assert any((isinstance(c, Scrollbar) for c in scrollable.children))
+    # ...but it never wants to show.
+    assert scrollable._wants_scrollbar() is False
+    assert scrollable._should_show_scrollbar() is False
 
 
-def test_scroller_physics():
-    """Scroller should accept physics parameter."""
+def test_scrollable_physics_from_controller():
+    """Scrollable.physics is sourced from its controller."""
     child = Column([Text("Item")])
-    scroller_clamp = Scroller(child=child, physics=ScrollPhysics.CLAMP)
-    assert scroller_clamp.physics is ScrollPhysics.CLAMP
-    scroller_never = Scroller(child=child, physics=ScrollPhysics.NEVER)
-    assert scroller_never.physics is ScrollPhysics.NEVER
+    clamp = VerticalScrollable(child=child, controller=ScrollController(physics="clamp"))
+    assert clamp.physics is ScrollPhysics.CLAMP
+    never = VerticalScrollable(child=child, controller=ScrollController(physics="never"))
+    assert never.physics is ScrollPhysics.NEVER
 
 
-def test_scroller_convenience_methods():
-    """Scroller should provide convenience methods that delegate to controller."""
+def test_scrollable_convenience_methods():
+    """Scrollable should provide convenience methods that delegate to controller."""
     controller = ScrollController()
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, scroll_controller=controller)
+    scrollable = VerticalScrollable(child=child, controller=controller)
     controller._update_metrics(max_extent=100.0, viewport_size=200, content_size=300)
-    scroller.scroll_to(50.0)
+    scrollable.scroll_to(50.0)
     assert controller.get_offset() == 50.0
-    scroller.scroll_to_start()
+    scrollable.scroll_to_start()
     assert controller.get_offset() == 0.0
-    scroller.scroll_to_end()
+    scrollable.scroll_to_end()
     assert controller.get_offset() == 100.0
-    assert scroller.scroll_offset == 100.0
-    assert scroller.max_scroll_extent == 100.0
+    assert scrollable.scroll_offset == 100.0
+    assert scrollable.max_scroll_extent == 100.0
 
 
-def test_scroller_mount_unmount():
-    """Scroller should subscribe/unsubscribe on mount/unmount."""
+def test_scrollable_mount_unmount():
+    """Scrollable should subscribe/unsubscribe on mount/unmount."""
     controller = ScrollController()
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, scroll_controller=controller)
-    assert scroller._scroll_unsubscribe is None
-    app = App(scroller, width=400, height=300)
-    scroller.mount(app)
-    assert scroller._scroll_unsubscribe is not None
-    scroller.unmount()
-    assert scroller._scroll_unsubscribe is None
+    scrollable = VerticalScrollable(child=child, controller=controller)
+    assert scrollable._scroll_unsubscribe is None
+    app = App(scrollable, width=400, height=300)
+    scrollable.mount(app)
+    assert scrollable._scroll_unsubscribe is not None
+    scrollable.unmount()
+    assert scrollable._scroll_unsubscribe is None
 
 
-def test_scroller_handle_scroll_event():
-    """Scroller should handle mouse_scroll event."""
+def test_scrollable_handle_scroll_event():
+    """Scrollable should handle mouse_scroll event."""
     controller = ScrollController()
     controller._update_metrics(max_extent=500.0, viewport_size=200, content_size=700)
     child = Column([Text(f"Item {i}") for i in range(50)])
-    scroller = Scroller(child=child, scroll_controller=controller)
-    handled = send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_y=3)
+    scrollable = VerticalScrollable(child=child, controller=controller)
+    handled = send_pointer_event_for_test(scrollable, PointerEventType.SCROLL, 0, 0, scroll_y=3)
     assert handled is True
     assert controller.get_offset() == 60.0
 
 
-def test_scroller_handle_scroll_event_physics_never():
-    """Scroller with physics='never' should not handle scroll events."""
-    controller = ScrollController()
+def test_scrollable_handle_scroll_event_physics_never():
+    """Scrollable with physics='never' should not handle scroll events."""
+    controller = ScrollController(physics="never")
     controller._update_metrics(max_extent=500.0, viewport_size=200, content_size=700)
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, scroll_controller=controller, physics=ScrollPhysics.NEVER)
-    handled = send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_y=3)
+    scrollable = VerticalScrollable(child=child, controller=controller)
+    handled = send_pointer_event_for_test(scrollable, PointerEventType.SCROLL, 0, 0, scroll_y=3)
     assert handled is False
     assert controller.get_offset() == 0.0
 
 
-def test_scroller_offset_subscription():
-    """Scroller should invalidate when offset changes."""
+def test_scrollable_offset_subscription():
+    """Scrollable should invalidate when offset changes."""
     controller = ScrollController()
     child = Column([Text("Item")])
-    scroller = Scroller(child=child, scroll_controller=controller)
+    scrollable = VerticalScrollable(child=child, controller=controller)
 
     class MockApp:
 
@@ -342,27 +358,27 @@ def test_scroller_offset_subscription():
             self.invalidate_count += 1
 
     app = MockApp()
-    scroller._app = app
-    scroller.on_mount()
+    scrollable._app = app
+    scrollable.on_mount()
     set_axis_offset(controller, 50.0)
     assert app.invalidate_count == 1
     set_axis_offset(controller, 100.0)
     assert app.invalidate_count == 2
-    scroller.on_unmount()
+    scrollable.on_unmount()
 
 
-def test_scroller_drag_updates_offset_via_mouse_move():
+def test_scrollable_drag_updates_offset_via_mouse_move():
     controller = ScrollController()
     controller._update_metrics(max_extent=300.0, viewport_size=200, content_size=500)
     child = Column([Text(f"Item {i}") for i in range(10)])
-    scroller = Scroller(child=child, scroll_controller=controller)
-    scroller.set_last_rect(0, 0, 200, 200)
-    assert send_pointer_event_for_test(scroller, PointerEventType.PRESS, 50, 150) is True
-    assert send_pointer_event_for_test(scroller, PointerEventType.MOVE, 50, 100) is True
+    scrollable = VerticalScrollable(child=child, controller=controller)
+    scrollable.set_last_rect(0, 0, 200, 200)
+    assert send_pointer_event_for_test(scrollable, PointerEventType.PRESS, 50, 150) is True
+    assert send_pointer_event_for_test(scrollable, PointerEventType.MOVE, 50, 100) is True
     assert controller.get_offset() > 0.0
 
 
-def test_scroller_horizontal_drag_updates_offset_via_mouse_move():
+def test_scrollable_horizontal_drag_updates_offset_via_mouse_move():
 
     class WideWidget(Widget):
 
@@ -374,22 +390,22 @@ def test_scroller_horizontal_drag_updates_offset_via_mouse_move():
 
     controller = ScrollController(axes=(ScrollDirection.HORIZONTAL,), primary_axis=ScrollDirection.HORIZONTAL)
     controller._update_metrics(max_extent=500.0, viewport_size=300, content_size=800)
-    scroller = Scroller(child=WideWidget(), direction=ScrollDirection.HORIZONTAL, scroll_controller=controller)
-    scroller.set_last_rect(0, 0, 300, 150)
-    assert send_pointer_event_for_test(scroller, PointerEventType.PRESS, 150, 50) is True
-    assert send_pointer_event_for_test(scroller, PointerEventType.MOVE, 100, 50) is True
+    scrollable = HorizontalScrollable(child=WideWidget(), controller=controller)
+    scrollable.set_last_rect(0, 0, 300, 150)
+    assert send_pointer_event_for_test(scrollable, PointerEventType.PRESS, 150, 50) is True
+    assert send_pointer_event_for_test(scrollable, PointerEventType.MOVE, 100, 50) is True
     assert controller.get_offset(axis=ScrollDirection.HORIZONTAL) > 0.0
 
 
-def test_scroller_horizontal_scroll_wheel_direction():
+def test_scrollable_horizontal_scroll_wheel_direction():
     controller = ScrollController(axes=(ScrollDirection.HORIZONTAL,), primary_axis=ScrollDirection.HORIZONTAL)
     controller._update_metrics(max_extent=400.0, viewport_size=300, content_size=700)
     child = Row([Text(f"Item {i}") for i in range(10)], gap=8)
-    scroller = Scroller(child=child, direction=ScrollDirection.HORIZONTAL, scroll_controller=controller)
-    assert send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_x=2) is True
+    scrollable = HorizontalScrollable(child=child, controller=controller)
+    assert send_pointer_event_for_test(scrollable, PointerEventType.SCROLL, 0, 0, scroll_x=2) is True
     assert controller.get_offset(axis=ScrollDirection.HORIZONTAL) > 0.0
     prev = controller.get_offset(axis=ScrollDirection.HORIZONTAL)
-    assert send_pointer_event_for_test(scroller, PointerEventType.SCROLL, 0, 0, scroll_x=-2) is True
+    assert send_pointer_event_for_test(scrollable, PointerEventType.SCROLL, 0, 0, scroll_x=-2) is True
     assert controller.get_offset(axis=ScrollDirection.HORIZONTAL) < prev
 
 

--- a/tests/layout/test_scrollable_interaction.py
+++ b/tests/layout/test_scrollable_interaction.py
@@ -1,4 +1,4 @@
-"""Interaction tests for Scroller + Scrollbar.
+"""Interaction tests for Scrollable + Scrollbar.
 
 These tests exercise mixed interactions such as dragging the scrollbar thumb
 and then performing other pointer actions (e.g., pressing the content /
@@ -13,8 +13,9 @@ help locate the regression.
 
 from nuiitivet.scrolling import ScrollController
 from nuiitivet.input.pointer import PointerEventType
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable
 from nuiitivet.layout.column import Column
+from nuiitivet.scrolling import ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
@@ -23,11 +24,10 @@ def _make_basic_scroller():
     controller = ScrollController()
     controller._update_metrics(max_extent=300.0, viewport_size=200, content_size=500)
     child = Column([Text(f"Item {i}") for i in range(20)])
-    scroller = Scroller(
+    scroller = VerticalScrollable(
         child=child,
-        scroll_controller=controller,
-        scrollbar_thickness=20,
-        scrollbar_padding=0,
+        controller=controller,
+        style=ScrollbarStyle(thickness=20, inset=0),
     )
     scroller.layout(200, 200)
     scroller.set_last_rect(0, 0, 200, 200)

--- a/tests/layout/test_scrollable_interaction_extended.py
+++ b/tests/layout/test_scrollable_interaction_extended.py
@@ -1,4 +1,4 @@
-"""Extended interaction tests for Scroller + Scrollbar.
+"""Extended interaction tests for Scrollable + Scrollbar.
 
 These tests exercise additional mixed interactions to catch ordering and
 state-transition bugs when multiple input sequences occur.
@@ -6,8 +6,9 @@ state-transition bugs when multiple input sequences occur.
 
 from nuiitivet.scrolling import ScrollController
 from nuiitivet.input.pointer import PointerEventType
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable
 from nuiitivet.layout.column import Column
+from nuiitivet.scrolling import ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
@@ -15,11 +16,10 @@ from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 def _make_basic_scroller():
     controller = ScrollController()
     child = Column([Text(f"Item {i}") for i in range(20)])
-    scroller = Scroller(
+    scroller = VerticalScrollable(
         child=child,
-        scroll_controller=controller,
-        scrollbar_thickness=20,
-        scrollbar_padding=0,
+        controller=controller,
+        style=ScrollbarStyle(thickness=20, inset=0),
     )
     scroller.layout(200, 200)
     scroller.set_last_rect(0, 0, 200, 200)

--- a/tests/layout/test_scrollable_scrollbar_modes.py
+++ b/tests/layout/test_scrollable_scrollbar_modes.py
@@ -1,4 +1,4 @@
-"""Tests for Scroller scrollbar display modes (overlay vs reserve-always).
+"""Tests for Scrollable scrollbar display modes (overlay vs reserve-always).
 
 These confirm Phase 1 behaviour:
 - auto_hide=True -> overlay (do not reserve viewport space)
@@ -6,8 +6,9 @@ These confirm Phase 1 behaviour:
 """
 
 from nuiitivet.scrolling import ScrollController
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 from nuiitivet.layout.column import Column
+from nuiitivet.scrolling import ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
 from nuiitivet.widgets.scrollbar import ScrollbarBehavior
 
@@ -16,12 +17,11 @@ def test_scroller_overlay_when_auto_hide_true():
     """When auto_hide=True (overlay), viewport area should NOT be reduced by scrollbar thickness."""
     child = Column([Text(f"Item {i}") for i in range(50)])
     controller = ScrollController()
-    scroller = Scroller(
+    scroller = VerticalScrollable(
         child=child,
-        scroll_controller=controller,
-        scrollbar=ScrollbarBehavior(auto_hide=True),
-        scrollbar_thickness=12,
-        scrollbar_padding=2,
+        controller=controller,
+        behavior=ScrollbarBehavior(auto_hide=True),
+        style=ScrollbarStyle(thickness=12, inset=2),
     )
     from nuiitivet.widgets import scrollbar as sb_mod
 
@@ -46,12 +46,11 @@ def test_scroller_reserve_always_when_auto_hide_false():
     child = Column([Text(f"Item {i}") for i in range(50)])
     controller = ScrollController()
     cfg = ScrollbarBehavior(auto_hide=False)
-    scroller = Scroller(
+    scroller = VerticalScrollable(
         child=child,
-        scroll_controller=controller,
-        scrollbar=cfg,
-        scrollbar_thickness=10,
-        scrollbar_padding=3,
+        controller=controller,
+        behavior=cfg,
+        style=ScrollbarStyle(thickness=10, inset=3),
     )
     from nuiitivet.widgets import scrollbar as sb_mod
 
@@ -82,13 +81,11 @@ def test_scroller_reserve_always_horizontal_reduces_height():
 
     cards = [Text(f"Card {i}") for i in range(20)]
     cfg = ScrollbarBehavior(auto_hide=False)
-    scroller = Scroller(
+    scroller = HorizontalScrollable(
         child=Row(cards, gap=4),
-        scrollbar=cfg,
-        direction="horizontal",
+        behavior=cfg,
         height=60,
-        scrollbar_thickness=10,
-        scrollbar_padding=4,
+        style=ScrollbarStyle(thickness=10, inset=4),
     )
     from nuiitivet.widgets import scrollbar as sb_mod
     from nuiitivet.widgets import text as text_mod

--- a/tests/layout/test_scrollable_viewport_hittest.py
+++ b/tests/layout/test_scrollable_viewport_hittest.py
@@ -1,7 +1,7 @@
 """Test that ScrollViewport correctly restricts hit_test to visible region."""
 
 from nuiitivet.layout.column import Column
-from nuiitivet.layout.scroller import Scroller
+from nuiitivet.layout.scrollable import VerticalScrollable
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -44,7 +44,7 @@ def test_viewport_hittest_only_in_visible_area() -> None:
     """ScrollViewport should only respond to hit_test within visible viewport."""
     widgets = [SimpleWidget() for _ in range(10)]
     col = Column(widgets, gap=10)
-    scroller = Scroller(col, height=100)
+    scroller = VerticalScrollable(col, height=100)
     canvas = MockCanvas()
     scroller.paint(canvas, 0, 0, 200, 100)
     hit = scroller.hit_test(50, 50)
@@ -59,7 +59,7 @@ def test_viewport_hittest_with_scroll_offset() -> None:
     """After scrolling, only visible content should respond to hit_test."""
     widgets = [SimpleWidget() for _ in range(20)]
     col = Column(widgets, gap=10)
-    scroller = Scroller(col, height=100)
+    scroller = VerticalScrollable(col, height=100)
     canvas = MockCanvas()
     scroller.paint(canvas, 0, 0, 200, 100)
     scroller.scroll_to(50)
@@ -76,7 +76,7 @@ def test_viewport_hittest_respects_padding() -> None:
     """ScrollViewport with padding should only hit inside padded viewport."""
     widgets = [SimpleWidget() for _ in range(10)]
     col = Column(widgets, gap=5)
-    scroller = Scroller(col, height=100, padding=10)
+    scroller = VerticalScrollable(col, height=100, padding=10)
     canvas = MockCanvas()
     scroller.paint(canvas, 50, 50, 200, 100)
     hit_inside = scroller.hit_test(99, 99)


### PR DESCRIPTION
## Summary
- Replace `Scroller` with axis-specific `VerticalScrollable` / `HorizontalScrollable` (axis encoded in the class like `Row`/`Column`); drop the `direction=` param and public `ScrollDirection`. Shared logic lives in a private `_ScrollableBase`.
- Consolidate scattered `scrollbar_*` args into `ScrollbarStyle` (appearance: thickness / min_thumb_length / inset) + existing `ScrollbarBehavior` (interaction). `enabled` becomes a reactive `scrollbar_visible` (`bool | Observable[bool]`).
- Move scroll-engine config (`physics`, `scroll_multiplier`) onto `ScrollController`.
- Place `ScrollbarStyle` in `scrolling/` (not `material/styles/`) so `layout` no longer depends directly on `material`.
- Remove the old `Scroller` (no alias). Migrate date_picker / samples / scripts, rename + update tests, translate carried-over Japanese to English.

Resolves #9. Scrollbar's own `material.theme` coupling is tracked in #255.

## Test plan
- [x] `pytest tests/` — 1425 passed
- [x] `mypy` clean on changed modules
- [x] Sample renders with a visible scrollbar (`samples/layout_overflow/scrollable_list.py`)
- [ ] Reviewer: confirm `nv.VerticalScrollable` / `nv.HorizontalScrollable` import and scroll/drag interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)