### PR TITLE
feat(material)!: curate widget size params via per-axis MD3 rule (#249)

### DIFF
--- a/docs/design/LAYOUT.md
+++ b/docs/design/LAYOUT.md
@@ -67,14 +67,19 @@ cell = Card(
 )
 ```
 
-#### The `size` Parameter (Specific Widgets)
+#### Which Dimensions Are Constructor Parameters (Per-Axis Binary Rule)
 
-Widgets where being square is essential (like `Icon` or `Checkbox`) provide `size` as an initialization parameter.
+Whether a size dimension is a **public constructor parameter** is decided **per axis, not per widget**, by a single binary rule derived from MD3. See [SIZE_POLICY.md](SIZE_POLICY.md) Section 0 for the full policy and the authoritative classification table.
 
-* **Purpose**: Enforces an aspect ratio (1:1) and prevents inconsistency between `width` and `height`.
-* **Behavior**:
-  * Takes `size` at initialization and internally sets both `width` and `height` to the same value.
-  * These Widgets typically do not accept separate `width` / `height` arguments in their constructors.
+* **MD3 leaves the axis open** → expose it on the constructor, named by its degree of freedom:
+  * independently variable single axis → **semantic name** (`width`, `length`);
+  * uniformly variable (1:1) → single **`size`** (e.g. `Icon`, `CircularProgressIndicator`).
+  * The parameter lives on the constructor, never inside `style`.
+* **MD3 fixes the axis** (spec token / size variant) → **not** a constructor parameter; customize via `style` only.
+  * Examples: `Button`/`ToggleButton`/chip **height** (size variant), `Checkbox`/`RadioButton`/`Switch` touch target (`*Style.default_touch_target`), `MenuItem` height (`MenuStyle.item_height`), `TextField` height, `Badge` dimensions.
+
+* **API curation only, no runtime enforcement.** Curation applies to the public constructor surface. The base `WidgetKernel`'s `width_sizing` / `height_sizing` remain an unsupported **escape hatch** — no clamping or validation is added (see [SIZE_POLICY.md](SIZE_POLICY.md), *No Runtime Enforcement*).
+* **Uniform (1:1) widgets** (`Icon`, circular progress) still take a single `size`, internally setting both `width` and `height`, and do not accept separate `width` / `height` arguments.
 
 ### 3. Alignment: Parent's Responsibility
 

--- a/docs/design/M3_AND_PADDING_INTEGRATION_RULES.md
+++ b/docs/design/M3_AND_PADDING_INTEGRATION_RULES.md
@@ -116,12 +116,13 @@ This is a **feature of the Widget base class**, having two interpretations:
 Each M3 component (Button, Checkbox, etc.) is a **closed unit with an internal structure**.
 
 ```python
-# M3 components have "M3-spec sizes"
-Checkbox(size=48)  # M3's "48dp touch target"
-Button(height=40)  # M3's "40dp container height"
+# M3-spec sizes are style-driven, not constructor parameters
+# (SIZE_POLICY Section 0: MD3 fixes the axis -> style only).
+Checkbox(style=CheckboxStyle(default_touch_target=48))  # M3's "48dp touch target"
+Button(style=ButtonStyle.filled("m"))                   # M3's container height (size variant)
 ```
 
-→ These are **M3-spec parameters** and are unrelated to `padding`.
+→ These are **M3-spec dimensions owned by `style`** and are unrelated to `padding`.
 
 ### Rule 2: Widget.padding = allocated → content insets
 
@@ -134,9 +135,9 @@ Note: In leaf widgets, this can appear as "outer margin."
 
 ```python
 # M3 component + Framework layout adjustment
-Checkbox(size=48, padding=10)
-#        ^         ^
-#        M3 spec   insets (padding)
+Checkbox(padding=10)
+#        ^
+#        insets (padding); touch target (48dp) is owned by style
 ```
 
 **Illustration**:

--- a/docs/design/SIZE_POLICY.md
+++ b/docs/design/SIZE_POLICY.md
@@ -13,6 +13,63 @@ This document defines how widgets determine their size (Layout) and how they dra
     * All widgets accept `fixed`, `auto`, and `flex` on both axes.
     * We rely on sensible default behaviors rather than restrictions.
 
+3. **API Curation, Per-Axis (see Section 0)**
+    * Whether a dimension is a *public constructor parameter* is decided **per axis, not per widget**, by a single binary rule derived from MD3.
+    * This is curation of the public surface only — it is **not** runtime enforcement (Principle 2 still holds; the base-kernel escape hatch always works).
+
+## 0. API Curation: Constructor Parameters vs Style
+
+This section governs **which size dimensions a Material widget exposes as public constructor parameters**. It is a curation rule for the public API surface; it deliberately adds no clamping or validation (see Principle 2, *No Runtime Enforcement*).
+
+### The Binary Per-Axis Rule
+
+A dimension is decided **per axis**, using one binary test:
+
+1. **MD3 leaves the axis open** → expose it as a public constructor parameter, named by its natural degree of freedom:
+   * independently variable single axis → **semantic name** (`width`, `length`);
+   * uniformly variable (1:1) → single **`size`**.
+   * The parameter lives on the **constructor**, never inside `style`.
+2. **MD3 fixes the axis** (spec token / size variant) → **do not** expose it; customization goes through `style` only.
+
+### Supporting Decisions
+
+* **Enforcement strength = "API curation only".** Public constructor params are curated by the rule above. Reaching into the inherited `width_sizing` / `height_sizing` of the base `WidgetKernel` still works as an unsupported **escape hatch**. We do **not** add clamping/ignore logic — this keeps the *No Runtime Enforcement* stance intact and costs nothing.
+* **Semantic naming is a feature.** `size` / `length` / `width` communicate *how* each axis is meant to vary, instead of a generic `width`/`height` everywhere.
+* **Icon stays variable.** MD3 defines multiple optical icon sizes (20/24/40/48dp), so the icon dimension is not MD3-fixed → `Icon(size=…)` remains a numeric `SizingLike` on the constructor.
+* **Coupling Icon size to Text type-scale is out of scope** (a separate ambient-theme concern; must not be folded into `Icon.size`).
+
+### Resulting Classification
+
+> The authoritative list is derived by a fresh audit of every public constructor against the rule. The table below records the outcome of that audit (issue #249).
+
+| Widget / axis | MD3 fixes it? | Exposure |
+| :--- | :--- | :--- |
+| Generic primitives / containers (`Box`, `Row`, `Column`, `Stack`, `*Scrollable`, `Card`, `Text`, `Image`) | No (both axes) | `width`, `height` |
+| `Button.width` / `ToggleButton.width` | No | `width` |
+| `Button.height` / `ToggleButton.height` | Yes (size variant) | style only |
+| `IconButton` / `IconToggleButton` / `Fab` / `ExtendedFab` | Yes (square = container height / content-driven) | style only (no size param) |
+| `GroupButton.width` | No | `width` |
+| `StandardButtonGroup` / `ConnectedButtonGroup` | Fixed by variant (content-fit / `100%`) | no public size param (internal only) |
+| `SplitButton.width` | No | `width` |
+| `Checkbox` / `RadioButton` / `Switch` | Yes (48dp target + fixed graphic) | style only (`*Style.default_touch_target`) |
+| Chips (`AssistChip` / `FilterChip` / `InputChip` / `SuggestionChip`) width | No | `width` |
+| Chips height | Yes (32dp container) | style only |
+| `Slider` / `CenteredSlider` / `RangeSlider` main axis | No | `length` |
+| `Slider` cross axis | Yes (track/handle tokens) | style only, internal `Sizing.fixed(...)` |
+| `Icon.size` | No (20/24/40/48dp) | `size` |
+| `CircularProgressIndicator.size` / `LoadingIndicator.size` | No | `size` |
+| `LinearProgressIndicator.width` (= length) | No (main) / thickness style | `width` |
+| `SmallBadge` / `LargeBadge` | Yes (spec tokens) / width content-driven | style only (no size param) |
+| `HorizontalDivider.width` / `VerticalDivider.height` | main No / cross Yes | axis-specific param only |
+| `DockedToolbar` / `Horizontal`·`VerticalFloatingToolbar` | style-driven | no public size param |
+| `TextField.width` | No | `width` |
+| `TextField.height` | Yes (56dp) | style only |
+| `MenuItem` / `SubMenuItem` height | Yes (48dp list item) | style only (`MenuStyle.item_height`) |
+| `NavigationRail.width` | No (expanded 220–360) | `width` |
+| `BasicDialog.width` | No (280–560) | `width` |
+| `Menu` / `SideSheet` / `BottomSheet` / `StandardSideSheet` | style-fixed | no public size param |
+| `Tooltip` / `RichTooltip` | container | `width`, `height` |
+
 ## 1. Layout Policy (Allocated Rect)
 
 The **Allocated Rect** is the space assigned to the widget by its parent during the layout pass.

--- a/src/nuiitivet/material/badge.py
+++ b/src/nuiitivet/material/badge.py
@@ -8,7 +8,7 @@ from nuiitivet.material.styles.badge_style import LargeBadgeStyle, SmallBadgeSty
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.material.text import Text
 from nuiitivet.modifiers.stick import StickModifier, stick
-from nuiitivet.rendering.sizing import Sizing, SizingLike
+from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.widgets.box import Box
 
@@ -19,27 +19,25 @@ class SmallBadge(Box):
     def __init__(
         self,
         *,
-        width: SizingLike = None,
-        height: SizingLike = None,
         padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
         style: Optional[SmallBadgeStyle] = None,
     ) -> None:
         """Initialize SmallBadge.
 
+        The dot dimensions are MD3-fixed (spec size tokens), so they are not
+        constructor parameters; customize them via ``style`` instead
+        (SIZE_POLICY: MD3 fixes the axis -> style only).
+
         Args:
-            width: Badge width sizing. Defaults to style width.
-            height: Badge height sizing. Defaults to style height.
             padding: External badge padding.
             style: Optional style override.
         """
         effective_style = style or SmallBadgeStyle()
-        resolved_width = width if width is not None else Sizing.fixed(effective_style.width)
-        resolved_height = height if height is not None else Sizing.fixed(effective_style.height)
 
         super().__init__(
             child=None,
-            width=resolved_width,
-            height=resolved_height,
+            width=Sizing.fixed(effective_style.width),
+            height=Sizing.fixed(effective_style.height),
             padding=padding,
             background_color=effective_style.background_color,
             corner_radius=effective_style.corner_radius,
@@ -70,17 +68,17 @@ class LargeBadge(Box):
         self,
         text: str,
         *,
-        width: SizingLike = None,
-        height: SizingLike = None,
         padding: Union[int, Tuple[int, int], Tuple[int, int, int, int], None] = None,
         style: Optional[LargeBadgeStyle] = None,
     ) -> None:
         """Initialize LargeBadge.
 
+        The height is MD3-fixed (spec) and the width is content-driven, so
+        neither is a constructor parameter; customize the height via ``style``
+        (SIZE_POLICY: MD3 fixes the axis -> style only).
+
         Args:
             text: Badge text to display. Must be non-empty.
-            width: Badge width sizing.
-            height: Badge height sizing. Defaults to style height.
             padding: External badge padding. Defaults to style padding.
             style: Optional style override.
         """
@@ -90,7 +88,7 @@ class LargeBadge(Box):
         self.text = text
 
         effective_style = style or LargeBadgeStyle()
-        resolved_height = height if height is not None else Sizing.fixed(effective_style.height)
+        resolved_height = Sizing.fixed(effective_style.height)
         resolved_padding = effective_style.padding if padding is None else padding
 
         label = Text(
@@ -105,7 +103,6 @@ class LargeBadge(Box):
 
         super().__init__(
             child=label,
-            width=width,
             height=resolved_height,
             padding=resolved_padding,
             background_color=effective_style.background_color,

--- a/src/nuiitivet/material/buttons.py
+++ b/src/nuiitivet/material/buttons.py
@@ -697,11 +697,15 @@ class Button(MaterialButtonBase):
         on_click: Optional[VoidCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
-        height: SizingLike = None,
         padding: Optional[Union[int, Tuple[int, int, int, int]]] = None,
         style: Optional[ButtonStyle] = None,
     ):
         """Initialize Button.
+
+        The height is MD3-fixed by the style's size variant, so it is not a
+        constructor parameter; select it through ``style`` (e.g.
+        ``ButtonStyle.filled("m")``) — SIZE_POLICY: MD3 fixes the axis -> style
+        only.
 
         Args:
             label: Text label for the button.
@@ -709,27 +713,25 @@ class Button(MaterialButtonBase):
             on_click: Callback invoked when the button is clicked.
             disabled: Whether the button is disabled.
             width: Width specification. Defaults to auto.
-            height: Height specification. Defaults to auto.
             padding: Padding override; ``None`` delegates to ``style.padding``.
             style: Visual style preset. Defaults to ``ButtonStyle.filled("s")``.
         """
         effective_style = style if style is not None else ButtonStyle.filled("s")
         self._user_style = effective_style
         self._user_padding = padding
-        self._user_height = height
+        self._user_height = None
 
         text_color = effective_style.foreground if effective_style else ColorRole.ON_PRIMARY
-        height_px = _coerce_fixed_height_px(height)
 
         child_widget = build_button_child(
             label=label,
             icon=icon,
             foreground=text_color,
-            button_height=height_px,
+            button_height=None,
             style=effective_style,
         )
 
-        params = resolve_button_style_params(effective_style, padding, height, disabled)
+        params = resolve_button_style_params(effective_style, padding, None, disabled)
 
         super().__init__(
             child=child_widget,
@@ -968,11 +970,15 @@ class ToggleButton(ToggleButtonBase):
         on_change: Optional[BoolCallback] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
-        height: SizingLike = None,
         padding: Optional[Union[int, Tuple[int, int, int, int]]] = None,
         style: Optional[ToggleButtonStyle] = None,
     ):
         """Initialize ToggleButton.
+
+        The height is MD3-fixed by the style's size variant, so it is not a
+        constructor parameter; select it through ``style`` (e.g.
+        ``ToggleButtonStyle.filled("m")``) — SIZE_POLICY: MD3 fixes the axis ->
+        style only.
 
         Args:
             label: Text label for the button.
@@ -981,7 +987,6 @@ class ToggleButton(ToggleButtonBase):
             on_change: Callback invoked with the new selected value.
             disabled: Whether the button is disabled.
             width: Width specification.
-            height: Height specification.
             padding: Padding override; ``None`` uses ``style.padding``.
             style: Toggle style preset. Defaults to ``ToggleButtonStyle.filled("s")``.
         """
@@ -994,7 +999,6 @@ class ToggleButton(ToggleButtonBase):
             on_change=on_change,
             disabled=disabled,
             width=width,
-            height=height,
             padding=padding,
         )
 

--- a/src/nuiitivet/material/chip.py
+++ b/src/nuiitivet/material/chip.py
@@ -21,22 +21,6 @@ if TYPE_CHECKING:
     from nuiitivet.material.symbols import Symbol
 
 
-def _resolve_fixed_height(height: SizingLike, fallback: int) -> int:
-    if isinstance(height, (int, float)):
-        return int(height)
-    if height is None:
-        return int(fallback)
-    try:
-        from nuiitivet.rendering.sizing import parse_sizing
-
-        parsed = parse_sizing(height, default=None)
-        if parsed.kind == "fixed":
-            return int(parsed.value)
-    except Exception:
-        pass
-    return int(fallback)
-
-
 def _chip_text(
     label: str | ReadOnlyObservableProtocol[str],
     color: ColorSpec,
@@ -88,7 +72,6 @@ class MaterialChipBase(InteractiveWidget):
         on_click: Optional[Callable[[], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
-        height: SizingLike = None,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["ChipStyle"] = None,
     ):
@@ -99,13 +82,13 @@ class MaterialChipBase(InteractiveWidget):
             on_click: Click callback.
             disabled: Disabled flag.
             width: Width sizing.
-            height: Height sizing.
             padding: External insets around chip widget.
             style: Optional chip style.
         """
         self._user_style = style
         effective_style = self.style
-        resolved_height = _resolve_fixed_height(height, effective_style.container_height)
+        # Chip height is MD3-fixed (container_height token) -> style only.
+        resolved_height = int(effective_style.container_height)
         content_padding = padding if padding is not None else 0
 
         super().__init__(
@@ -170,7 +153,6 @@ class AssistChip(MaterialChipBase):
         on_click: Optional[Callable[[], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
-        height: SizingLike = None,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["ChipStyle"] = None,
     ):
@@ -182,7 +164,6 @@ class AssistChip(MaterialChipBase):
             on_click: Click callback.
             disabled: Disabled flag.
             width: Width sizing.
-            height: Height sizing.
             padding: External insets around chip widget.
             style: Optional chip style.
         """
@@ -208,7 +189,6 @@ class AssistChip(MaterialChipBase):
             on_click=on_click,
             disabled=disabled,
             width=width,
-            height=height,
             padding=padding,
             style=style,
         )
@@ -231,7 +211,6 @@ class FilterChip(MaterialChipBase):
         on_click: Optional[Callable[[], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
-        height: SizingLike = None,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["ChipStyle"] = None,
     ):
@@ -245,7 +224,6 @@ class FilterChip(MaterialChipBase):
             on_click: Additional click callback.
             disabled: Disabled flag.
             width: Width sizing.
-            height: Height sizing.
             padding: External insets around chip widget.
             style: Optional chip style.
         """
@@ -272,7 +250,6 @@ class FilterChip(MaterialChipBase):
             on_click=self._handle_click,
             disabled=disabled,
             width=width,
-            height=height,
             padding=padding,
             style=style,
         )
@@ -365,7 +342,6 @@ class InputChip(MaterialChipBase):
         on_click: Optional[Callable[[], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
-        height: SizingLike = None,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["ChipStyle"] = None,
     ):
@@ -379,7 +355,6 @@ class InputChip(MaterialChipBase):
             on_click: Click callback.
             disabled: Disabled flag.
             width: Width sizing.
-            height: Height sizing.
             padding: External insets around chip widget.
             style: Optional chip style.
         """
@@ -420,7 +395,6 @@ class InputChip(MaterialChipBase):
             on_click=on_click,
             disabled=disabled,
             width=width,
-            height=height,
             padding=padding,
             style=style,
         )
@@ -441,7 +415,6 @@ class SuggestionChip(MaterialChipBase):
         on_click: Optional[Callable[[], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = None,
-        height: SizingLike = None,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["ChipStyle"] = None,
     ):
@@ -453,7 +426,6 @@ class SuggestionChip(MaterialChipBase):
             on_click: Click callback.
             disabled: Disabled flag.
             width: Width sizing.
-            height: Height sizing.
             padding: External insets around chip widget.
             style: Optional chip style.
         """
@@ -479,7 +451,6 @@ class SuggestionChip(MaterialChipBase):
             on_click=on_click,
             disabled=disabled,
             width=width,
-            height=height,
             padding=padding,
             style=style,
         )

--- a/src/nuiitivet/material/menu.py
+++ b/src/nuiitivet/material/menu.py
@@ -21,7 +21,7 @@ from nuiitivet.material.text import Text
 from nuiitivet.observable import runtime
 from nuiitivet.overlay.overlay_position import AnchoredOverlayPosition
 from nuiitivet.material.theme.elevation import md3_elevation_to_shadow
-from nuiitivet.rendering.sizing import Sizing, SizingLike
+from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.theme.types import ColorBase, ColorSpec
 from nuiitivet.widgets.interaction import FocusNode, FocusSource
 from nuiitivet.widgeting.widget import Widget
@@ -60,9 +60,12 @@ class MenuItem(InteractiveWidget):
         disabled: bool = False,
         leading_icon: Symbol | str | None = None,
         trailing: Symbol | str | None = None,
-        height: SizingLike = None,
     ) -> None:
         """Initialize MenuItem.
+
+        The item height is MD3-fixed (list-item token), so it is not a
+        constructor parameter; customize it via ``MenuStyle.item_height``
+        (SIZE_POLICY: MD3 fixes the axis -> style only).
 
         Args:
             label: Item label.
@@ -70,14 +73,12 @@ class MenuItem(InteractiveWidget):
             disabled: Whether this item is disabled.
             leading_icon: Optional leading icon.
             trailing: Optional trailing icon (Symbol) or trailing text (str).
-            height: Optional fixed item height.
         """
         self.label = label
         self.leading_icon = leading_icon
         self.trailing = trailing
         self._menu_style: MenuStyle = MenuStyle.standard()
         self._selected = False
-        self._uses_style_height = height is None
         self._leading_icon_widget: Icon | None = None
         self._label_widget: Text | None = None
         self._trailing_text_widget: Text | None = None
@@ -86,7 +87,7 @@ class MenuItem(InteractiveWidget):
         self._content_container: Container | None = None
         self._content_icon_size: int | None = None
 
-        resolved_height = height if height is not None else Sizing.fixed(self._menu_style.item_height)
+        resolved_height = Sizing.fixed(self._menu_style.item_height)
 
         super().__init__(
             child=Text(label),
@@ -192,8 +193,7 @@ class MenuItem(InteractiveWidget):
         self._PRESS_OPACITY = float(style.pressed_alpha)
         self.corner_radius = float(style.state_layer_corner_radius)
 
-        if self._uses_style_height:
-            self.height_sizing = Sizing.fixed(style.item_height)
+        self.height_sizing = Sizing.fixed(style.item_height)
 
         foreground = style.selected_foreground if self._selected else style.label_color
         icon_color = style.selected_foreground if self._selected else style.icon_color
@@ -273,7 +273,6 @@ class SubMenuItem(MenuItem):
         *,
         leading_icon: Symbol | str | None = None,
         disabled: bool = False,
-        height: SizingLike = None,
     ) -> None:
         """Initialize SubMenuItem.
 
@@ -282,7 +281,6 @@ class SubMenuItem(MenuItem):
             items: Submenu entries.
             leading_icon: Optional leading icon.
             disabled: Whether this item is disabled.
-            height: Optional fixed item height.
         """
         self._submenu_items = list(items)
         self._submenu_handle: OverlayHandle[object] | None = None
@@ -298,7 +296,6 @@ class SubMenuItem(MenuItem):
             disabled=disabled,
             leading_icon=leading_icon,
             trailing=Symbols.chevron_right,
-            height=height,
         )
 
     def _on_self_click(self) -> None:

--- a/src/nuiitivet/material/selection_controls.py
+++ b/src/nuiitivet/material/selection_controls.py
@@ -15,7 +15,6 @@ from nuiitivet.animation import Animatable
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.layout.container import Container
 from nuiitivet.observable import Observable, ObservableProtocol
-from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.widgets.toggleable import Toggleable
 from nuiitivet.material.interactive_widget import InteractiveWidget
@@ -36,7 +35,6 @@ class Checkbox(Toggleable, InteractiveWidget):
     Parameters:
     - checked: Checked state source (bool / Observable[bool] / Observable[Optional[bool]])
     - on_toggle: Callback when toggled
-    - size: Touch target size (default 48dp, M3 recommendation)
     - padding: Space around the checkbox (M3: "space between UI elements")
     - indeterminate: Indeterminate flag (bool / Observable[bool])
     - disabled: Disable interaction (bool / Observable[bool])
@@ -50,7 +48,6 @@ class Checkbox(Toggleable, InteractiveWidget):
         on_toggle: Optional[Callable[[Optional[bool]], None]] = None,
         indeterminate: bool | ObservableProtocol[bool] = False,
         disabled: bool | ObservableProtocol[bool] = False,
-        size: SizingLike = 48,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["CheckboxStyle"] = None,
     ):
@@ -89,6 +86,13 @@ class Checkbox(Toggleable, InteractiveWidget):
         # Store style (use provided or get from theme lazily)
         self._style = style
 
+        # Touch-target size is style-driven, not a constructor parameter: MD3
+        # fixes the selection-control target at 48dp (SIZE_POLICY: MD3 fixes the
+        # axis -> style only). Sourced from the resolved style's
+        # ``default_touch_target``; the ``width_sizing``/``height_sizing``
+        # escape hatch on the base kernel still overrides it.
+        touch_target = int(self._style.default_touch_target) if self._style is not None else 48
+
         # Resolve padding
         final_padding = padding
         if final_padding is None:
@@ -103,8 +107,8 @@ class Checkbox(Toggleable, InteractiveWidget):
             on_change=on_toggle,
             tristate=False,  # Checkbox does not cycle to indeterminate
             disabled=disabled,
-            width=size,
-            height=size,
+            width=touch_target,
+            height=touch_target,
             padding=final_padding,
         )
 
@@ -112,22 +116,7 @@ class Checkbox(Toggleable, InteractiveWidget):
         # We can do this in on_mount or similar if we want full theme support for padding.
         self._user_padding = padding
 
-        # Parse size for M3 touch target
-        try:
-            from nuiitivet.rendering.sizing import parse_sizing
-
-            parsed = parse_sizing(size, default=None)
-            if parsed.kind == "fixed":
-                self._touch_target_size = int(parsed.value)
-            elif parsed.kind in ("flex", "auto"):
-                # Checkbox cannot resolve flex/auto without parent context
-                self._touch_target_size = 48
-            else:
-                # Last resort: try numeric coercion
-                self._touch_target_size = int(cast(int, size))
-        except Exception:
-            exception_once(_logger, "checkbox_size_exc", "Failed to parse checkbox size")
-            self._touch_target_size = 48
+        self._touch_target_size = touch_target
 
         initial_selection = 1.0 if self.value is True or self.value is None else 0.0
         self._state_layer_anim: Animatable[float] = Animatable(0.0, motion=EXPRESSIVE_DEFAULT_EFFECTS)
@@ -557,7 +546,6 @@ class RadioButton(Toggleable, InteractiveWidget):
         value: object | None,
         *,
         disabled: bool | ObservableProtocol[bool] = False,
-        size: SizingLike = 48,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["RadioButtonStyle"] = None,
     ) -> None:
@@ -566,12 +554,14 @@ class RadioButton(Toggleable, InteractiveWidget):
         Args:
             value: Option value represented by this radio button.
             disabled: Disable interaction when True.
-            size: Touch target size.
             padding: Space around the touch target.
             style: Style override. Uses theme style when omitted.
         """
         self.option_value = value
         self._style = style
+
+        # Touch-target size is style-driven (MD3 fixes the axis -> style only).
+        touch_target = int(self._style.default_touch_target) if self._style is not None else 48
 
         final_padding = padding if padding is not None else (style.padding if style is not None else 0)
         self._user_padding = padding
@@ -581,21 +571,12 @@ class RadioButton(Toggleable, InteractiveWidget):
             on_change=None,
             tristate=False,
             disabled=disabled,
-            width=size,
-            height=size,
+            width=touch_target,
+            height=touch_target,
             padding=final_padding,
         )
 
-        try:
-            from nuiitivet.rendering.sizing import parse_sizing
-
-            parsed = parse_sizing(size, default=None)
-            if parsed.kind == "fixed":
-                self._touch_target_size = int(parsed.value)
-            else:
-                self._touch_target_size = 48
-        except Exception:
-            self._touch_target_size = 48
+        self._touch_target_size = touch_target
 
         self._state_layer_anim: Animatable[float] = Animatable(0.0, motion=EXPRESSIVE_DEFAULT_EFFECTS)
         self.bind(self._state_layer_anim.subscribe(lambda _: self.invalidate()))
@@ -809,7 +790,6 @@ class Switch(Toggleable, InteractiveWidget):
         *,
         on_change: Optional[Callable[[bool], None]] = None,
         disabled: bool | ObservableProtocol[bool] = False,
-        size: SizingLike = 48,
         padding: Optional[Union[int, Tuple[int, int], Tuple[int, int, int, int]]] = None,
         style: Optional["SwitchStyle"] = None,
     ) -> None:
@@ -819,13 +799,15 @@ class Switch(Toggleable, InteractiveWidget):
             checked: Checked state source (bool or observable bool).
             on_change: Callback invoked when checked state changes.
             disabled: Disable interaction when True.
-            size: Touch target size.
             padding: Space around the switch.
             style: Style override. Uses theme style when omitted.
         """
         self._style = style
         self._user_padding = padding
         self._on_change_bool = on_change
+
+        # Touch-target size is style-driven (MD3 fixes the axis -> style only).
+        touch_target = int(self._style.default_touch_target) if self._style is not None else 48
 
         final_padding = padding if padding is not None else (style.padding if style is not None else 0)
 
@@ -840,21 +822,12 @@ class Switch(Toggleable, InteractiveWidget):
             on_change=_on_toggle,
             tristate=False,
             disabled=disabled,
-            width=size,
-            height=size,
+            width=touch_target,
+            height=touch_target,
             padding=final_padding,
         )
 
-        try:
-            from nuiitivet.rendering.sizing import parse_sizing
-
-            parsed = parse_sizing(size, default=None)
-            if parsed.kind == "fixed":
-                self._touch_target_size = int(parsed.value)
-            else:
-                self._touch_target_size = 48
-        except Exception:
-            self._touch_target_size = 48
+        self._touch_target_size = touch_target
 
         self._state_layer_anim: Animatable[float] = Animatable(0.0, motion=EXPRESSIVE_DEFAULT_EFFECTS)
         self.bind(self._state_layer_anim.subscribe(lambda _: self.invalidate()))

--- a/src/nuiitivet/material/text_fields.py
+++ b/src/nuiitivet/material/text_fields.py
@@ -158,7 +158,6 @@ class TextField(InteractiveWidget):
         error_text: str | ReadOnlyObservableProtocol[str | None] | None = None,
         disabled: bool | ObservableProtocol[bool] = False,
         width: SizingLike = 200,
-        height: SizingLike = None,
         padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
         style: Optional[TextFieldStyle] = None,
     ):
@@ -178,13 +177,11 @@ class TextField(InteractiveWidget):
             error_text: Deprecated alias for supporting_text.
             disabled: Whether the text field is disabled.
             width: Width specification.
-            height: Height specification.
             padding: Padding around the text field.
             style: Custom style configuration.
         """
         super().__init__(
             width=width,
-            height=height,
             padding=padding,
             state_layer_color=ColorRole.ON_SURFACE,
             disabled=False,  # Set initial disabled state below

--- a/tests/material/test_button.py
+++ b/tests/material/test_button.py
@@ -12,8 +12,10 @@ def test_preferred_size_default_and_custom():
     w, h = b.preferred_size()
     assert w >= 64
     assert h == 48
-    b2 = Button("ok", width=200, height=60, style=ButtonStyle.filled())
-    assert b2.preferred_size() == (200, 60)
+    # Height is MD3-fixed by the style size variant (filled("s") -> 48dp);
+    # only width is a constructor parameter.
+    b2 = Button("ok", width=200, style=ButtonStyle.filled())
+    assert b2.preferred_size() == (200, 48)
 
 
 def test_pointer_event_click_calls_handler_and_pressed_state():

--- a/tests/material/test_checkbox.py
+++ b/tests/material/test_checkbox.py
@@ -14,14 +14,17 @@ def _make_obs(initial):
 
 
 def test_preferred_size_default_and_custom():
-    """Test preferred_size with default (48dp M3) and custom sizes."""
+    """Test preferred_size with default (48dp M3) and style-driven sizes."""
+    from nuiitivet.material.styles.checkbox_style import CheckboxStyle
+
     c = Checkbox()
     assert c.preferred_size() == (48, 48)
-    c2 = Checkbox(size=56)
+    # Touch-target size is style-driven (MD3 fixes the axis -> style only).
+    c2 = Checkbox(style=CheckboxStyle(default_touch_target=56))
     assert c2.preferred_size() == (56, 56)
-    c3 = Checkbox(size=48, padding=8)
+    c3 = Checkbox(style=CheckboxStyle(default_touch_target=48), padding=8)
     assert c3.preferred_size() == (64, 64)
-    c4 = Checkbox(size=40)
+    c4 = Checkbox(style=CheckboxStyle(default_touch_target=40))
     assert c4.preferred_size() == (40, 40)
 
 
@@ -187,7 +190,7 @@ def test_checkbox_padding():
 
 def test_checkbox_content_rect():
     """Test content_rect applies padding correctly."""
-    c = Checkbox(size=48, padding=10)
+    c = Checkbox(padding=10)
     cx, cy, cw, ch = c.content_rect(0, 0, 100, 100)
     assert cx == 10
     assert cy == 10

--- a/tests/material/test_checkbox_icon_scaling.py
+++ b/tests/material/test_checkbox_icon_scaling.py
@@ -15,7 +15,7 @@ class TestCheckboxIconScaling(unittest.TestCase):
             self.skipTest("skia-python is required for this test")
 
         # Checkbox with flex width (simulated by passing large rect to paint)
-        c = Checkbox(size="100%")
+        c = Checkbox()
 
         # Mock canvas
         canvas = MagicMock()
@@ -61,7 +61,7 @@ class TestCheckboxIconScaling(unittest.TestCase):
         self.assertTrue(found_large_font, "Icon did not scale to fit allocated rect")
 
     def test_checkbox_hit_test_rect(self):
-        c = Checkbox(size="100%")
+        c = Checkbox()
         canvas = MagicMock()
         # Paint with 100x100
         c.paint(canvas, 0, 0, 100, 100)

--- a/tests/material/test_checkbox_style.py
+++ b/tests/material/test_checkbox_style.py
@@ -30,7 +30,7 @@ def test_checkbox_accepts_custom_style():
 def test_checkbox_style_compute_sizes():
     """Checkbox should use style.compute_sizes() for layout."""
     custom_style = CheckboxStyle(icon_size_ratio=0.6, corner_radius_ratio=0.2, stroke_width_ratio=0.15)
-    checkbox = Checkbox(size=40, style=custom_style)
+    checkbox = Checkbox(style=custom_style)
     sizes = checkbox.style.compute_sizes(40)
     assert sizes["icon_size"] == 24
     assert abs(sizes["corner_radius"] - 4.8) < 0.01
@@ -59,10 +59,12 @@ def test_theme_with_custom_checkbox_style():
     assert new_mat_data.checkbox_style.hover_alpha == 0.1
 
 
-def test_checkbox_style_backward_compatible():
-    """Existing code without style parameter should continue working."""
-    checkbox1 = Checkbox(checked=True, size=48)
+def test_checkbox_touch_target_from_style():
+    """Touch-target size is sourced from the style (MD3 fixes the axis)."""
+    checkbox1 = Checkbox(checked=True)
     assert checkbox1.style is not None
-    checkbox2 = Checkbox(checked=False, size=40, padding=8, disabled=True)
+    checkbox2 = Checkbox(
+        checked=False, style=CheckboxStyle(default_touch_target=40), padding=8, disabled=True
+    )
     assert checkbox2.style is not None
     assert checkbox2._touch_target_size == 40

--- a/tests/material/test_switch.py
+++ b/tests/material/test_switch.py
@@ -51,11 +51,14 @@ def test_switch_disabled_prevents_toggle() -> None:
 
 
 def test_switch_preferred_size_default_and_padding() -> None:
+    from nuiitivet.material.styles.switch_style import SwitchStyle
+
     s1 = Switch()
     assert s1.preferred_size() == (48, 48)
 
-    s2 = Switch(size=56)
+    # Touch-target size is style-driven (MD3 fixes the axis -> style only).
+    s2 = Switch(style=SwitchStyle(default_touch_target=56))
     assert s2.preferred_size() == (56, 56)
 
-    s3 = Switch(size=48, padding=8)
+    s3 = Switch(style=SwitchStyle(default_touch_target=48), padding=8)
     assert s3.preferred_size() == (64, 64)


### PR DESCRIPTION
## Summary
- Codify a single **binary, per-axis rule** for which size dimensions are public constructor parameters: MD3 leaves the axis open → expose it with a semantic name (`size`/`length`/`width`); MD3 fixes the axis → `style` only. API curation only — **no runtime enforcement**, and the `width_sizing`/`height_sizing` escape hatch still works.
- **Breaking API changes** (customize via style instead):
  - `Checkbox`/`RadioButton`/`Switch`: removed `size` → sourced from `*Style.default_touch_target`
  - `SmallBadge`/`LargeBadge`: removed `width`/`height` (spec-fixed / content-driven)
  - `Button`/`ToggleButton`: removed `height` (fixed by style size variant)
  - Chips (`Assist`/`Filter`/`Input`/`Suggestion`): removed `height`
  - `TextField`: removed `height`; `MenuItem`/`SubMenuItem`: removed `height` (from `MenuStyle.item_height`)
- **Audit correction**: `ButtonGroup.group_width` is an internal `_ButtonGroupBase` param, not public API → button groups already conform (no change).
- Docs: `SIZE_POLICY.md` Section 0 (rule + curation stance + semantic naming + full classification table), `LAYOUT.md`, `M3_AND_PADDING_INTEGRATION_RULES.md` updated.
- Follow-ups filed: #258 (ambient icon theme), #259 (axis-specific Scrollbar).

## Test plan
- [x] `pytest tests` — 1425 passed
- [x] `mypy` on changed material files — clean
- [x] `compileall` on `src` and `samples` — clean
- [x] Confirmed default appearance unchanged (touch target / heights sourced from style)

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)