### PR TITLE
refactor(scrollbar)!: split Scrollbar into axis-specific classes (#259)

### DIFF
--- a/docs/design/SIZE_POLICY.md
+++ b/docs/design/SIZE_POLICY.md
@@ -61,6 +61,7 @@ A dimension is decided **per axis**, using one binary test:
 | `LinearProgressIndicator.width` (= length) | No (main) / thickness style | `width` |
 | `SmallBadge` / `LargeBadge` | Yes (spec tokens) / width content-driven | style only (no size param) |
 | `HorizontalDivider.width` / `VerticalDivider.height` | main No / cross Yes | axis-specific param only |
+| `HorizontalScrollbar.width` / `VerticalScrollbar.height` (= `length`) | main No / cross Yes (`thickness`) | axis-specific `length` param only |
 | `DockedToolbar` / `Horizontal`·`VerticalFloatingToolbar` | style-driven | no public size param |
 | `TextField.width` | No | `width` |
 | `TextField.height` | Yes (56dp) | style only |

--- a/src/nuiitivet/layout/scrollable.py
+++ b/src/nuiitivet/layout/scrollable.py
@@ -25,7 +25,12 @@ from ..widgeting.widget import Widget
 from ..scrolling import ScrollController, ScrollDirection, ScrollPhysics, ScrollbarStyle
 from ..rendering.sizing import Sizing, SizingLike
 from ..input.pointer import PointerEvent, PointerEventType
-from ..widgets.scrollbar import Scrollbar, ScrollbarBehavior
+from ..widgets.scrollbar import (
+    HorizontalScrollbar,
+    ScrollbarBehavior,
+    VerticalScrollbar,
+    _ScrollbarBase,
+)
 from .scroll_viewport import ScrollViewport
 
 logger = logging.getLogger(__name__)
@@ -56,6 +61,9 @@ class _ScrollableBase(Widget):
 
     #: Scroll axis fixed by each concrete subclass.
     _direction: ClassVar[ScrollDirection]
+
+    #: Axis-specific scrollbar class fixed by each concrete subclass.
+    _scrollbar_class: ClassVar[type[_ScrollbarBase]]
 
     def __init__(
         self,
@@ -117,10 +125,9 @@ class _ScrollableBase(Widget):
         )
         self.add_child(self._viewport)
 
-        self._scrollbar = Scrollbar(
+        self._scrollbar = self._scrollbar_class(
             self._controller,
             behavior=self._scrollbar_behavior,
-            direction=self.direction,
             thickness=self._scrollbar_style.thickness,
             min_thumb_length=self._scrollbar_style.min_thumb_length,
             padding=self._scrollbar_style.inset,
@@ -526,12 +533,14 @@ class VerticalScrollable(_ScrollableBase):
     """Scrolls its child along the vertical axis."""
 
     _direction = ScrollDirection.VERTICAL
+    _scrollbar_class = VerticalScrollbar
 
 
 class HorizontalScrollable(_ScrollableBase):
     """Scrolls its child along the horizontal axis."""
 
     _direction = ScrollDirection.HORIZONTAL
+    _scrollbar_class = HorizontalScrollbar
 
 
 __all__ = ["VerticalScrollable", "HorizontalScrollable"]

--- a/src/nuiitivet/widgets/scrollbar.py
+++ b/src/nuiitivet/widgets/scrollbar.py
@@ -1,8 +1,16 @@
-"""Scrollbar widget: independent scrollbar drawing and event handling.
+"""Scrollbar widgets: independent scrollbar drawing and event handling.
 
-This is a minimal, reusable implementation that supports vertical scrollbars.
-It derives colors from the current Theme (ColorRole.ON_SURFACE) and exposes
-handle_event/draw APIs so containers (like Scrollable) can delegate behavior.
+Public API:
+
+* :class:`VerticalScrollbar` — scrollbar for the vertical axis.
+* :class:`HorizontalScrollbar` — scrollbar for the horizontal axis.
+
+Both share :class:`_ScrollbarBase`, which holds the axis-parameterized drawing
+and gesture logic. Per the size policy, only the **main axis** (scroll length)
+is a public dimension; the **cross axis** is the fixed ``thickness``. Colors are
+derived from the current Theme (``ColorRole.ON_SURFACE`` / ``ColorRole.PRIMARY``),
+and the widgets expose paint / event APIs so containers (like ``*Scrollable``)
+can delegate behavior.
 """
 
 from __future__ import annotations
@@ -11,7 +19,7 @@ from dataclasses import dataclass
 import logging
 import threading
 import time
-from typing import Optional, Tuple
+from typing import ClassVar, Optional, Tuple
 
 from nuiitivet.animation import Animatable, LinearMotion
 from nuiitivet.input.pointer import PointerEvent
@@ -34,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class ScrollbarBehavior:
-    """Immutable behavior configuration for :class:`Scrollbar`."""
+    """Immutable behavior configuration for scrollbar widgets."""
 
     auto_hide: bool = True
     hide_delay: float = 1.0
@@ -56,8 +64,19 @@ class ScrollbarBehavior:
             object.__setattr__(self, "track_click_behavior", "none")
 
 
-class Scrollbar(InteractionHostMixin, Widget):
-    """Minimal vertical scrollbar widget."""
+class _ScrollbarBase(InteractionHostMixin, Widget):
+    """(Internal) Axis-parameterized scrollbar widget.
+
+    Not part of the public API. Use :class:`VerticalScrollbar` or
+    :class:`HorizontalScrollbar`, which fix the scroll axis via ``_direction``.
+
+    Draws a track + thumb for a single scroll axis and delegates gestures
+    (thumb drag, track click) to :class:`ScrollController`. Only the main-axis
+    length is a public dimension; the cross axis is the fixed ``thickness``.
+    """
+
+    #: Scroll axis fixed by each concrete subclass.
+    _direction: ClassVar[ScrollDirection]
 
     _offset_unsubscribe: Optional[object]
     _hide_timer: Optional[threading.Timer]
@@ -68,18 +87,29 @@ class Scrollbar(InteractionHostMixin, Widget):
         controller: ScrollController,
         behavior: Optional[ScrollbarBehavior] = None,
         *,
-        direction: ScrollDirection | str = ScrollDirection.VERTICAL,
+        length: SizingLike = None,
         thickness: int = 8,
         min_thumb_length: int = 24,
         padding: int | tuple | None = 0,
-        width: SizingLike = None,
-        height: SizingLike = None,
     ) -> None:
+        """Initialize shared scrollbar state.
+
+        Args:
+            controller: The :class:`ScrollController` driving the scroll axis.
+            behavior: Interaction behavior (auto-hide, track clicks…).
+            length: Main-axis length sizing override (cross axis is
+                ``thickness``). Maps to ``height`` for vertical scrollbars and
+                ``width`` for horizontal scrollbars via the concrete subclass.
+            thickness: Cross-axis thickness in pixels.
+            min_thumb_length: Minimum thumb length in pixels.
+            padding: Inner padding (inset) of the scrollbar.
+        """
+        width, height = self._axis_sizing(length, thickness)
         super().__init__(width=width, height=height, padding=padding)
         beh = behavior or ScrollbarBehavior()
         self._controller = controller
         self._behavior = beh
-        self.direction = direction if isinstance(direction, ScrollDirection) else ScrollDirection(direction)
+        self.direction = self._direction
         self.thickness = int(thickness)
         self.min_thumb_length = int(min_thumb_length)
         self.interactive = bool(beh.interactive)
@@ -555,5 +585,43 @@ class Scrollbar(InteractionHostMixin, Widget):
         self._active_pointer_id = None
         self._on_interaction()
 
+    @staticmethod
+    def _axis_sizing(length: SizingLike, thickness: int) -> Tuple[SizingLike, SizingLike]:
+        """Map the main-axis ``length`` onto ``(width, height)`` for the axis.
 
-__all__ = ["Scrollbar", "ScrollbarBehavior"]
+        The cross axis is fixed to ``thickness`` (not exposed publicly); the
+        concrete subclass overrides this to assign ``length`` to the correct
+        dimension. The base implementation raises to force a subclass.
+        """
+        raise NotImplementedError
+
+
+class VerticalScrollbar(_ScrollbarBase):
+    """Scrollbar for the vertical axis.
+
+    Only ``length`` (mapped to ``height``) is a public dimension; the width is
+    the fixed ``thickness`` (cross axis).
+    """
+
+    _direction = ScrollDirection.VERTICAL
+
+    @staticmethod
+    def _axis_sizing(length: SizingLike, thickness: int) -> Tuple[SizingLike, SizingLike]:
+        return (int(thickness), length)
+
+
+class HorizontalScrollbar(_ScrollbarBase):
+    """Scrollbar for the horizontal axis.
+
+    Only ``length`` (mapped to ``width``) is a public dimension; the height is
+    the fixed ``thickness`` (cross axis).
+    """
+
+    _direction = ScrollDirection.HORIZONTAL
+
+    @staticmethod
+    def _axis_sizing(length: SizingLike, thickness: int) -> Tuple[SizingLike, SizingLike]:
+        return (length, int(thickness))
+
+
+__all__ = ["VerticalScrollbar", "HorizontalScrollbar", "ScrollbarBehavior"]

--- a/tests/layout/test_scrollable.py
+++ b/tests/layout/test_scrollable.py
@@ -11,7 +11,7 @@ from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.scrolling import ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
-from nuiitivet.widgets.scrollbar import Scrollbar, ScrollbarBehavior
+from nuiitivet.widgets.scrollbar import ScrollbarBehavior, _ScrollbarBase
 from tests.helpers.pointer import send_pointer_event_for_test
 
 
@@ -269,7 +269,7 @@ def test_scrollable_registers_children_in_store():
     viewport = next((c for c in scrollable.children if isinstance(c, ScrollViewport)), None)
     assert viewport is not None
     assert child in viewport.children
-    assert any((isinstance(c, Scrollbar) for c in scrollable.children))
+    assert any((isinstance(c, _ScrollbarBase) for c in scrollable.children))
 
 
 def test_scrollable_scrollbar_visible_false_suppresses_display():
@@ -277,7 +277,7 @@ def test_scrollable_scrollbar_visible_false_suppresses_display():
     child = Column([Text("Item")])
     scrollable = VerticalScrollable(child=child, scrollbar_visible=False)
     # The scrollbar widget is still mounted as a child...
-    assert any((isinstance(c, Scrollbar) for c in scrollable.children))
+    assert any((isinstance(c, _ScrollbarBase) for c in scrollable.children))
     # ...but it never wants to show.
     assert scrollable._wants_scrollbar() is False
     assert scrollable._should_show_scrollbar() is False

--- a/tests/widgets/test_scrollbar.py
+++ b/tests/widgets/test_scrollbar.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from nuiitivet.scrolling import ScrollController, ScrollDirection
 from nuiitivet.input.pointer import PointerEventType
-from nuiitivet.widgets.scrollbar import Scrollbar, ScrollbarBehavior
+from nuiitivet.widgets.scrollbar import HorizontalScrollbar, ScrollbarBehavior, VerticalScrollbar
 from tests.helpers.pointer import send_pointer_event_for_test
 
 
@@ -21,7 +21,7 @@ class DummyApp:
 def test_scrollbar_mounts_and_listens_to_controller() -> None:
     controller = ScrollController()
     controller._update_metrics(max_extent=100.0, viewport_size=200, content_size=300)
-    scrollbar = Scrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False))
+    scrollbar = VerticalScrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False))
     app = DummyApp()
     scrollbar.mount(app)
     assert scrollbar._offset_unsubscribe is not None
@@ -37,7 +37,7 @@ def test_scrollbar_auto_hide_starts_animation_on_scroll() -> None:
     controller = ScrollController()
     controller._update_metrics(max_extent=200.0, viewport_size=200, content_size=400)
     behavior = ScrollbarBehavior(auto_hide=True, hide_delay=0.2, fade_duration=0.01)
-    scrollbar = Scrollbar(controller, behavior=behavior)
+    scrollbar = VerticalScrollbar(controller, behavior=behavior)
     app = DummyApp()
     scrollbar.mount(app)
 
@@ -58,7 +58,7 @@ def test_scrollbar_auto_hide_starts_animation_on_scroll() -> None:
 def test_scrollbar_drag_responds_to_mouse_move() -> None:
     controller = ScrollController()
     controller._update_metrics(max_extent=400.0, viewport_size=200, content_size=600)
-    scrollbar = Scrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False))
+    scrollbar = VerticalScrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False))
     scrollbar.bar_rect = (0, 0, scrollbar.thickness, 200)
     scrollbar.thumb_rect = (0, 0, scrollbar.thickness, 40)
     assert send_pointer_event_for_test(scrollbar, PointerEventType.PRESS, 2, 10) is True
@@ -72,7 +72,7 @@ def test_scrollbar_drag_responds_to_mouse_move() -> None:
 def test_scrollbar_horizontal_drag_responds_to_mouse_move() -> None:
     controller = ScrollController(axes=(ScrollDirection.HORIZONTAL,), primary_axis=ScrollDirection.HORIZONTAL)
     controller._update_metrics(max_extent=400.0, viewport_size=300, content_size=700)
-    scrollbar = Scrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False), direction=ScrollDirection.HORIZONTAL)
+    scrollbar = HorizontalScrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False))
     scrollbar.bar_rect = (0, 0, 200, scrollbar.thickness)
     scrollbar.thumb_rect = (0, 0, 60, scrollbar.thickness)
     assert send_pointer_event_for_test(scrollbar, PointerEventType.PRESS, 30, 2) is True
@@ -87,7 +87,7 @@ def test_hit_slop_expands_hover_and_press() -> None:
     controller = ScrollController()
     controller._update_metrics(max_extent=400.0, viewport_size=200, content_size=600)
     behavior = ScrollbarBehavior(auto_hide=False)
-    scrollbar = Scrollbar(controller, behavior=behavior)
+    scrollbar = VerticalScrollbar(controller, behavior=behavior)
     scrollbar.bar_rect = (0, 0, scrollbar.thickness, 200)
     scrollbar.thumb_rect = (0, 0, scrollbar.thickness, 40)
     hs = max(8, scrollbar.thickness)
@@ -105,7 +105,7 @@ def test_hit_slop_expands_hover_and_press_horizontal() -> None:
     controller = ScrollController(axes=(ScrollDirection.HORIZONTAL,), primary_axis=ScrollDirection.HORIZONTAL)
     controller._update_metrics(max_extent=400.0, viewport_size=300, content_size=700)
     behavior = ScrollbarBehavior(auto_hide=False)
-    scrollbar = Scrollbar(controller, behavior=behavior, direction=ScrollDirection.HORIZONTAL)
+    scrollbar = HorizontalScrollbar(controller, behavior=behavior)
     scrollbar.bar_rect = (0, 0, 200, scrollbar.thickness)
     scrollbar.thumb_rect = (0, 0, 60, scrollbar.thickness)
     hs = max(8, scrollbar.thickness)
@@ -124,7 +124,7 @@ def test_track_click_behavior_page_vertical() -> None:
     controller._update_metrics(max_extent=400.0, viewport_size=100, content_size=500)
     controller.scroll_to(200.0)
     behavior = ScrollbarBehavior(auto_hide=False, track_click_behavior="page")
-    scrollbar = Scrollbar(controller, behavior=behavior)
+    scrollbar = VerticalScrollbar(controller, behavior=behavior)
     scrollbar.bar_rect = (0, 0, scrollbar.thickness, 200)
     scrollbar.thumb_rect = (0, 80, scrollbar.thickness, 40)
     assert send_pointer_event_for_test(scrollbar, PointerEventType.PRESS, 2, 50) is True
@@ -137,7 +137,7 @@ def test_track_click_behavior_jump_vertical() -> None:
     controller = ScrollController()
     controller._update_metrics(max_extent=400.0, viewport_size=100, content_size=500)
     behavior = ScrollbarBehavior(auto_hide=False, track_click_behavior="jump")
-    scrollbar = Scrollbar(controller, behavior=behavior)
+    scrollbar = VerticalScrollbar(controller, behavior=behavior)
     scrollbar.bar_rect = (0, 0, scrollbar.thickness, 200)
     scrollbar.thumb_rect = (0, 0, scrollbar.thickness, 40)
     click_y = 150
@@ -149,7 +149,7 @@ def test_track_click_behavior_jump_vertical() -> None:
 def test_scrollbar_release_clears_hover_after_drag() -> None:
     controller = ScrollController()
     controller._update_metrics(max_extent=300.0, viewport_size=150, content_size=450)
-    scrollbar = Scrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False))
+    scrollbar = VerticalScrollbar(controller, behavior=ScrollbarBehavior(auto_hide=False))
     scrollbar.bar_rect = (0, 0, scrollbar.thickness, 200)
     scrollbar.thumb_rect = (0, 0, scrollbar.thickness, 40)
     assert send_pointer_event_for_test(scrollbar, PointerEventType.PRESS, 2, 10, pointer_id=1) is True


### PR DESCRIPTION
## Summary
- Replace the single `direction`-parameterized `Scrollbar` with axis-specific `VerticalScrollbar` / `HorizontalScrollbar`, mirroring the `*Scrollable` (#9) and Slider/Divider/FloatingToolbar (#250) axis-specific redesigns.
- Rename `Scrollbar` to internal `_ScrollbarBase` (`_direction` ClassVar); expose only the main-axis `length`, with the cross axis fixed as `thickness`.
- Drop the `direction` / `width` / `height` constructor params (breaking change, acceptable per project policy).
- `_ScrollableBase` picks its scrollbar via a `_scrollbar_class` ClassVar instead of threading `direction` through.
- Update SIZE_POLICY.md classification table and tests.

Closes #259

## Test plan
- [x] `pytest` full suite — 1425 passed
- [x] `mypy` on changed source files — no issues
- [x] Verified no lingering references to the old `Scrollbar` symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)