### PR TITLE
feat(scrollable)!: introduce ScrollableStyle and separate placement concerns (#261)

### DIFF
--- a/src/nuiitivet/layout/scrollable.py
+++ b/src/nuiitivet/layout/scrollable.py
@@ -7,10 +7,12 @@ Public API:
 
 Both share :class:`_ScrollableBase`, which holds the direction-parameterized
 layout / paint / gesture logic. The scroll *engine* configuration (``physics``
-and ``scroll_multiplier``) lives on :class:`~nuiitivet.scrolling.ScrollController`;
-scrollbar appearance is configured via
-:class:`~nuiitivet.scrolling.ScrollbarStyle` and scrollbar
-interaction via :class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
+and ``scroll_multiplier``) lives on :class:`~nuiitivet.scrolling.ScrollController`.
+Three independent concerns configure the scrollbar: appearance via
+:class:`~nuiitivet.scrolling.ScrollbarStyle`, placement (viewport padding, bar
+offset, overlay vs. inline) via :class:`~nuiitivet.scrolling.ScrollableStyle`,
+and temporal interaction via
+:class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
 """
 
 from __future__ import annotations
@@ -22,7 +24,8 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
 
 from ..widgeting.widget import Widget
-from ..scrolling import ScrollController, ScrollDirection, ScrollPhysics, ScrollbarStyle
+from ..scrolling import ScrollableStyle, ScrollController, ScrollDirection, ScrollPhysics, ScrollbarStyle
+from ..rendering.padding import parse_padding
 from ..rendering.sizing import Sizing, SizingLike
 from ..input.pointer import PointerEvent, PointerEventType
 from ..widgets.scrollbar import (
@@ -73,11 +76,16 @@ class _ScrollableBase(Widget):
         scrollbar_visible: ScrollbarVisibleLike = True,
         width: SizingLike = None,
         height: SizingLike = None,
-        padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
-        behavior: Optional[ScrollbarBehavior] = None,
-        style: Optional[ScrollbarStyle] = None,
+        scrollbar_behavior: Optional[ScrollbarBehavior] = None,
+        scrollbar_style: Optional[ScrollbarStyle] = None,
+        style: Optional[ScrollableStyle] = None,
     ) -> None:
         """Initialize the scrollable.
+
+        The three configuration concerns are kept separate: ``scrollbar_style``
+        owns the bar's appearance, ``style`` owns placement (viewport padding,
+        bar offset, overlay vs. inline), and ``scrollbar_behavior`` owns
+        temporal behavior (auto-hide, track clicks…).
 
         Args:
             child: The widget to make scrollable.
@@ -87,9 +95,10 @@ class _ScrollableBase(Widget):
                 or an ``Observable[bool]`` for reactive visibility.
             width: Width sizing override.
             height: Height sizing override.
-            padding: Inner padding of the viewport (scrolled area).
-            behavior: Scrollbar interaction behavior (auto-hide, track clicks…).
-            style: Scrollbar appearance (thickness, min thumb length, inset).
+            scrollbar_behavior: Scrollbar interaction behavior (auto-hide,
+                track clicks…).
+            scrollbar_style: Scrollbar appearance (thickness, min thumb length).
+            style: Placement (viewport padding, scrollbar padding, overlay).
         """
         super().__init__(width=width, height=height)
 
@@ -113,15 +122,18 @@ class _ScrollableBase(Widget):
         self.physics = self._controller.physics
         self.scroll_multiplier = self._controller.scroll_multiplier
 
-        self._scrollbar_behavior = behavior or ScrollbarBehavior()
-        self._scrollbar_style = style or ScrollbarStyle()
+        self._scrollbar_behavior = scrollbar_behavior or ScrollbarBehavior()
+        self._scrollbar_style = scrollbar_style or ScrollbarStyle()
+        self._scrollable_style = style or ScrollableStyle()
+        #: Bar offset from the viewport edge, parsed to (left, top, right, bottom).
+        self._scrollbar_padding = parse_padding(self._scrollable_style.scrollbar_padding)
         self._scrollbar_visible: ScrollbarVisibleLike = scrollbar_visible
 
         self._viewport = ScrollViewport(
             child=child,
             controller=self._controller,
             direction=self.direction,
-            padding=padding,
+            padding=parse_padding(self._scrollable_style.viewport_padding),
         )
         self.add_child(self._viewport)
 
@@ -130,7 +142,6 @@ class _ScrollableBase(Widget):
             behavior=self._scrollbar_behavior,
             thickness=self._scrollbar_style.thickness,
             min_thumb_length=self._scrollbar_style.min_thumb_length,
-            padding=self._scrollbar_style.inset,
         )
         self.add_child(self._scrollbar)
 
@@ -246,15 +257,15 @@ class _ScrollableBase(Widget):
         viewport_height = int(height)
 
         wants_scrollbar = self._wants_scrollbar()
-        reserve_always = bool(wants_scrollbar and (not bool(self._scrollbar_behavior.auto_hide)))
+        reserve_space = bool(wants_scrollbar and self._reserves_scrollbar_space())
 
-        if wants_scrollbar and reserve_always:
+        if reserve_space:
             if self.direction is ScrollDirection.VERTICAL:
-                pad_r = self._scrollbar.padding[2]
+                pad_r = self._scrollbar_padding[2]
                 thickness = self._scrollbar.thickness
                 viewport_width = max(0, viewport_width - thickness - pad_r)
             elif self.direction is ScrollDirection.HORIZONTAL:
-                pad_b = self._scrollbar.padding[3]
+                pad_b = self._scrollbar_padding[3]
                 thickness = self._scrollbar.thickness
                 viewport_height = max(0, viewport_height - thickness - pad_b)
 
@@ -265,13 +276,13 @@ class _ScrollableBase(Widget):
 
         if wants_scrollbar and self._should_show_scrollbar():
             if self.direction is ScrollDirection.VERTICAL:
-                pad_r = scrollbar.padding[2]
+                pad_r = self._scrollbar_padding[2]
                 bar_x = int(width) - scrollbar.thickness - pad_r
                 bar_y = 0
                 bar_w = scrollbar.thickness
                 bar_h = viewport_height
             else:
-                pad_b = scrollbar.padding[3]
+                pad_b = self._scrollbar_padding[3]
                 bar_x = 0
                 bar_y = int(height) - scrollbar.thickness - pad_b
                 bar_w = viewport_width
@@ -308,18 +319,17 @@ class _ScrollableBase(Widget):
 
         wants_scrollbar = self._wants_scrollbar()
 
-        # Phase 1 behaviour:
-        # - if scrollbar.auto_hide is True -> overlay: do NOT reserve space (draw on top)
-        # - if scrollbar.auto_hide is False -> reserve-always: always reserve space for the scrollbar
-        reserve_always = bool(wants_scrollbar and (not bool(self._scrollbar_behavior.auto_hide)))
+        # Placement:
+        # - scrollbar_overlay is True  -> overlay: do NOT reserve space (draw on top)
+        # - scrollbar_overlay is False -> inline: reserve a gutter for the scrollbar
+        reserve_space = bool(wants_scrollbar and self._reserves_scrollbar_space())
 
-        # If we must reserve space (auto_hide == False) subtract thickness regardless
-        if wants_scrollbar and reserve_always:
+        if reserve_space:
             if self.direction is ScrollDirection.VERTICAL:
-                pad_r = self._scrollbar.padding[2]
+                pad_r = self._scrollbar_padding[2]
                 viewport_width = max(0, viewport_width - self._scrollbar.thickness - pad_r)
             elif self.direction is ScrollDirection.HORIZONTAL:
-                pad_b = self._scrollbar.padding[3]
+                pad_b = self._scrollbar_padding[3]
                 viewport_height = max(0, viewport_height - self._scrollbar.thickness - pad_b)
 
         self._viewport.paint(canvas, x, y, viewport_width, viewport_height)
@@ -329,7 +339,7 @@ class _ScrollableBase(Widget):
             viewport_rect = self._viewport.viewport_rect or (x, y, viewport_width, viewport_height)
             scrollbar = self._scrollbar
             if self.direction is ScrollDirection.VERTICAL:
-                pad_r = scrollbar.padding[2]
+                pad_r = self._scrollbar_padding[2]
                 bar_x = x + width - scrollbar.thickness - pad_r
                 bar_y = viewport_rect[1]
                 bar_w = scrollbar.thickness
@@ -342,7 +352,7 @@ class _ScrollableBase(Widget):
                 except Exception:
                     exception_once(logger, "scrollable_scrollbar_paint_exc", "Scrollbar paint failed")
             elif self.direction is ScrollDirection.HORIZONTAL:
-                pad_b = scrollbar.padding[3]
+                pad_b = self._scrollbar_padding[3]
                 bar_x = viewport_rect[0]
                 bar_y = y + height - scrollbar.thickness - pad_b
                 bar_w = viewport_rect[2]
@@ -358,6 +368,14 @@ class _ScrollableBase(Widget):
     def _wants_scrollbar(self) -> bool:
         """Whether a scrollbar should participate in layout / paint at all."""
         return _read_bool(self._scrollbar_visible) and self.physics is not ScrollPhysics.NEVER
+
+    def _reserves_scrollbar_space(self) -> bool:
+        """Whether the viewport reserves a gutter for the scrollbar (inline).
+
+        Driven purely by placement (``ScrollableStyle.scrollbar_overlay``) and
+        independent of temporal behavior (``ScrollbarBehavior.auto_hide``).
+        """
+        return not self._scrollable_style.scrollbar_overlay
 
     def _should_show_scrollbar(self) -> bool:
         """Whether the scrollbar should currently be shown."""
@@ -518,6 +536,11 @@ class _ScrollableBase(Widget):
     def scrollbar_style(self) -> ScrollbarStyle:
         """Return the immutable scrollbar visual style."""
         return self._scrollbar_style
+
+    @property
+    def scrollable_style(self) -> ScrollableStyle:
+        """Return the immutable placement style (viewport/scrollbar padding, overlay)."""
+        return self._scrollable_style
 
     def _apply_axis_sizing_defaults(self) -> None:
         """Ensure the scroll axis stretches to parent constraints by default."""

--- a/src/nuiitivet/material/date_picker.py
+++ b/src/nuiitivet/material/date_picker.py
@@ -26,7 +26,7 @@ from nuiitivet.layout.container import Container
 from nuiitivet.layout.row import Row
 from nuiitivet.layout.scrollable import VerticalScrollable
 from nuiitivet.layout.uniform_flow import UniformFlow
-from nuiitivet.scrolling import ScrollController, ScrollDirection
+from nuiitivet.scrolling import ScrollableStyle, ScrollController, ScrollDirection
 from nuiitivet.material.buttons import Button, IconButton
 from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL
 from nuiitivet.modifiers.transform import rotate
@@ -594,7 +594,7 @@ class _YearChipGrid(ComposableWidget):
             scrollbar_visible=False,
             width=int(style.container_width),
             height=self._list_height,
-            padding=(12, 15, 12, 4),
+            style=ScrollableStyle(viewport_padding=(12, 15, 12, 4)),
         )
 
 

--- a/src/nuiitivet/scrolling/__init__.py
+++ b/src/nuiitivet/scrolling/__init__.py
@@ -1,12 +1,14 @@
 """Scrolling domain primitives."""
 
 from .controller import ScrollAxisState, ScrollController
+from .scrollable_style import ScrollableStyle
 from .scrollbar_style import ScrollbarStyle
 from .types import ScrollDirection, ScrollPhysics
 
 __all__ = [
     "ScrollAxisState",
     "ScrollController",
+    "ScrollableStyle",
     "ScrollbarStyle",
     "ScrollDirection",
     "ScrollPhysics",

--- a/src/nuiitivet/scrolling/scrollable_style.py
+++ b/src/nuiitivet/scrolling/scrollable_style.py
@@ -1,0 +1,50 @@
+"""Scrollable placement style definitions.
+
+Lives in the framework-common ``scrolling`` package (not under ``material``):
+placement carries no design-system dependency.
+
+Separates *placement* (where the viewport and bar sit) from *appearance*
+(:class:`~nuiitivet.scrolling.ScrollbarStyle`, the bar's own look) and
+*temporal behavior* (:class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`,
+e.g. auto-hide). These are independent axes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from nuiitivet.rendering.padding import PaddingLike
+
+
+@dataclass(frozen=True)
+class ScrollableStyle:
+    """Immutable placement style for a ``Scrollable``.
+
+    Owns *where* the viewport and the scrollbar sit, independently of how the
+    bar looks (:class:`ScrollbarStyle`) or when it is shown
+    (:class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`).
+
+    Attributes:
+        viewport_padding: Inner padding of the viewport (scrolled area).
+            Accepts a single int or a padding tuple. Defaults to ``0``.
+        scrollbar_padding: Offset of the scrollbar from the viewport edge.
+            Accepts a single int or a padding tuple. Defaults to ``2``.
+        scrollbar_overlay: When ``True`` the bar is drawn on top of the content
+            without reserving space (overlay). When ``False`` a gutter is
+            reserved for the bar (inline). Defaults to ``True``.
+    """
+
+    viewport_padding: PaddingLike = 0
+    scrollbar_padding: PaddingLike = 2
+    scrollbar_overlay: bool = True
+
+    def copy_with(self, **changes) -> "ScrollableStyle":
+        """Return a copy of this style with the given fields overridden.
+
+        Args:
+            **changes: Fields to override.
+
+        Returns:
+            A new :class:`ScrollableStyle` with the specified changes applied.
+        """
+        return replace(self, **changes)

--- a/src/nuiitivet/scrolling/scrollbar_style.py
+++ b/src/nuiitivet/scrolling/scrollbar_style.py
@@ -9,28 +9,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 
-from nuiitivet.rendering.padding import PaddingLike
-
 
 @dataclass(frozen=True)
 class ScrollbarStyle:
     """Immutable visual style for the scrollbar of a ``Scrollable``.
 
-    Holds only static appearance/layout. Dynamic visibility is controlled by
-    the ``scrollbar_visible`` parameter of the scrollable widget, and
-    interaction behavior (auto-hide, track clicks, etc.) lives in
+    Holds only the bar's own appearance. Placement (viewport padding, offset
+    from the edge, overlay vs. inline) lives in
+    :class:`~nuiitivet.scrolling.ScrollableStyle`; dynamic visibility is
+    controlled by the ``scrollbar_visible`` parameter of the scrollable widget,
+    and interaction behavior (auto-hide, track clicks, etc.) lives in
     :class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
 
     Attributes:
         thickness: Scrollbar thickness in pixels. Defaults to ``8``.
         min_thumb_length: Minimum thumb length in pixels. Defaults to ``24``.
-        inset: Offset of the scrollbar from the viewport edge. Accepts a single
-            int or a padding tuple. Defaults to ``2``.
     """
 
     thickness: int = 8
     min_thumb_length: int = 24
-    inset: PaddingLike = 2
 
     def copy_with(self, **changes) -> "ScrollbarStyle":
         """Return a copy of this style with the given fields overridden.

--- a/src/nuiitivet/widgets/scrollbar.py
+++ b/src/nuiitivet/widgets/scrollbar.py
@@ -90,9 +90,12 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
         length: SizingLike = None,
         thickness: int = 8,
         min_thumb_length: int = 24,
-        padding: int | tuple | None = 0,
     ) -> None:
         """Initialize shared scrollbar state.
+
+        The bar knows only its own appearance; its placement (offset from the
+        viewport edge) is decided by the enclosing container. See
+        :class:`~nuiitivet.scrolling.ScrollableStyle`.
 
         Args:
             controller: The :class:`ScrollController` driving the scroll axis.
@@ -102,10 +105,9 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
                 ``width`` for horizontal scrollbars via the concrete subclass.
             thickness: Cross-axis thickness in pixels.
             min_thumb_length: Minimum thumb length in pixels.
-            padding: Inner padding (inset) of the scrollbar.
         """
         width, height = self._axis_sizing(length, thickness)
-        super().__init__(width=width, height=height, padding=padding)
+        super().__init__(width=width, height=height)
         beh = behavior or ScrollbarBehavior()
         self._controller = controller
         self._behavior = beh
@@ -430,24 +432,6 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
         return track_color, thumb_color
 
     # --- drawing ---
-    def draw_vertical(
-        self,
-        canvas,
-        x: int,
-        y: int,
-        width: int,
-        height: int,
-        vp_x: int,
-        vp_y: int,
-        vp_w: int,
-        vp_h: int,
-    ):
-        bar_x = x + width - self.thickness - self.padding[2]
-        bar_y = vp_y
-        bar_w = self.thickness
-        bar_h = vp_h
-        self.paint(canvas, bar_x, bar_y, bar_w, bar_h)
-
     def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
         content_extent = self._controller.axis_content_size(self.direction)
         viewport_extent = self._controller.axis_viewport_size(self.direction)

--- a/tests/layout/test_scrollable.py
+++ b/tests/layout/test_scrollable.py
@@ -9,7 +9,7 @@ from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 from nuiitivet.layout.scroll_viewport import ScrollViewport
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
-from nuiitivet.scrolling import ScrollbarStyle
+from nuiitivet.scrolling import ScrollableStyle, ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
 from nuiitivet.widgets.scrollbar import ScrollbarBehavior, _ScrollbarBase
 from tests.helpers.pointer import send_pointer_event_for_test
@@ -173,7 +173,7 @@ def test_scrollable_requires_child():
 def test_scrollable_preferred_size():
     """Scrollable preferred_size should include padding."""
     child = Column([Text("Item")])
-    scrollable = VerticalScrollable(child=child, padding=10)
+    scrollable = VerticalScrollable(child=child, style=ScrollableStyle(viewport_padding=10))
     child_w, child_h = child.preferred_size()
     scrollable_w, scrollable_h = scrollable.preferred_size()
     assert scrollable_w == child_w + 20
@@ -250,16 +250,20 @@ def test_scrollable_rejects_controller_without_required_axis():
         HorizontalScrollable(child=child, controller=controller)
 
 
-def test_scrollable_accepts_behavior_and_style():
-    """Scrollable should accept behavior + style configuration objects."""
+def test_scrollable_accepts_behavior_and_styles():
+    """Scrollable should accept behavior + appearance + placement config objects."""
     child = Column([Text("Item")])
     behavior = ScrollbarBehavior(auto_hide=False)
-    style = ScrollbarStyle(thickness=12, inset=4)
-    scrollable = VerticalScrollable(child=child, behavior=behavior, style=style)
+    scrollbar_style = ScrollbarStyle(thickness=12)
+    style = ScrollableStyle(scrollbar_padding=4)
+    scrollable = VerticalScrollable(
+        child=child, scrollbar_behavior=behavior, scrollbar_style=scrollbar_style, style=style
+    )
     assert scrollable.scrollbar_behavior is behavior
-    assert scrollable.scrollbar_style is style
+    assert scrollable.scrollbar_style is scrollbar_style
+    assert scrollable.scrollable_style is style
     assert scrollable._scrollbar.thickness == 12
-    assert scrollable._scrollbar.padding[2] == 4
+    assert scrollable._scrollbar_padding[2] == 4
 
 
 def test_scrollable_registers_children_in_store():

--- a/tests/layout/test_scrollable_interaction.py
+++ b/tests/layout/test_scrollable_interaction.py
@@ -15,7 +15,7 @@ from nuiitivet.scrolling import ScrollController
 from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.layout.scrollable import VerticalScrollable
 from nuiitivet.layout.column import Column
-from nuiitivet.scrolling import ScrollbarStyle
+from nuiitivet.scrolling import ScrollableStyle, ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
@@ -27,7 +27,8 @@ def _make_basic_scroller():
     scroller = VerticalScrollable(
         child=child,
         controller=controller,
-        style=ScrollbarStyle(thickness=20, inset=0),
+        scrollbar_style=ScrollbarStyle(thickness=20),
+        style=ScrollableStyle(scrollbar_padding=0),
     )
     scroller.layout(200, 200)
     scroller.set_last_rect(0, 0, 200, 200)

--- a/tests/layout/test_scrollable_interaction_extended.py
+++ b/tests/layout/test_scrollable_interaction_extended.py
@@ -8,7 +8,7 @@ from nuiitivet.scrolling import ScrollController
 from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.layout.scrollable import VerticalScrollable
 from nuiitivet.layout.column import Column
-from nuiitivet.scrolling import ScrollbarStyle
+from nuiitivet.scrolling import ScrollableStyle, ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
@@ -19,7 +19,8 @@ def _make_basic_scroller():
     scroller = VerticalScrollable(
         child=child,
         controller=controller,
-        style=ScrollbarStyle(thickness=20, inset=0),
+        scrollbar_style=ScrollbarStyle(thickness=20),
+        style=ScrollableStyle(scrollbar_padding=0),
     )
     scroller.layout(200, 200)
     scroller.set_last_rect(0, 0, 200, 200)

--- a/tests/layout/test_scrollable_scrollbar_modes.py
+++ b/tests/layout/test_scrollable_scrollbar_modes.py
@@ -1,107 +1,87 @@
-"""Tests for Scrollable scrollbar display modes (overlay vs reserve-always).
+"""Tests for Scrollable scrollbar placement modes (overlay vs inline).
 
-These confirm Phase 1 behaviour:
-- auto_hide=True -> overlay (do not reserve viewport space)
-- auto_hide=False -> reserve-always (always reserve scrollbar thickness)
+Placement is owned by ``ScrollableStyle.scrollbar_overlay`` and is fully
+decoupled from temporal behavior (``ScrollbarBehavior.auto_hide``):
+- scrollbar_overlay=True  -> overlay (do not reserve viewport space)
+- scrollbar_overlay=False -> inline (reserve scrollbar thickness + padding)
+
+All four combinations of overlay x auto_hide are exercised below.
 """
 
-from nuiitivet.scrolling import ScrollController
+import pytest
+
+from nuiitivet.scrolling import ScrollController, ScrollableStyle, ScrollbarStyle
 from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 from nuiitivet.layout.column import Column
-from nuiitivet.scrolling import ScrollbarStyle
+from nuiitivet.layout.row import Row
 from nuiitivet.widgets.text import TextBase as Text
 from nuiitivet.widgets.scrollbar import ScrollbarBehavior
 
 
-def test_scroller_overlay_when_auto_hide_true():
-    """When auto_hide=True (overlay), viewport area should NOT be reduced by scrollbar thickness."""
-    child = Column([Text(f"Item {i}") for i in range(50)])
-    controller = ScrollController()
-    scroller = VerticalScrollable(
-        child=child,
-        controller=controller,
-        behavior=ScrollbarBehavior(auto_hide=True),
-        style=ScrollbarStyle(thickness=12, inset=2),
-    )
+def _paint(scroller, width, height):
+    """Paint a scroller with skia/text side effects stubbed out."""
     from nuiitivet.widgets import scrollbar as sb_mod
-
-    orig_sb_get_skia = sb_mod.get_skia
-    sb_mod.get_skia = lambda raise_if_missing=False: None
     from nuiitivet.widgets import text as text_mod
 
+    orig_sb_get_skia = sb_mod.get_skia
     orig_text_paint = text_mod.TextBase.paint
+    sb_mod.get_skia = lambda raise_if_missing=False: None
     text_mod.TextBase.paint = lambda self, canvas, x, y, w, h: None
     try:
-        scroller.paint(canvas=None, x=0, y=0, width=200, height=150)
+        scroller.paint(canvas=None, x=0, y=0, width=width, height=height)
     finally:
         sb_mod.get_skia = orig_sb_get_skia
         text_mod.TextBase.paint = orig_text_paint
+
+
+@pytest.mark.parametrize("auto_hide", [True, False])
+def test_overlay_does_not_reserve_space(auto_hide):
+    """scrollbar_overlay=True -> viewport width is NOT reduced, for any auto_hide."""
+    child = Column([Text(f"Item {i}") for i in range(50)])
+    scroller = VerticalScrollable(
+        child=child,
+        controller=ScrollController(),
+        scrollbar_behavior=ScrollbarBehavior(auto_hide=auto_hide),
+        scrollbar_style=ScrollbarStyle(thickness=12),
+        style=ScrollableStyle(scrollbar_padding=2, scrollbar_overlay=True),
+    )
+    _paint(scroller, width=200, height=150)
     vp = scroller._viewport.viewport_rect
     assert vp is not None
     assert vp[2] == 200
 
 
-def test_scroller_reserve_always_when_auto_hide_false():
-    """When auto_hide=False (reserve-always), viewport area should be reduced by scrollbar thickness+padding."""
+@pytest.mark.parametrize("auto_hide", [True, False])
+def test_inline_reserves_space_vertical(auto_hide):
+    """scrollbar_overlay=False -> viewport width reduced by thickness+padding, for any auto_hide."""
     child = Column([Text(f"Item {i}") for i in range(50)])
-    controller = ScrollController()
-    cfg = ScrollbarBehavior(auto_hide=False)
     scroller = VerticalScrollable(
         child=child,
-        controller=controller,
-        behavior=cfg,
-        style=ScrollbarStyle(thickness=10, inset=3),
+        controller=ScrollController(),
+        scrollbar_behavior=ScrollbarBehavior(auto_hide=auto_hide),
+        scrollbar_style=ScrollbarStyle(thickness=10),
+        style=ScrollableStyle(scrollbar_padding=3, scrollbar_overlay=False),
     )
-    from nuiitivet.widgets import scrollbar as sb_mod
-
-    orig_sb_get_skia = sb_mod.get_skia
-    sb_mod.get_skia = lambda raise_if_missing=False: None
-    from nuiitivet.widgets import text as text_mod
-
-    orig_text_paint = text_mod.TextBase.paint
-    text_mod.TextBase.paint = lambda self, canvas, x, y, w, h: None
-    try:
-        scroller.paint(canvas=None, x=0, y=0, width=240, height=180)
-    finally:
-        sb_mod.get_skia = orig_sb_get_skia
-        text_mod.TextBase.paint = orig_text_paint
+    _paint(scroller, width=240, height=180)
     vp = scroller._viewport.viewport_rect
     assert vp is not None
-    sb = scroller._scrollbar
-    assert sb is not None
-    expected_w = max(0, 240 - sb.thickness - sb.padding[2])
+    expected_w = max(0, 240 - scroller._scrollbar.thickness - scroller._scrollbar_padding[2])
     assert vp[2] == expected_w
 
 
-def test_scroller_reserve_always_horizontal_reduces_height():
-    """For horizontal scrollers with auto_hide=False the viewport height
-    should be reduced by thickness + padding (reserve-always).
-    """
-    from nuiitivet.layout.row import Row
-
+@pytest.mark.parametrize("auto_hide", [True, False])
+def test_inline_reserves_space_horizontal(auto_hide):
+    """Horizontal inline mode reduces viewport height by thickness+padding, for any auto_hide."""
     cards = [Text(f"Card {i}") for i in range(20)]
-    cfg = ScrollbarBehavior(auto_hide=False)
     scroller = HorizontalScrollable(
         child=Row(cards, gap=4),
-        behavior=cfg,
+        scrollbar_behavior=ScrollbarBehavior(auto_hide=auto_hide),
         height=60,
-        style=ScrollbarStyle(thickness=10, inset=4),
+        scrollbar_style=ScrollbarStyle(thickness=10),
+        style=ScrollableStyle(scrollbar_padding=4, scrollbar_overlay=False),
     )
-    from nuiitivet.widgets import scrollbar as sb_mod
-    from nuiitivet.widgets import text as text_mod
-
-    orig_sb_get_skia = sb_mod.get_skia
-    sb_mod.get_skia = lambda raise_if_missing=False: None
-    orig_text_paint = text_mod.TextBase.paint
-    text_mod.TextBase.paint = lambda self, canvas, x, y, w, h: None
-    try:
-        scroller.paint(canvas=None, x=0, y=0, width=400, height=60)
-        vp = scroller._viewport.viewport_rect
-        assert vp is not None
-        sb = scroller._scrollbar
-        assert sb is not None
-        expected_h = max(0, 60 - sb.thickness - sb.padding[3])
-        assert vp[3] == expected_h
-    finally:
-        sb_mod.get_skia = orig_sb_get_skia
-        text_mod.TextBase.paint = orig_text_paint
+    _paint(scroller, width=400, height=60)
+    vp = scroller._viewport.viewport_rect
+    assert vp is not None
+    expected_h = max(0, 60 - scroller._scrollbar.thickness - scroller._scrollbar_padding[3])
+    assert vp[3] == expected_h

--- a/tests/layout/test_scrollable_viewport_hittest.py
+++ b/tests/layout/test_scrollable_viewport_hittest.py
@@ -2,6 +2,7 @@
 
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.scrollable import VerticalScrollable
+from nuiitivet.scrolling import ScrollableStyle
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -76,7 +77,7 @@ def test_viewport_hittest_respects_padding() -> None:
     """ScrollViewport with padding should only hit inside padded viewport."""
     widgets = [SimpleWidget() for _ in range(10)]
     col = Column(widgets, gap=5)
-    scroller = VerticalScrollable(col, height=100, padding=10)
+    scroller = VerticalScrollable(col, height=100, style=ScrollableStyle(viewport_padding=10))
     canvas = MockCanvas()
     scroller.paint(canvas, 50, 50, 200, 100)
     hit_inside = scroller.hit_test(99, 99)


### PR DESCRIPTION
## Summary
- Separate the scrollbar's three concerns into independent axes: **appearance**, **placement**, and **temporal behavior**
- Add `ScrollableStyle` (`viewport_padding` / `scrollbar_padding` / `scrollbar_overlay: bool`) owning placement
- Remove `ScrollbarStyle.inset`; the bar now carries appearance only (`thickness`, `min_thumb_length`)
- Decouple overlay vs. inline from `ScrollbarBehavior.auto_hide` — it now reads `ScrollableStyle.scrollbar_overlay`, so all four combinations (overlay/inline × always-visible/auto_hide) are expressible
- `Scrollbar` drops its `padding` argument; the container places the bar from `ScrollableStyle.scrollbar_padding`
- New `_ScrollableBase.__init__` signature: drop `padding`, rename `style` → `scrollbar_style`, rename `behavior` → `scrollbar_behavior`, add `style: ScrollableStyle`

> Includes breaking API changes, acceptable under the project's future-compatibility-first policy.

Closes #261

## Test plan
- [x] `ScrollableStyle` introduced and exported from `nuiitivet.scrolling`
- [x] `ScrollbarStyle.inset` removed and migrated to `ScrollableStyle.scrollbar_padding`
- [x] Overlay/inline decision driven by `scrollbar_overlay`, independent of `auto_hide`
- [x] All four overlay × auto_hide combinations covered (parametrized tests)
- [x] Affected tests, samples, and `date_picker` call site updated
- [x] Full suite green (1428 passed); mypy clean on changed modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)