### PR TITLE
feat(scrollbar)!: decouple Scrollbar from Material via generic theme seam (#255)

### DIFF
--- a/docs/guide/layout_overflow.md
+++ b/docs/guide/layout_overflow.md
@@ -92,6 +92,17 @@ The scroll axis is chosen by the class (`VerticalScrollable` /
 | `behavior` | Scrollbar interaction via `ScrollbarBehavior(auto_hide, …)` |
 | `controller` | A `ScrollController` carrying scroll `physics` and `scroll_multiplier` |
 
+The scrollbar is a **generic** widget, so its colors are not baked into the
+widget. Following the framework-wide `ThemeData` / `Style` split:
+
+- The **app-wide default palette** comes from the active theme's
+  `ScrollbarThemeData` (`track`, `thumb`, `thumb_hover`, `thumb_active`),
+  resolved at paint time. Each design system supplies its own — Material maps
+  them onto `ColorRole.ON_SURFACE` / `PRIMARY` — so a single scrollbar
+  automatically follows light/dark theme switches.
+- A **per-instance override** can be set via the matching nullable `ColorSpec`
+  fields on `ScrollbarStyle`; a `None` field falls back to the theme.
+
 ## Next Steps
 
 - Basic Spacing: [layout_spacing.md](layout_spacing.md)

--- a/scripts/debug/my_widget.py
+++ b/scripts/debug/my_widget.py
@@ -253,7 +253,7 @@ class MyWidget(ComposableWidget):
                                 gap=8,
                                 cross_alignment="center",
                             ),
-                            behavior=ScrollbarBehavior(auto_hide=False),
+                            scrollbar_behavior=ScrollbarBehavior(auto_hide=False),
                             height=50,
                         ),
                     ],

--- a/src/nuiitivet/layout/scrollable.py
+++ b/src/nuiitivet/layout/scrollable.py
@@ -140,8 +140,7 @@ class _ScrollableBase(Widget):
         self._scrollbar = self._scrollbar_class(
             self._controller,
             behavior=self._scrollbar_behavior,
-            thickness=self._scrollbar_style.thickness,
-            min_thumb_length=self._scrollbar_style.min_thumb_length,
+            style=self._scrollbar_style,
         )
         self.add_child(self._scrollbar)
 

--- a/src/nuiitivet/material/theme/material_theme.py
+++ b/src/nuiitivet/material/theme/material_theme.py
@@ -4,9 +4,25 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from nuiitivet.scrolling import ScrollbarThemeData
 from nuiitivet.theme.theme import Theme
+from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.theme_data import MaterialThemeData
 from nuiitivet.material.theme.palette import from_seed
+
+
+def _material_scrollbar_theme_data() -> ScrollbarThemeData:
+    """Default scrollbar palette mapped onto Material color roles.
+
+    Colors are stored as tokens (not resolved RGBA), so the same instance
+    resolves to the correct light/dark values against whichever theme is active.
+    """
+    return ScrollbarThemeData(
+        track=(ColorRole.ON_SURFACE, 0.12),
+        thumb=(ColorRole.ON_SURFACE, 0.70),
+        thumb_hover=(ColorRole.PRIMARY, 0.90),
+        thumb_active=(ColorRole.PRIMARY, 1.0),
+    )
 
 
 class MaterialThemeFactory:
@@ -19,7 +35,11 @@ class MaterialThemeFactory:
         roles = dark_roles if mode == "dark" else light_roles
 
         material_data = MaterialThemeData(roles=roles)
-        return Theme(mode=mode, extensions=[material_data], name=name)
+        return Theme(
+            mode=mode,
+            extensions=[material_data, _material_scrollbar_theme_data()],
+            name=name,
+        )
 
     @staticmethod
     def light(seed_color: str) -> Theme:

--- a/src/nuiitivet/scrolling/__init__.py
+++ b/src/nuiitivet/scrolling/__init__.py
@@ -2,6 +2,7 @@
 
 from .controller import ScrollAxisState, ScrollController
 from .scrollable_style import ScrollableStyle
+from .scrollbar_theme_data import ScrollbarThemeData
 from .scrollbar_style import ScrollbarStyle
 from .types import ScrollDirection, ScrollPhysics
 
@@ -10,6 +11,7 @@ __all__ = [
     "ScrollController",
     "ScrollableStyle",
     "ScrollbarStyle",
+    "ScrollbarThemeData",
     "ScrollDirection",
     "ScrollPhysics",
 ]

--- a/src/nuiitivet/scrolling/scrollbar_style.py
+++ b/src/nuiitivet/scrolling/scrollbar_style.py
@@ -8,26 +8,51 @@ dependency.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
+
+from nuiitivet.scrolling.scrollbar_theme_data import ScrollbarThemeData
+from nuiitivet.theme.types import ColorSpec
+
+if TYPE_CHECKING:
+    from nuiitivet.theme.theme import Theme
+
+Rgba = Tuple[int, int, int, int]
 
 
 @dataclass(frozen=True)
 class ScrollbarStyle:
     """Immutable visual style for the scrollbar of a ``Scrollable``.
 
-    Holds only the bar's own appearance. Placement (viewport padding, offset
-    from the edge, overlay vs. inline) lives in
-    :class:`~nuiitivet.scrolling.ScrollableStyle`; dynamic visibility is
-    controlled by the ``scrollbar_visible`` parameter of the scrollable widget,
-    and interaction behavior (auto-hide, track clicks, etc.) lives in
-    :class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
+    Holds the bar's own appearance: geometry plus optional per-instance color
+    overrides. Placement (viewport padding, offset from the edge, overlay vs.
+    inline) lives in :class:`~nuiitivet.scrolling.ScrollableStyle`; dynamic
+    visibility is controlled by the ``scrollbar_visible`` parameter of the
+    scrollable widget, and interaction behavior (auto-hide, track clicks, etc.)
+    lives in :class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
+
+    Colors follow the framework-wide ``ThemeData`` / ``Style`` division: the
+    app-wide default palette is supplied by the design system via
+    :class:`~nuiitivet.scrolling.ScrollbarThemeData`, and the nullable
+    ``ColorSpec`` fields here override it per instance. A ``None`` color falls
+    back to the theme. Use :meth:`resolve_colors` to obtain concrete RGBA values.
 
     Attributes:
         thickness: Scrollbar thickness in pixels. Defaults to ``8``.
         min_thumb_length: Minimum thumb length in pixels. Defaults to ``24``.
+        track: Per-instance override for the track color (``None`` → theme).
+        thumb: Per-instance override for the idle thumb color (``None`` → theme).
+        thumb_hover: Per-instance override for the hovered thumb color
+            (``None`` → theme).
+        thumb_active: Per-instance override for the pressed/dragging thumb color
+            (``None`` → theme).
     """
 
     thickness: int = 8
     min_thumb_length: int = 24
+    track: Optional[ColorSpec] = None
+    thumb: Optional[ColorSpec] = None
+    thumb_hover: Optional[ColorSpec] = None
+    thumb_active: Optional[ColorSpec] = None
 
     def copy_with(self, **changes) -> "ScrollbarStyle":
         """Return a copy of this style with the given fields overridden.
@@ -39,3 +64,38 @@ class ScrollbarStyle:
             A new :class:`ScrollbarStyle` with the specified changes applied.
         """
         return replace(self, **changes)
+
+    def resolve_colors(
+        self,
+        theme_data: Optional[ScrollbarThemeData] = None,
+        theme: "Theme | None" = None,
+    ) -> Dict[str, Rgba]:
+        """Resolve track/thumb colors to concrete RGBA values.
+
+        Per-instance overrides on this style win over ``theme_data``; any slot
+        left ``None`` falls back to ``theme_data`` (or, when no design system is
+        registered, the neutral :class:`ScrollbarThemeData` defaults). Tokens are
+        resolved against ``theme`` so a single palette renders correctly across
+        light and dark modes.
+
+        Args:
+            theme_data: App-wide default palette from the active theme.
+            theme: The active theme, used to resolve design-system tokens.
+
+        Returns:
+            A dict with ``track`` / ``thumb`` / ``thumb_hover`` / ``thumb_active``
+            RGBA tuples (ints 0-255).
+        """
+        from nuiitivet.theme.resolver import resolve_color_to_rgba
+
+        base = theme_data or ScrollbarThemeData()
+
+        def _pick(override: Optional[ColorSpec], default: ColorSpec) -> ColorSpec:
+            return override if override is not None else default
+
+        return {
+            "track": resolve_color_to_rgba(_pick(self.track, base.track), theme=theme),
+            "thumb": resolve_color_to_rgba(_pick(self.thumb, base.thumb), theme=theme),
+            "thumb_hover": resolve_color_to_rgba(_pick(self.thumb_hover, base.thumb_hover), theme=theme),
+            "thumb_active": resolve_color_to_rgba(_pick(self.thumb_active, base.thumb_active), theme=theme),
+        }

--- a/src/nuiitivet/scrolling/scrollbar_theme_data.py
+++ b/src/nuiitivet/scrolling/scrollbar_theme_data.py
@@ -1,0 +1,67 @@
+"""Scrollbar color theme data.
+
+Lives in the framework-common ``scrolling`` package (not under ``material``):
+the scrollbar is a generic widget, so its palette is supplied through the
+generic theme seam (:class:`~nuiitivet.theme.types.ThemeExtension`) rather than
+by reading Material color roles directly.
+
+Each design system registers a :class:`ScrollbarThemeData` into its
+:class:`~nuiitivet.theme.theme.Theme` (see ``material.theme`` and
+``theme.plain_theme``) with colors expressed as
+:data:`~nuiitivet.theme.types.ColorSpec` **tokens**. Because the colors are
+tokens — not baked RGBA — they are resolved at paint time against the *current*
+theme, so light/dark switching works automatically.
+
+Role split (mirrors the Material ``ThemeData`` / ``Style`` division):
+
+* **App-wide default palette** → :class:`ScrollbarThemeData` (this class),
+  supplied by the design system via the theme.
+* **Per-instance override** → nullable ``ColorSpec`` fields on
+  :class:`~nuiitivet.scrolling.ScrollbarStyle`.
+* **Shape** → :class:`~nuiitivet.scrolling.ScrollbarStyle` geometry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from nuiitivet.theme.types import ColorSpec
+
+
+@dataclass(frozen=True)
+class ScrollbarThemeData:
+    """App-wide themeable colors for the scrollbar, resolved at paint time.
+
+    Colors are :data:`~nuiitivet.theme.types.ColorSpec` values — literals or
+    design-system tokens (optionally paired with an alpha multiplier). Storing
+    tokens (rather than resolved RGBA) is what lets a single
+    ``ScrollbarThemeData`` render correctly across light and dark modes: the
+    token resolves against whichever :class:`~nuiitivet.theme.theme.Theme` is
+    active when the scrollbar paints.
+
+    The defaults are neutral, design-system-agnostic literals so that a bare
+    ``ScrollbarThemeData()`` is usable even when no design system is registered.
+
+    Attributes:
+        track: Color of the scrollbar track.
+        thumb: Color of the thumb when idle.
+        thumb_hover: Color of the thumb while hovered.
+        thumb_active: Color of the thumb while pressed / dragging.
+    """
+
+    track: ColorSpec = ("#000000", 0.12)
+    thumb: ColorSpec = ("#000000", 0.70)
+    thumb_hover: ColorSpec = ("#000000", 0.90)
+    thumb_active: ColorSpec = ("#000000", 1.0)
+
+    def copy_with(self, **changes: Any) -> "ScrollbarThemeData":
+        """Return a copy of this theme data with the given fields overridden.
+
+        Args:
+            **changes: Fields to override.
+
+        Returns:
+            A new :class:`ScrollbarThemeData` with the specified changes applied.
+        """
+        return replace(self, **changes)

--- a/src/nuiitivet/theme/plain_theme.py
+++ b/src/nuiitivet/theme/plain_theme.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from nuiitivet.scrolling.scrollbar_theme_data import ScrollbarThemeData
 from nuiitivet.theme.theme import Theme
 
 if TYPE_CHECKING:
@@ -57,6 +58,22 @@ class PlainColorRole(Enum):
         return None
 
 
+def _plain_scrollbar_theme_data() -> ScrollbarThemeData:
+    """Default scrollbar palette for the Plain design system.
+
+    The Plain theme has no accent color, so every slot maps onto
+    ``PlainColorRole.ON_SURFACE`` (with differing alpha) as tokens. Resolving at
+    paint time keeps the scrollbar in sync when switching between the light and
+    dark Plain themes.
+    """
+    return ScrollbarThemeData(
+        track=(PlainColorRole.ON_SURFACE, 0.12),
+        thumb=(PlainColorRole.ON_SURFACE, 0.70),
+        thumb_hover=(PlainColorRole.ON_SURFACE, 0.90),
+        thumb_active=(PlainColorRole.ON_SURFACE, 1.0),
+    )
+
+
 class PlainTheme:
     """Factory for creating Themes with Plain configuration."""
 
@@ -69,7 +86,11 @@ class PlainTheme:
             outline="#79747E",
             scrim="#000000",
         )
-        return Theme(mode="light", extensions=[data], name="plain-light")
+        return Theme(
+            mode="light",
+            extensions=[data, _plain_scrollbar_theme_data()],
+            name="plain-light",
+        )
 
     @staticmethod
     def dark() -> Theme:
@@ -80,4 +101,8 @@ class PlainTheme:
             outline="#938F99",
             scrim="#000000",
         )
-        return Theme(mode="dark", extensions=[data], name="plain-dark")
+        return Theme(
+            mode="dark",
+            extensions=[data, _plain_scrollbar_theme_data()],
+            name="plain-dark",
+        )

--- a/src/nuiitivet/widgets/scrollbar.py
+++ b/src/nuiitivet/widgets/scrollbar.py
@@ -8,9 +8,11 @@ Public API:
 Both share :class:`_ScrollbarBase`, which holds the axis-parameterized drawing
 and gesture logic. Per the size policy, only the **main axis** (scroll length)
 is a public dimension; the **cross axis** is the fixed ``thickness``. Colors are
-derived from the current Theme (``ColorRole.ON_SURFACE`` / ``ColorRole.PRIMARY``),
-and the widgets expose paint / event APIs so containers (like ``*Scrollable``)
-can delegate behavior.
+resolved at paint time from the generic theme seam via
+:class:`~nuiitivet.scrolling.ScrollbarThemeData` (no direct Material dependency),
+with per-instance overrides from :class:`~nuiitivet.scrolling.ScrollbarStyle`, and
+the widgets expose paint / event APIs so containers (like ``*Scrollable``) can
+delegate behavior.
 """
 
 from __future__ import annotations
@@ -23,12 +25,11 @@ from typing import ClassVar, Optional, Tuple
 
 from nuiitivet.animation import Animatable, LinearMotion
 from nuiitivet.input.pointer import PointerEvent
-from nuiitivet.scrolling import ScrollController, ScrollDirection
+from nuiitivet.scrolling import ScrollController, ScrollDirection, ScrollbarStyle, ScrollbarThemeData
 from nuiitivet.widgeting.widget import Widget
-from nuiitivet.colors.utils import hex_to_rgba
+from nuiitivet.colors.utils import apply_alpha_to_rgba
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.rendering.skia import draw_round_rect, get_skia, make_paint, make_rect, rgba_to_skia_color  # noqa: F401
-from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.widgets.interaction import (
     DraggableNode,
@@ -88,8 +89,7 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
         behavior: Optional[ScrollbarBehavior] = None,
         *,
         length: SizingLike = None,
-        thickness: int = 8,
-        min_thumb_length: int = 24,
+        style: Optional[ScrollbarStyle] = None,
     ) -> None:
         """Initialize shared scrollbar state.
 
@@ -103,17 +103,19 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
             length: Main-axis length sizing override (cross axis is
                 ``thickness``). Maps to ``height`` for vertical scrollbars and
                 ``width`` for horizontal scrollbars via the concrete subclass.
-            thickness: Cross-axis thickness in pixels.
-            min_thumb_length: Minimum thumb length in pixels.
+            style: Scrollbar appearance (geometry + optional per-instance color
+                overrides). See :class:`~nuiitivet.scrolling.ScrollbarStyle`.
         """
-        width, height = self._axis_sizing(length, thickness)
+        st = style or ScrollbarStyle()
+        width, height = self._axis_sizing(length, st.thickness)
         super().__init__(width=width, height=height)
         beh = behavior or ScrollbarBehavior()
         self._controller = controller
         self._behavior = beh
+        self._style = st
         self.direction = self._direction
-        self.thickness = int(thickness)
-        self.min_thumb_length = int(min_thumb_length)
+        self.thickness = int(st.thickness)
+        self.min_thumb_length = int(st.min_thumb_length)
         self.interactive = bool(beh.interactive)
         self.track_click_behavior = beh.track_click_behavior
         self.auto_hide = bool(beh.auto_hide)
@@ -415,22 +417,6 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
             exception_once(logger, "scrollbar_hide_timer_cancel_exc", "Hide timer cancel raised")
         self._hide_timer = None
 
-    def _derive_colors(self, _unused=None):
-        try:
-            from nuiitivet.theme.theme import Theme
-
-            theme = Theme.of(self)
-            base = theme.get(ColorRole.ON_SURFACE)
-        except Exception:
-            base = "#000000"
-
-        tr = hex_to_rgba(base, alpha=0.12)
-        th = hex_to_rgba(base, alpha=0.70)
-
-        track_color = rgba_to_skia_color(tr)
-        thumb_color = rgba_to_skia_color(th)
-        return track_color, thumb_color
-
     # --- drawing ---
     def paint(self, canvas, x: int, y: int, width: int, height: int) -> None:
         content_extent = self._controller.axis_content_size(self.direction)
@@ -445,19 +431,17 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
         try:
             from nuiitivet.theme.theme import Theme
 
-            theme = Theme.of(self)
-            from nuiitivet.material.theme.theme_data import MaterialThemeData
-
-            mat = theme.extension(MaterialThemeData)
-            roles = mat.roles if mat is not None else {}
-            on_surface = roles.get(ColorRole.ON_SURFACE, "#000000")
-            primary = roles.get(ColorRole.PRIMARY, "#000000")
+            theme: Optional[Theme] = Theme.of(self)
         except Exception:
-            on_surface = "#000000"
-            primary = "#000000"
+            theme = None
 
-        tr = hex_to_rgba(on_surface, alpha=0.12)
-        track_color = rgba_to_skia_color(tr)
+        theme_data: Optional[ScrollbarThemeData] = None
+        if theme is not None:
+            try:
+                theme_data = theme.extension(ScrollbarThemeData)
+            except Exception:
+                theme_data = None
+
         progress = 1.0 if not self.auto_hide else float(self._visibility.value)
 
         try:
@@ -472,20 +456,20 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
             self.set_last_rect(bar_x, bar_y, bar_w, bar_h)
             return
 
+        # Colors are resolved at paint time against the current theme so a single
+        # palette renders correctly across light/dark modes; per-instance style
+        # overrides win over the theme. Auto-hide visibility is applied as an
+        # extra alpha multiplier on top.
+        colors = self._style.resolve_colors(theme_data, theme)
         if self._pressed or self._dragging:
-            thumb_base = primary
-            thumb_alpha = 1.0
+            thumb_rgba = colors["thumb_active"]
         elif self._thumb_hover:
-            thumb_base = primary
-            thumb_alpha = 0.9
+            thumb_rgba = colors["thumb_hover"]
         else:
-            thumb_base = on_surface
-            thumb_alpha = 0.7
-        effective_alpha = thumb_alpha * vis_progress
-        th = hex_to_rgba(thumb_base, alpha=effective_alpha)
-        thumb_color = rgba_to_skia_color(th)
-        tr_vis = hex_to_rgba(on_surface, alpha=0.12 * vis_progress)
-        track_color = rgba_to_skia_color(tr_vis)
+            thumb_rgba = colors["thumb"]
+
+        thumb_color = rgba_to_skia_color(apply_alpha_to_rgba(thumb_rgba, vis_progress))
+        track_color = rgba_to_skia_color(apply_alpha_to_rgba(colors["track"], vis_progress))
         track_paint = make_paint(color=track_color, style="fill", aa=True)
         corner_radius = (bar_w / 2) if self.direction is ScrollDirection.VERTICAL else (bar_h / 2)
         track_rect = make_rect(bar_x, bar_y, bar_w, bar_h)

--- a/tests/widgets/test_scrollbar_theme.py
+++ b/tests/widgets/test_scrollbar_theme.py
@@ -1,0 +1,121 @@
+"""Tests for generic scrollbar theming via the theme seam (issue #255).
+
+The scrollbar is a generic widget: it must not depend on ``material`` and must
+resolve its colors from :class:`~nuiitivet.scrolling.ScrollbarThemeData` at paint
+time so a single theme renders correctly across light and dark modes. Per the
+framework-wide ``ThemeData`` / ``Style`` split, per-instance overrides live on
+:class:`~nuiitivet.scrolling.ScrollbarStyle` and win over the theme default.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from nuiitivet.material.theme.material_theme import MaterialThemeFactory
+from nuiitivet.scrolling import ScrollbarStyle, ScrollbarThemeData
+from nuiitivet.theme.plain_theme import PlainTheme
+from nuiitivet.theme.resolver import resolve_color_to_rgba
+
+
+def test_scrollbar_widget_does_not_import_material_layer() -> None:
+    """``widgets/scrollbar.py`` must not depend on ``nuiitivet.material``."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    scrollbar_file = repo_root / "src" / "nuiitivet" / "widgets" / "scrollbar.py"
+
+    tree = ast.parse(scrollbar_file.read_text(encoding="utf-8"), filename=str(scrollbar_file))
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "nuiitivet.material" or alias.name.startswith("nuiitivet.material."):
+                    violations.append(f"{node.lineno} imports {alias.name}")
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "nuiitivet.material" or module.startswith("nuiitivet.material."):
+                violations.append(f"{node.lineno} imports from {module}")
+
+    assert violations == []
+
+
+def test_bare_theme_data_has_neutral_defaults() -> None:
+    """A bare ``ScrollbarThemeData()`` resolves without any registered theme."""
+
+    theme_data = ScrollbarThemeData()
+    assert resolve_color_to_rgba(theme_data.track, theme=None) == (0, 0, 0, 30)
+    assert resolve_color_to_rgba(theme_data.thumb, theme=None) == (0, 0, 0, 178)
+
+
+def test_plain_theme_scrollbar_follows_light_dark_mode() -> None:
+    """Plain themes carry a ScrollbarThemeData whose thumb flips with the mode."""
+
+    light = PlainTheme.light()
+    dark = PlainTheme.dark()
+
+    st_light = light.extension(ScrollbarThemeData)
+    st_dark = dark.extension(ScrollbarThemeData)
+    assert st_light is not None and st_dark is not None
+
+    light_thumb = resolve_color_to_rgba(st_light.thumb, theme=light)
+    dark_thumb = resolve_color_to_rgba(st_dark.thumb, theme=dark)
+
+    # on_surface is black in light, white in dark; alpha stays the same.
+    assert light_thumb[:3] == (0, 0, 0)
+    assert dark_thumb[:3] == (255, 255, 255)
+    assert light_thumb[3] == dark_thumb[3]
+
+
+def test_material_theme_scrollbar_follows_light_dark_mode() -> None:
+    """Material themes register a token-based ScrollbarThemeData for both modes."""
+
+    light = MaterialThemeFactory.light("#6750A4")
+    dark = MaterialThemeFactory.dark("#6750A4")
+
+    st_light = light.extension(ScrollbarThemeData)
+    st_dark = dark.extension(ScrollbarThemeData)
+    assert st_light is not None and st_dark is not None
+
+    # The same token instance resolves to different RGB per mode.
+    assert resolve_color_to_rgba(st_light.thumb, theme=light) != resolve_color_to_rgba(
+        st_dark.thumb, theme=dark
+    )
+    # Active (pressed/drag) maps onto the PRIMARY accent — fully opaque.
+    assert resolve_color_to_rgba(st_light.thumb_active, theme=light)[3] == 255
+    assert resolve_color_to_rgba(st_dark.thumb_active, theme=dark)[3] == 255
+
+
+def test_style_resolve_colors_falls_back_to_theme_data() -> None:
+    """With no per-instance overrides, ScrollbarStyle uses the theme palette."""
+
+    light = PlainTheme.light()
+    theme_data = light.extension(ScrollbarThemeData)
+    style = ScrollbarStyle()  # no color overrides
+
+    resolved = style.resolve_colors(theme_data, theme=light)
+    # Plain light on_surface is black; idle thumb alpha 0.70 -> 178.
+    assert resolved["thumb"] == (0, 0, 0, 178)
+    assert resolved["track"] == (0, 0, 0, 30)
+
+
+def test_style_override_wins_over_theme_data() -> None:
+    """A per-instance ColorSpec on ScrollbarStyle overrides the theme palette."""
+
+    light = PlainTheme.light()
+    theme_data = light.extension(ScrollbarThemeData)
+    style = ScrollbarStyle(thumb=(255, 0, 0, 255), track=("#00FF00", 0.5))
+
+    resolved = style.resolve_colors(theme_data, theme=light)
+    assert resolved["thumb"] == (255, 0, 0, 255)
+    assert resolved["track"] == (0, 255, 0, 127)
+    # Un-overridden slots still come from the theme.
+    assert resolved["thumb_active"] == resolve_color_to_rgba(theme_data.thumb_active, theme=light)
+
+
+def test_style_resolve_colors_without_theme_data_uses_neutral_defaults() -> None:
+    """resolve_colors works even when no ScrollbarThemeData is registered."""
+
+    resolved = ScrollbarStyle().resolve_colors(None, theme=None)
+    assert resolved["track"] == (0, 0, 0, 30)
+    assert resolved["thumb"] == (0, 0, 0, 178)

--- a/tests/widgets/test_scrollbar_theme.py
+++ b/tests/widgets/test_scrollbar_theme.py
@@ -104,6 +104,7 @@ def test_style_override_wins_over_theme_data() -> None:
 
     light = PlainTheme.light()
     theme_data = light.extension(ScrollbarThemeData)
+    assert theme_data is not None
     style = ScrollbarStyle(thumb=(255, 0, 0, 255), track=("#00FF00", 0.5))
 
     resolved = style.resolve_colors(theme_data, theme=light)


### PR DESCRIPTION
## Summary
- Remove the last generic→Material dependency: `widgets/scrollbar.py` no longer imports `ColorRole` / `MaterialThemeData`, so the whole scroll stack stays Material-free. Closes #255.
- Add `ScrollbarThemeData` (a `ThemeExtension` in `scrolling/`) as the app-wide default palette (`track` / `thumb` / `thumb_hover` / `thumb_active`). Design systems register it as `ColorSpec` **tokens** (Material → `ON_SURFACE`/`PRIMARY`, Plain → `ON_SURFACE`), resolved at paint time so one palette follows light/dark.
- Follow the framework-wide **ThemeData / Style** split: `ScrollbarStyle` gains nullable `ColorSpec` override fields + `resolve_colors(theme_data, theme)` (mirroring `ButtonStyle.resolve_colors`); per-instance overrides win, `None` falls back to the theme.
- `*Scrollbar` now takes a `ScrollbarStyle` instead of `thickness`/`min_thumb_length`.
- `ScrollbarBehavior` relocation is tracked separately in #264.

## BREAKING CHANGE
`_ScrollbarBase` / `VerticalScrollbar` / `HorizontalScrollbar` take `style: ScrollbarStyle` instead of `thickness` / `min_thumb_length` kwargs.

## Test plan
- [x] `pytest` full suite — 1435 passed
- [x] `mypy` on changed files — clean
- [x] Light/dark switching resolves per-mode (Material & Plain)
- [x] Per-instance `ScrollbarStyle` color override wins over theme; `None` falls back
- [x] Guardrail test: `widgets/scrollbar.py` has no `nuiitivet.material` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)