### PR TITLE
refactor(scrollbar)!: move ScrollbarBehavior into scrolling/

### DIFF
--- a/src/nuiitivet/layout/scrollable.py
+++ b/src/nuiitivet/layout/scrollable.py
@@ -12,7 +12,7 @@ Three independent concerns configure the scrollbar: appearance via
 :class:`~nuiitivet.scrolling.ScrollbarStyle`, placement (viewport padding, bar
 offset, overlay vs. inline) via :class:`~nuiitivet.scrolling.ScrollableStyle`,
 and temporal interaction via
-:class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
+:class:`~nuiitivet.scrolling.ScrollbarBehavior`.
 """
 
 from __future__ import annotations
@@ -24,13 +24,19 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
 
 from ..widgeting.widget import Widget
-from ..scrolling import ScrollableStyle, ScrollController, ScrollDirection, ScrollPhysics, ScrollbarStyle
+from ..scrolling import (
+    ScrollableStyle,
+    ScrollbarBehavior,
+    ScrollController,
+    ScrollDirection,
+    ScrollPhysics,
+    ScrollbarStyle,
+)
 from ..rendering.padding import parse_padding
 from ..rendering.sizing import Sizing, SizingLike
 from ..input.pointer import PointerEvent, PointerEventType
 from ..widgets.scrollbar import (
     HorizontalScrollbar,
-    ScrollbarBehavior,
     VerticalScrollbar,
     _ScrollbarBase,
 )

--- a/src/nuiitivet/scrolling/__init__.py
+++ b/src/nuiitivet/scrolling/__init__.py
@@ -2,6 +2,7 @@
 
 from .controller import ScrollAxisState, ScrollController
 from .scrollable_style import ScrollableStyle
+from .scrollbar_behavior import ScrollbarBehavior
 from .scrollbar_theme_data import ScrollbarThemeData
 from .scrollbar_style import ScrollbarStyle
 from .types import ScrollDirection, ScrollPhysics
@@ -10,6 +11,7 @@ __all__ = [
     "ScrollAxisState",
     "ScrollController",
     "ScrollableStyle",
+    "ScrollbarBehavior",
     "ScrollbarStyle",
     "ScrollbarThemeData",
     "ScrollDirection",

--- a/src/nuiitivet/scrolling/scrollable_style.py
+++ b/src/nuiitivet/scrolling/scrollable_style.py
@@ -5,7 +5,7 @@ placement carries no design-system dependency.
 
 Separates *placement* (where the viewport and bar sit) from *appearance*
 (:class:`~nuiitivet.scrolling.ScrollbarStyle`, the bar's own look) and
-*temporal behavior* (:class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`,
+*temporal behavior* (:class:`~nuiitivet.scrolling.ScrollbarBehavior`,
 e.g. auto-hide). These are independent axes.
 """
 
@@ -22,7 +22,7 @@ class ScrollableStyle:
 
     Owns *where* the viewport and the scrollbar sit, independently of how the
     bar looks (:class:`ScrollbarStyle`) or when it is shown
-    (:class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`).
+    (:class:`~nuiitivet.scrolling.ScrollbarBehavior`).
 
     Attributes:
         viewport_padding: Inner padding of the viewport (scrolled area).

--- a/src/nuiitivet/scrolling/scrollbar_behavior.py
+++ b/src/nuiitivet/scrolling/scrollbar_behavior.py
@@ -1,0 +1,41 @@
+"""Scrollbar behavior definitions.
+
+Lives in the framework-common ``scrolling`` package alongside the other
+scrollbar config types (``ScrollbarStyle`` for geometry, ``ScrollbarThemeData``
+for colors). This one carries the interaction/temporal config and, like its
+siblings, has no design-system dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Optional
+
+from nuiitivet.common.logging_once import exception_once
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ScrollbarBehavior:
+    """Immutable behavior configuration for scrollbar widgets."""
+
+    auto_hide: bool = True
+    hide_delay: float = 1.0
+    fade_duration: float = 0.15
+    hide_threshold: float = 0.25
+    track_click_behavior: str = "jump"
+    interactive: bool = True
+    hit_slop: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "hide_delay", max(0.0, float(self.hide_delay)))
+        object.__setattr__(self, "fade_duration", max(0.0, float(self.fade_duration)))
+        object.__setattr__(self, "hide_threshold", max(0.0, min(1.0, float(self.hide_threshold))))
+        try:
+            if self.track_click_behavior not in ("none", "page", "jump"):
+                object.__setattr__(self, "track_click_behavior", "none")
+        except Exception:
+            exception_once(logger, "scrollbar_behavior_post_init_exc", "ScrollbarBehavior.__post_init__ failed")
+            object.__setattr__(self, "track_click_behavior", "none")

--- a/src/nuiitivet/scrolling/scrollbar_style.py
+++ b/src/nuiitivet/scrolling/scrollbar_style.py
@@ -28,7 +28,7 @@ class ScrollbarStyle:
     inline) lives in :class:`~nuiitivet.scrolling.ScrollableStyle`; dynamic
     visibility is controlled by the ``scrollbar_visible`` parameter of the
     scrollable widget, and interaction behavior (auto-hide, track clicks, etc.)
-    lives in :class:`~nuiitivet.widgets.scrollbar.ScrollbarBehavior`.
+    lives in :class:`~nuiitivet.scrolling.ScrollbarBehavior`.
 
     Colors follow the framework-wide ``ThemeData`` / ``Style`` division: the
     app-wide default palette is supplied by the design system via

--- a/src/nuiitivet/widgets/scrollbar.py
+++ b/src/nuiitivet/widgets/scrollbar.py
@@ -17,7 +17,6 @@ delegate behavior.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 import threading
 import time
@@ -25,7 +24,7 @@ from typing import ClassVar, Optional, Tuple
 
 from nuiitivet.animation import Animatable, LinearMotion
 from nuiitivet.input.pointer import PointerEvent
-from nuiitivet.scrolling import ScrollController, ScrollDirection, ScrollbarStyle, ScrollbarThemeData
+from nuiitivet.scrolling import ScrollbarBehavior, ScrollController, ScrollDirection, ScrollbarStyle, ScrollbarThemeData
 from nuiitivet.widgeting.widget import Widget
 from nuiitivet.colors.utils import apply_alpha_to_rgba
 from nuiitivet.rendering.sizing import SizingLike
@@ -39,30 +38,6 @@ from nuiitivet.widgets.interaction import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class ScrollbarBehavior:
-    """Immutable behavior configuration for scrollbar widgets."""
-
-    auto_hide: bool = True
-    hide_delay: float = 1.0
-    fade_duration: float = 0.15
-    hide_threshold: float = 0.25
-    track_click_behavior: str = "jump"
-    interactive: bool = True
-    hit_slop: Optional[int] = None
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "hide_delay", max(0.0, float(self.hide_delay)))
-        object.__setattr__(self, "fade_duration", max(0.0, float(self.fade_duration)))
-        object.__setattr__(self, "hide_threshold", max(0.0, min(1.0, float(self.hide_threshold))))
-        try:
-            if self.track_click_behavior not in ("none", "page", "jump"):
-                object.__setattr__(self, "track_click_behavior", "none")
-        except Exception:
-            exception_once(logger, "scrollbar_behavior_post_init_exc", "ScrollbarBehavior.__post_init__ failed")
-            object.__setattr__(self, "track_click_behavior", "none")
 
 
 class _ScrollbarBase(InteractionHostMixin, Widget):
@@ -592,4 +567,4 @@ class HorizontalScrollbar(_ScrollbarBase):
         return (length, int(thickness))
 
 
-__all__ = ["VerticalScrollbar", "HorizontalScrollbar", "ScrollbarBehavior"]
+__all__ = ["VerticalScrollbar", "HorizontalScrollbar"]

--- a/tests/layout/test_scrollable.py
+++ b/tests/layout/test_scrollable.py
@@ -9,9 +9,9 @@ from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 from nuiitivet.layout.scroll_viewport import ScrollViewport
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
-from nuiitivet.scrolling import ScrollableStyle, ScrollbarStyle
+from nuiitivet.scrolling import ScrollableStyle, ScrollbarBehavior, ScrollbarStyle
 from nuiitivet.widgets.text import TextBase as Text
-from nuiitivet.widgets.scrollbar import ScrollbarBehavior, _ScrollbarBase
+from nuiitivet.widgets.scrollbar import _ScrollbarBase
 from tests.helpers.pointer import send_pointer_event_for_test
 
 

--- a/tests/layout/test_scrollable_scrollbar_modes.py
+++ b/tests/layout/test_scrollable_scrollbar_modes.py
@@ -10,12 +10,11 @@ All four combinations of overlay x auto_hide are exercised below.
 
 import pytest
 
-from nuiitivet.scrolling import ScrollController, ScrollableStyle, ScrollbarStyle
+from nuiitivet.scrolling import ScrollbarBehavior, ScrollController, ScrollableStyle, ScrollbarStyle
 from nuiitivet.layout.scrollable import VerticalScrollable, HorizontalScrollable
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.widgets.text import TextBase as Text
-from nuiitivet.widgets.scrollbar import ScrollbarBehavior
 
 
 def _paint(scroller, width, height):

--- a/tests/widgets/test_scrollbar.py
+++ b/tests/widgets/test_scrollbar.py
@@ -1,9 +1,9 @@
 """Unit tests for the standalone Scrollbar widget."""
 
 from __future__ import annotations
-from nuiitivet.scrolling import ScrollController, ScrollDirection
+from nuiitivet.scrolling import ScrollbarBehavior, ScrollController, ScrollDirection
 from nuiitivet.input.pointer import PointerEventType
-from nuiitivet.widgets.scrollbar import HorizontalScrollbar, ScrollbarBehavior, VerticalScrollbar
+from nuiitivet.widgets.scrollbar import HorizontalScrollbar, VerticalScrollbar
 from tests.helpers.pointer import send_pointer_event_for_test
 
 


### PR DESCRIPTION
## Summary
- Move `ScrollbarBehavior` from `widgets/scrollbar.py` to new `scrolling/scrollbar_behavior.py`, so all scrollbar config (`ScrollbarStyle` geometry, `ScrollbarThemeData` colors, `ScrollbarBehavior` interaction) lives under `scrolling/`
- Re-export `ScrollbarBehavior` from `scrolling/__init__.py`; the widget module now holds only the widget
- Update importers (`layout/scrollable.py`) and docstring cross-references in `scrollable_style.py` / `scrollbar_style.py`
- Update test imports

**BREAKING CHANGE**: import path changes from `nuiitivet.widgets.scrollbar.ScrollbarBehavior` to `nuiitivet.scrolling.ScrollbarBehavior`.

Closes #264

## Test plan
- [x] `pytest tests/` — 1435 passed
- [x] `mypy` on affected source files — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)