### PR TITLE
fix(scrollbar): center track-click jump and continue as drag

### DIFF
--- a/src/nuiitivet/widgets/scrollbar.py
+++ b/src/nuiitivet/widgets/scrollbar.py
@@ -265,18 +265,22 @@ class _ScrollbarBase(InteractionHostMixin, Widget):
             self._on_interaction()
             return
 
-        # Jump behavior
+        # Jump behavior: center the thumb on the click position.
         if track_length <= 0:
             return
         max_offset = self._controller.axis_max_extent(self.direction)
         thumb_len = max(self.min_thumb_length, int((thumb_length) or (track_length * 0.1)))
-        rel = float(click_axis - axis_origin) / float(max(1, track_length))
-        rel = max(0.0, min(1.0, rel))
-        thumb_pos = int((track_length - thumb_len) * rel)
+        # Place the thumb so its center sits under the pointer, then clamp its
+        # start into the valid track range before deriving the scroll ratio.
+        thumb_pos = int((click_axis - axis_origin) - thumb_len / 2)
+        thumb_pos = max(0, min(track_length - thumb_len, thumb_pos))
         denom = max(1, track_length - thumb_len)
         scroll_ratio = float(thumb_pos) / float(denom) if denom > 0 else 0.0
         target_offset = scroll_ratio * max_offset
         self._controller.scroll_to(target_offset, axis=self.direction)
+        # Continue the press as a thumb drag so the user can keep dragging from
+        # the jumped position, matching a press that starts on the thumb.
+        self._thumb_node.activate(event)
         self._on_interaction()
 
     def _on_track_hover_change(self, hovered: bool) -> None:

--- a/tests/widgets/test_scrollbar.py
+++ b/tests/widgets/test_scrollbar.py
@@ -146,6 +146,58 @@ def test_track_click_behavior_jump_vertical() -> None:
     assert abs(controller.get_offset() - expected) < 50.0
 
 
+def test_track_click_jump_centers_thumb_on_click_vertical() -> None:
+    controller = ScrollController()
+    controller._update_metrics(max_extent=400.0, viewport_size=100, content_size=500)
+    behavior = ScrollbarBehavior(auto_hide=False, track_click_behavior="jump")
+    scrollbar = VerticalScrollbar(controller, behavior=behavior)
+    track_len = 200
+    thumb_len = 40
+    scrollbar.bar_rect = (0, 0, scrollbar.thickness, track_len)
+    scrollbar.thumb_rect = (0, 0, scrollbar.thickness, thumb_len)
+    click_y = 100
+    assert send_pointer_event_for_test(scrollbar, PointerEventType.PRESS, 2, click_y) is True
+    max_offset = controller.axis_max_extent(ScrollDirection.VERTICAL)
+    scroll_ratio = controller.get_offset() / max_offset
+    thumb_center = (track_len - thumb_len) * scroll_ratio + thumb_len / 2
+    assert abs(thumb_center - click_y) <= 1.0
+
+
+def test_track_click_jump_centers_thumb_on_click_horizontal() -> None:
+    controller = ScrollController(axes=(ScrollDirection.HORIZONTAL,), primary_axis=ScrollDirection.HORIZONTAL)
+    controller._update_metrics(max_extent=400.0, viewport_size=100, content_size=500)
+    behavior = ScrollbarBehavior(auto_hide=False, track_click_behavior="jump")
+    scrollbar = HorizontalScrollbar(controller, behavior=behavior)
+    track_len = 200
+    thumb_len = 40
+    scrollbar.bar_rect = (0, 0, track_len, scrollbar.thickness)
+    scrollbar.thumb_rect = (0, 0, thumb_len, scrollbar.thickness)
+    click_x = 120
+    assert send_pointer_event_for_test(scrollbar, PointerEventType.PRESS, click_x, 2) is True
+    max_offset = controller.axis_max_extent(ScrollDirection.HORIZONTAL)
+    scroll_ratio = controller.get_offset(axis=ScrollDirection.HORIZONTAL) / max_offset
+    thumb_center = (track_len - thumb_len) * scroll_ratio + thumb_len / 2
+    assert abs(thumb_center - click_x) <= 1.0
+
+
+def test_track_click_jump_starts_drag() -> None:
+    controller = ScrollController()
+    controller._update_metrics(max_extent=400.0, viewport_size=100, content_size=500)
+    behavior = ScrollbarBehavior(auto_hide=False, track_click_behavior="jump")
+    scrollbar = VerticalScrollbar(controller, behavior=behavior)
+    scrollbar.bar_rect = (0, 0, scrollbar.thickness, 200)
+    scrollbar.thumb_rect = (0, 0, scrollbar.thickness, 40)
+    # Press on empty track (not on the thumb) should jump AND begin a drag.
+    assert send_pointer_event_for_test(scrollbar, PointerEventType.PRESS, 2, 100) is True
+    assert scrollbar._dragging is True
+    after_jump = controller.get_offset()
+    # Continuing to move the pointer should keep scrolling as a drag.
+    assert send_pointer_event_for_test(scrollbar, PointerEventType.MOVE, 2, 140) is True
+    assert controller.get_offset() > after_jump
+    assert send_pointer_event_for_test(scrollbar, PointerEventType.RELEASE, 2, 140) is True
+    assert scrollbar._dragging is False
+
+
 def test_scrollbar_release_clears_hover_after_drag() -> None:
     controller = ScrollController()
     controller._update_metrics(max_extent=300.0, viewport_size=150, content_size=450)


### PR DESCRIPTION
## Summary
- Track click (`track_click_behavior="jump"`) now hands the press off to the thumb `DraggableNode` via `activate()`, so a jump continues as a drag — matching a press that starts on the thumb.
- The jump now centers the thumb on the click position (clamped into the valid track range) instead of mapping the click proportionally onto the thumb's start, fixing the off-center offset (slightly up for vertical, slightly left for horizontal).

Closes #268

## Test plan
- [x] `pytest tests/widgets/test_scrollbar.py` (12 passed)
- [x] Added `test_track_click_jump_centers_thumb_on_click_vertical` / `_horizontal` — thumb center aligns with click
- [x] Added `test_track_click_jump_starts_drag` — press on empty track jumps then keeps scrolling on move
- [x] `pytest` scrollbar/scrollable suites (25 passed), `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)