### PR TITLE
docs(layout): document dynamic children generation (builder/ForEach)

### DIFF
--- a/docs/guide/layout.md
+++ b/docs/guide/layout.md
@@ -43,6 +43,7 @@ Refer to the following guides based on what you want to create.
 | Create wrapping lists (Tag lists, etc.) | [layout_extras.md](layout_extras.md) | `Flow` |
 | Make scrollable | [layout_overflow.md](layout_overflow.md) | `VerticalScrollable` / `HorizontalScrollable` |
 | Create tab switching | [layout_extras.md](layout_extras.md) | `Deck` |
+| Dynamically generate a list from data | [layout_dynamic.md](layout_dynamic.md) | `builder()` / `ForEach` |
 
 ## More Details
 

--- a/docs/guide/layout_dynamic.md
+++ b/docs/guide/layout_dynamic.md
@@ -1,0 +1,142 @@
+---
+layout: default
+---
+
+# Dynamically Generating a List from Data
+
+Screens often need to render a collection of items — tags, cards, list rows —
+whose contents come from data rather than being written out one by one.
+NuiiTivet offers three ways to do this, from the simplest static form to a
+fully reactive one.
+
+## Static: List Comprehension
+
+When the data is fixed at build time, a plain Python list comprehension is all
+you need. Each item is turned into a widget inline:
+
+```python
+import nuiitivet as nv
+import nuiitivet.material as md
+
+tags = ["Python", "UI", "Framework", "Layout"]
+
+nv.Flow(
+    main_gap=8,
+    cross_gap=8,
+    children=[
+        md.Card(md.Text(tag), style=md.CardStyle.outlined()) for tag in tags
+    ],
+)
+```
+
+This is the right choice when the collection does not change after the layout is
+built. If the list can change at runtime and you want the layout to update
+automatically, use `builder()` instead.
+
+## `builder()` (Recommended)
+
+`Row`, `Column`, `Stack`, `Flow`, and `UniformFlow` all expose a `builder()`
+class method that materializes children from a data collection:
+
+```python
+Row.builder(items, fn, ...)
+```
+
+- `items`: the source data collection — a plain list, or an **observable** for
+  reactive updates.
+- `fn`: a builder function with the signature `(item, index) -> Widget`, called
+  once per item.
+
+```python
+import nuiitivet as nv
+import nuiitivet.material as md
+
+tags = ["Python", "UI", "Framework", "Layout"]
+
+nv.Flow.builder(
+    tags,
+    lambda tag, index: md.Card(md.Text(tag), style=md.CardStyle.outlined()),
+    main_gap=8,
+    cross_gap=8,
+)
+```
+
+`builder()` reads naturally: `Row.builder(items, ...)` says "a Row builds its
+children from items", which matches the mental model of the widget owning its
+own children. This is why it is the recommended approach for general use.
+
+> **Note:** `Deck` does **not** support `builder()`. `Deck` switches between
+> children by `index` rather than laying them all out, so it has no `builder()`
+> method. Use it with an explicit list of children instead.
+
+### Reactive Regeneration with an Observable
+
+The essential value of `builder()` shows when you pass an **observable** as
+`items`. The layout then subscribes to it and regenerates automatically whenever
+the collection changes — and only the affected regions are invalidated, not the
+whole layout:
+
+```python
+import nuiitivet as nv
+import nuiitivet.material as md
+
+class TagList:
+    def __init__(self):
+        self.tags = nv.Observable(["Python", "UI"])
+
+    def build(self):
+        return nv.Flow.builder(
+            self.tags,
+            lambda tag, index: md.Card(md.Text(tag), style=md.CardStyle.outlined()),
+            main_gap=8,
+            cross_gap=8,
+        )
+
+    def add(self, tag: str) -> None:
+        # Reassigning .value pushes the change; the Flow regenerates its cards.
+        self.tags.value = [*self.tags.value, tag]
+```
+
+With a static list you would have to rebuild and re-render the layout yourself.
+With an observable, `builder()` keeps the children in sync with the data for you.
+
+## `ForEach` (SwiftUI-like Style)
+
+If you prefer a SwiftUI-style declaration, `ForEach` provides the same dynamic
+generation as an embedded element inside a normal `children` list:
+
+```python
+import nuiitivet as nv
+import nuiitivet.material as md
+from nuiitivet.layout.for_each import ForEach
+
+tags = ["Python", "UI", "Framework", "Layout"]
+
+nv.Flow(
+    main_gap=8,
+    cross_gap=8,
+    children=[
+        ForEach(
+            tags,
+            lambda tag, index: md.Card(md.Text(tag), style=md.CardStyle.outlined()),
+        ),
+    ],
+)
+```
+
+`ForEach` accepts the same `items` (including observables) and `(item, index) ->
+Widget` builder, so it behaves identically to `builder()` at runtime.
+
+> **Caveat:** written as `children=[ForEach(...)]`, it visually reads as a
+> dynamic array nested inside another array, which can clash with the mental
+> model of a flat child list. For that reason `builder()` is recommended for
+> general use, with `ForEach` offered for those who prefer the SwiftUI-like
+> expression.
+
+## When to Use Which
+
+| Situation | Approach |
+| --- | --- |
+| Collection is fixed at build time | List comprehension |
+| Collection changes at runtime (dynamic) | `builder()` (recommended) |
+| You prefer a SwiftUI-like declaration | `ForEach` |

--- a/docs/guide/layout_extras.md
+++ b/docs/guide/layout_extras.md
@@ -130,6 +130,8 @@ nv.Flow(
 
 ![Flow example](../assets/layout_extras_flow.png)
 
+> To generate the children from a data collection (including reactive updates), see [layout_dynamic.md](layout_dynamic.md).
+
 ## UniformFlow (Uniform Grid)
 
 Arranges elements into a grid with **uniform column widths**.
@@ -160,6 +162,8 @@ nv.UniformFlow(
 
 - Use **Flow** for wrapping rows with variable-width items (tags, chips, variable text).
 - Use **UniformFlow** for grid-like layouts with uniform columns (tiles, cards, image grids).
+
+> To generate the children from a data collection (including reactive updates), see [layout_dynamic.md](layout_dynamic.md).
 
 ## Container (Decoration/Size Control)
 

--- a/samples/layout_dynamic/builder_basic.py
+++ b/samples/layout_dynamic/builder_basic.py
@@ -1,0 +1,35 @@
+"""Dynamic list generation: builder() (recommended).
+
+Demonstrates the ``builder()`` class method available on
+Row / Column / Stack / Flow / UniformFlow. It materializes children from a
+data collection via a ``(item, index) -> Widget`` builder function.
+"""
+
+import nuiitivet as nv
+import nuiitivet.material as md
+
+
+def main(png: str = ""):
+    tags = ["Python", "UI", "Framework", "Layout"]
+
+    widget = nv.Flow.builder(
+        tags,
+        lambda tag, index: md.Card(md.Text(tag, padding=8), style=md.CardStyle.outlined()),
+        main_gap=8,
+        cross_gap=8,
+        padding=8,
+        width=300,
+    )
+
+    root = nv.Container(alignment="center", child=widget)
+
+    app = md.App(content=root, title="Dynamic List: builder()")
+    if png:
+        app.render_to_png(png)
+        print(f"Rendered {png}")
+        return
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/layout_dynamic/builder_reactive.py
+++ b/samples/layout_dynamic/builder_reactive.py
@@ -1,0 +1,58 @@
+"""Dynamic list generation: reactive builder() with an observable.
+
+Passing an observable as ``items`` makes the layout regenerate its children
+automatically whenever the collection changes. Only the affected regions are
+invalidated, not the whole layout.
+
+Click "Add tag" to append an item and watch the Flow regenerate.
+"""
+
+import nuiitivet as nv
+import nuiitivet.material as md
+from nuiitivet.widgeting.widget import ComposableWidget, Widget
+
+
+class TagListApp(ComposableWidget):
+    """A Flow whose cards are driven by an observable list of tags."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tags = nv.Observable(["Python", "UI"])
+        self._counter = 0
+
+    def add(self) -> None:
+        # Reassigning .value pushes the change; the Flow regenerates its cards.
+        self._counter += 1
+        self.tags.value = [*self.tags.value, f"Tag {self._counter}"]
+
+    def build(self) -> Widget:
+        return nv.Column(
+            padding=16,
+            gap=12,
+            children=[
+                nv.Flow.builder(
+                    self.tags,
+                    lambda tag, index: md.Card(md.Text(tag, padding=8), style=md.CardStyle.outlined()),
+                    main_gap=8,
+                    cross_gap=8,
+                    width=300,
+                ),
+                md.Button("Add tag", on_click=lambda: self.add(), style=md.ButtonStyle.filled()),
+            ],
+        )
+
+
+def main(png: str = ""):
+    widget = TagListApp()
+    root = nv.Container(alignment="center", child=widget)
+
+    app = md.App(content=root, title="Dynamic List: reactive builder()")
+    if png:
+        app.render_to_png(png)
+        print(f"Rendered {png}")
+        return
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/layout_dynamic/foreach_embedded.py
+++ b/samples/layout_dynamic/foreach_embedded.py
@@ -1,0 +1,39 @@
+"""Dynamic list generation: ForEach (SwiftUI-like style).
+
+Demonstrates the embedded ``children=[ForEach(...)]`` form. It behaves
+identically to ``builder()`` at runtime but reads in a SwiftUI-like style.
+"""
+
+import nuiitivet as nv
+import nuiitivet.material as md
+from nuiitivet.layout.for_each import ForEach
+
+
+def main(png: str = ""):
+    tags = ["Python", "UI", "Framework", "Layout"]
+
+    widget = nv.Flow(
+        main_gap=8,
+        cross_gap=8,
+        padding=8,
+        width=300,
+        children=[
+            ForEach(
+                tags,
+                lambda tag, index: md.Card(md.Text(tag, padding=8), style=md.CardStyle.outlined()),
+            ),
+        ],
+    )
+
+    root = nv.Container(alignment="center", child=widget)
+
+    app = md.App(content=root, title="Dynamic List: ForEach")
+    if png:
+        app.render_to_png(png)
+        print(f"Rendered {png}")
+        return
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/layout_dynamic/static_list.py
+++ b/samples/layout_dynamic/static_list.py
@@ -1,0 +1,34 @@
+"""Dynamic list generation: static list comprehension.
+
+Demonstrates the simplest form — turning a fixed collection into widgets
+inline with a list comprehension. Use this when the data does not change
+after the layout is built.
+"""
+
+import nuiitivet as nv
+import nuiitivet.material as md
+
+
+def main(png: str = ""):
+    tags = ["Python", "UI", "Framework", "Layout"]
+
+    widget = nv.Flow(
+        main_gap=8,
+        cross_gap=8,
+        padding=8,
+        children=[md.Card(md.Text(tag, padding=8), style=md.CardStyle.outlined()) for tag in tags],
+        width=300,
+    )
+
+    root = nv.Container(alignment="center", child=widget)
+
+    app = md.App(content=root, title="Dynamic List: Static Comprehension")
+    if png:
+        app.render_to_png(png)
+        print(f"Rendered {png}")
+        return
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nuiitivet/layout/for_each.py
+++ b/src/nuiitivet/layout/for_each.py
@@ -2,10 +2,11 @@
 
 ForEach acts as a layout provider that materializes its children inside
 scoped fragments so individual items can be invalidated without forcing
-the parent layout to rebuild entirely. The widget can be embedded inside
-Row/Column/Flow (or any other layout) and can also materialize
-convenience wrappers via ``row()``, ``column()`` and ``flow()`` helper
-methods.
+the parent layout to rebuild entirely. Embed it directly in a layout's
+``children`` list (e.g. ``Row/Column/Flow(children=[ForEach(...)])``). For
+the common case, prefer the ``builder()`` class method on
+``Row``/``Column``/``Stack``/``Flow``/``UniformFlow``, which constructs the
+layout with an embedded ForEach for you.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Add `docs/guide/layout_dynamic.md`: contrasts static list comprehension, `builder()` (recommended), and `ForEach` (SwiftUI-like) for generating children from a data collection; documents reactive regeneration with observable `items` and excludes `Deck` from `builder()` support.
- Add runnable samples under `samples/layout_dynamic/` (static, builder, reactive builder, ForEach). Screenshots skipped: output duplicates the existing Flow image and cannot convey reactive behavior (consistent with other conceptual guides such as observable.md).
- Cross-link the new page from the `layout.md` topic table and the Flow / UniformFlow sections in `layout_extras.md`.
- Fix stale `ForEach` module docstring referencing nonexistent `row()`/`column()`/`flow()` helpers.

Closes #270

## Test plan
- [x] All four samples in `samples/layout_dynamic/` run and render to PNG
- [x] Guide code snippets execute (`builder()`, observable, embedded `ForEach`)
- [ ] Guide renders correctly on the docs site (visual review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)