### PR TITLE
docs(README): reframe 1.2 Data Binding around its benefit

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For why modifiers exist and what kinds are available, see [docs/guide/modifier.m
 ### 1.2 Data Binding
 
 Dynamic UIs need state management.
-Starting with React (the JavaScript one), many frameworks rebuild the UI whenever state changes. Nuiitivet doesn't rebuild — it *binds* state to the UI instead.
+With **data binding**, you declare *what the UI shows* in terms of your state — once — and that link stays live. Change the state, and every bound part of the UI follows on its own. You never write the code that pushes a value into a widget, and the UI can't drift out of sync with your state, because your state *is* the UI's single source of truth.
 
 That mechanism is `Observable`. It binds directly to the UI like Signals (SolidJS, MobX), and it also carries operators like `throttle()` and `debounce()` like Rx — the best of both worlds. (It's inspired by WPF's ReactiveProperty.)
 


### PR DESCRIPTION
## Summary
- Rewrite the README 1.2 Data Binding intro (README.md:84-85) to remove the inaccurate "Nuiitivet doesn't rebuild" claim, which contradicts the implementation (ForEach regenerates children; scoped fragments rebuild on invalidation).
- Reframe the paragraph around what data binding gives the developer — you never write state↔UI sync code, state is the single source of truth, so the UI can't drift out of sync — instead of an internal rebuild-vs-diff mechanism.
- Drop the React comparison entirely (no framework-comparison framing).

## Test plan
- [ ] Read README §1.2 and confirm the intro reads naturally into the following `Observable` paragraph ("That mechanism is `Observable`.").
- [ ] Confirm no remaining "doesn't rebuild" / re-run-mechanism claims in §1.2.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)