### PR TITLE
feat(navigation-rail): inset collapsed labels and scale expanded width to MD3 range

### DIFF
--- a/src/nuiitivet/material/navigation_rail.py
+++ b/src/nuiitivet/material/navigation_rail.py
@@ -4,7 +4,8 @@ from typing import Callable, Optional, Sequence, Tuple, Union
 import logging
 
 from nuiitivet.widgeting.widget import Widget
-from nuiitivet.rendering.sizing import SizingLike, Sizing
+from nuiitivet.common.logging_once import warning_once
+from nuiitivet.rendering.sizing import SizingLike, Sizing, parse_sizing
 from nuiitivet.observable.value import _ObservableValue
 from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
 from nuiitivet.animation import Animatable, Rect, lerp, lerp_rect
@@ -25,6 +26,55 @@ from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL, EXPRESSIVE_DEF
 from nuiitivet.modifiers.transform import rotate
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_expanded_width(
+    width: Union[SizingLike, ReadOnlyObservableProtocol, None],
+    style: NavigationRailStyle,
+) -> Tuple[float, Optional[Tuple[str, str]]]:
+    """Resolve the effective expanded rail width from the ``width`` argument.
+
+    Only a *fixed* width is interpreted as the expanded width (clamped into the
+    MD3 range ``[min, max]``). ``None`` silently falls back to the minimum
+    expanded width. Any other value (flex/auto/percent/observable) cannot be
+    interpreted as an expanded width, so the minimum is used and a warning is
+    returned so the caller can surface it.
+
+    Returns ``(effective_width, warning)`` where ``warning`` is either ``None``
+    or a ``(log_once_key, message)`` pair for :func:`warning_once`.
+    """
+    lo = style.container_width_expanded_min
+    hi = style.container_width_expanded_max
+    if width is None:
+        # No width provided: default to the minimum expanded width, silently.
+        return style.clamp_expanded_width(lo), None
+    if isinstance(width, (Sizing, int, float, str)):
+        sizing = parse_sizing(width)
+        if sizing.kind == "fixed":
+            requested = float(sizing.value)
+            effective = style.clamp_expanded_width(requested)
+            if effective != requested:
+                return effective, (
+                    f"navigation_rail_width_clamped:{requested:g}:{lo:g}:{hi:g}",
+                    f"NavigationRail width {requested:g}dp is outside the MD3 "
+                    f"expanded range [{lo:g}, {hi:g}]; clamped to {effective:g}dp. "
+                    f"Raise NavigationRailStyle.container_width_expanded_max to "
+                    f"allow wider rails.",
+                )
+            return effective, None
+        # A non-fixed sizing (flex/auto/percent) cannot be an expanded width.
+        return style.clamp_expanded_width(lo), (
+            f"navigation_rail_width_non_fixed:{sizing.kind}",
+            f"NavigationRail width is not a fixed size ({sizing.kind}); the "
+            f"expanded width defaulted to {lo:g}dp. Pass a fixed width "
+            f"(e.g. width=280) to set the expanded width.",
+        )
+    # Observable or otherwise non-interpretable width.
+    return style.clamp_expanded_width(lo), (
+        "navigation_rail_width_observable",
+        "NavigationRail width must be a fixed size to set the expanded width; "
+        f"the expanded width defaulted to {lo:g}dp.",
+    )
 
 
 class RailItem(Widget):
@@ -137,6 +187,7 @@ class _RailItemButton(InteractiveWidget):
         expand_animation: Animatable,
         label_animation: Animatable,
         rail_style: Optional[NavigationRailStyle] = None,
+        expanded_width: float = NavigationRailStyle().container_width_expanded_min,
         on_click: Optional[Callable[[], None]] = None,
     ) -> None:
         self._expand_animation = expand_animation
@@ -144,6 +195,8 @@ class _RailItemButton(InteractiveWidget):
         # Resolve effective style: item style > rail style > defaults
         eff_style = rail_item.style or rail_style or NavigationRailStyle()
         self._eff_style = eff_style
+        # Effective expanded rail width used to size the pill and label.
+        self._expanded_width = expanded_width
         self._selected = bool(selected)
         self._indicator_color: Optional[ColorSpec] = None
         self._indicator_rect: Optional[Tuple[int, int, int, int]] = None
@@ -158,10 +211,20 @@ class _RailItemButton(InteractiveWidget):
             text_alignment="start",
         )
 
+        # Inset the collapsed label so long labels never touch the rail edges.
+        # 96dp rail - 2 * 8dp = 80dp label box (M3 collapsed container width).
+        collapsed_label_width = max(
+            0.0,
+            eff_style.container_width_collapsed - 2.0 * eff_style.label_horizontal_inset,
+        )
+        # Expanded label width scales with the container so it fills the pill at
+        # any container width in the M3 expanded range (220-360dp).
+        expanded_label_width = eff_style.expanded_label_width(expanded_width)
+
         self._vertical_label = Text(
             rail_item.label_spec,
             style=base_label_style.copy_with(font_size=12, text_alignment="center"),
-            width=Sizing.fixed(eff_style.container_width_collapsed),
+            width=Sizing.fixed(collapsed_label_width),
             max_lines=1,
             overflow="ellipsis",
             # Single-line label: fill the width and truncate mid-word instead of
@@ -171,16 +234,19 @@ class _RailItemButton(InteractiveWidget):
         self._horizontal_label = Text(
             rail_item.label_spec,
             style=base_label_style.copy_with(font_size=14, text_alignment="start"),
-            width=Sizing.fixed(eff_style.horizontal_label_width),
+            width=Sizing.fixed(expanded_label_width),
             max_lines=1,
             overflow="ellipsis",
             soft_wrap=False,
         )
 
         # Fixed content size with animated clip window.
+        # Inset content box (centered in the full-width container below), which
+        # keeps the 8dp margin on each side while the outer container stays at
+        # the full rail width for layout/animation.
         self._vertical_content = Box(
             child=self._vertical_label,
-            width=Sizing.fixed(eff_style.container_width_collapsed),
+            width=Sizing.fixed(collapsed_label_width),
             height=Sizing.fixed(eff_style.label_height),
             alignment="center",
         )
@@ -194,13 +260,13 @@ class _RailItemButton(InteractiveWidget):
 
         self._horizontal_content = Box(
             child=self._horizontal_label,
-            width=Sizing.fixed(eff_style.horizontal_label_width),
+            width=Sizing.fixed(expanded_label_width),
             height=Sizing.fixed(eff_style.label_height),
             alignment="center_left",
         )
         self._horizontal_label_container = Box(
             child=self._horizontal_content,
-            width=Sizing.fixed(eff_style.horizontal_label_width),
+            width=Sizing.fixed(expanded_label_width),
             height=Sizing.fixed(eff_style.label_height),
             alignment="center_left",
         )
@@ -346,7 +412,7 @@ class _RailItemButton(InteractiveWidget):
             Rect(
                 x=margin,
                 y=0.0,
-                width=float(self._eff_style.indicator_width_expanded),
+                width=self._eff_style.expanded_indicator_width(self._expanded_width),
                 height=float(self._eff_style.item_height),
             ),
             t_layout,
@@ -393,7 +459,7 @@ class _RailItemButton(InteractiveWidget):
             Rect(
                 x=label_x_expanded,
                 y=label_y_expanded,
-                width=float(self._eff_style.horizontal_label_width),
+                width=self._eff_style.expanded_label_width(self._expanded_width),
                 height=label_height,
             ),
             t_label,
@@ -629,7 +695,8 @@ class NavigationRail(Widget):
 
     Display modes:
     - Collapsed (expanded=False): Icon above label (vertical), 96px wide
-    - Expanded (expanded=True): Icon + label (horizontal), 220px wide
+    - Expanded (expanded=True): Icon + label (horizontal), 220-360px wide
+      (the expanded width is set via the ``width`` argument; see ``__init__``)
 
     Both modes show labels. The active indicator (selection background) wraps:
     - Collapsed: Only the icon (56×32dp)
@@ -665,7 +732,13 @@ class NavigationRail(Widget):
             on_select: Callback when an item is selected.
             expanded: Whether the rail is expanded (bool or Observable).
             show_menu_button: Whether to show the menu toggle button.
-            width: Width specification.
+            width: Expanded rail width. A *fixed* value (e.g. ``280`` or
+                ``Sizing.fixed(280)``) sets the expanded width, clamped into the
+                MD3 range ``[220, 360]`` (see ``NavigationRailStyle``). The rail
+                always animates between the collapsed width and this expanded
+                width; the collapsed width is never overridden here. Any
+                non-fixed value (or ``None``) uses the minimum expanded width;
+                non-fixed values also emit a warning.
             height: Height specification.
             padding: Padding specification.
             style: Custom NavigationRailStyle.
@@ -688,21 +761,22 @@ class NavigationRail(Widget):
         self._log_instance_id = id(self)
         logger.debug("NavigationRail init id=%s", self._log_instance_id)
 
-        # Drive width via animation if not fixed
-        if width is None:
-            width = self._expand_animation.map(
-                lambda progress: Sizing.fixed(
-                    int(
-                        lerp(
-                            float(eff_style.container_width_collapsed),
-                            float(eff_style.container_width_expanded),
-                            progress,
-                        )
-                    )
-                )
+        # Resolve the expanded width from `width` (only a fixed value sets it),
+        # then always drive the outer width via the collapse animation so the
+        # rail animates 96dp <-> expanded width regardless of what was passed.
+        self._expanded_width, width_warning = _resolve_expanded_width(width, eff_style)
+        collapsed_width = float(eff_style.container_width_collapsed)
+        expanded_width = self._expanded_width
+        animated_width = self._expand_animation.map(
+            lambda progress: Sizing.fixed(
+                int(lerp(collapsed_width, expanded_width, progress))
             )
+        )
 
-        super().__init__(width=width, height=height, padding=padding)
+        super().__init__(width=animated_width, height=height, padding=padding)
+
+        if width_warning is not None:
+            warning_once(logger, width_warning[0], width_warning[1])
 
         self._item_buttons: list[_RailItemButton] = []
 
@@ -797,6 +871,7 @@ class NavigationRail(Widget):
                 expand_animation=self._expand_animation,
                 label_animation=self._label_animation,
                 rail_style=self.style,
+                expanded_width=self._expanded_width,
                 on_click=_on_click,
             )
             item_buttons.append(button)
@@ -822,13 +897,16 @@ class NavigationRail(Widget):
         self.add_child(rail_bg)
 
     def _calculate_width(self) -> int:
-        """Calculate rail width based on expanded state."""
-        if self.width_sizing.kind == "fixed":
-            # Use explicit width if provided.
-            return int(self.width_sizing.value)
-        # M3 defaults: 96dp collapsed, 220dp expanded.
+        """Calculate rail width based on expanded state.
+
+        The outer width animates between the collapsed width and the resolved
+        expanded width (:attr:`_expanded_width`), so this returns the target for
+        the current state.
+        """
         eff_style = self.style or NavigationRailStyle()
-        return int(eff_style.container_width_expanded if self._is_expanded else eff_style.container_width_collapsed)
+        if self._is_expanded:
+            return int(self._expanded_width)
+        return int(eff_style.container_width_collapsed)
 
     def _build_menu_button(self) -> Widget:
         """Build the menu toggle button."""

--- a/src/nuiitivet/material/styles/navigation_rail_style.py
+++ b/src/nuiitivet/material/styles/navigation_rail_style.py
@@ -11,6 +11,11 @@ from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.material.styles.text_style import TextStyle
 
+# Trailing margin (dp) kept between the expanded active-indicator pill and the
+# rail's trailing edge when the indicator width is auto-derived. Chosen so the
+# 220dp default reproduces the historical 174dp pill (220 - 20 leading - 26).
+_EXPANDED_INDICATOR_TRAILING_MARGIN = 26.0
+
 
 @dataclass(frozen=True)
 class NavigationRailStyle:
@@ -26,15 +31,33 @@ class NavigationRailStyle:
         label_text_style: The base text style for labels.
         menu_icon_color: The color of the menu icon.
         container_width_collapsed: Width when collapsed.
-        container_width_expanded: Width when expanded.
+        container_width_expanded_min: Minimum expanded width (dp). Also the
+            default expanded width when the ``NavigationRail`` ``width`` is not a
+            fixed value. Matches the M3 lower bound (220dp).
+        container_width_expanded_max: Maximum expanded width (dp). Fixed
+            ``width`` values are clamped into
+            ``[container_width_expanded_min, container_width_expanded_max]``.
+            Matches the M3 upper bound (360dp); raise it to allow wider rails.
         icon_size: Icon size.
         item_height: Item height.
         indicator_height_collapsed: Indicator height when collapsed.
         indicator_width_collapsed: Indicator width when collapsed.
-        indicator_width_expanded: Indicator width when expanded.
+        indicator_width_expanded: Active-indicator (pill) width when expanded.
+            ``None`` (default) auto-derives it from the resolved expanded width
+            so the pill scales across the M3 expanded range (220-360dp), leaving
+            a fixed trailing margin to the rail edge. Set an explicit value to
+            pin it. See :meth:`expanded_indicator_width`.
         indicator_horizontal_padding: Horizontal padding inside indicator.
         label_height: Label height.
-        horizontal_label_width: Label width in expanded mode.
+        horizontal_label_width: Label width in expanded mode. ``None`` (default)
+            auto-derives it from the resolved indicator width so the label fills
+            the pill minus symmetric ``indicator_horizontal_padding`` inner
+            padding (and never overflows it) at any container width. Set an
+            explicit value to pin it. See :meth:`expanded_label_width`.
+        label_horizontal_inset: Horizontal inset applied to each side of the
+            collapsed (vertical) label so it never touches the rail edges.
+            The default 8dp yields an 80dp label box inside the 96dp rail,
+            matching the M3 collapsed navigation rail container width (80dp).
         gap_collapsed: Gap between items when collapsed.
         gap_expanded: Gap between items when expanded.
         label_gap_expanded: Icon-label gap when expanded.
@@ -51,20 +74,69 @@ class NavigationRailStyle:
     label_text_style: Optional[TextStyle] = None
     menu_icon_color: Optional[ColorSpec] = ColorRole.ON_SURFACE
     container_width_collapsed: float = 96.0
-    container_width_expanded: float = 220.0
+    container_width_expanded_min: float = 220.0
+    container_width_expanded_max: float = 360.0
     icon_size: float = 24.0
     item_height: float = 56.0
     indicator_height_collapsed: float = 32.0
     indicator_width_collapsed: float = 56.0
-    indicator_width_expanded: float = 174.0
+    indicator_width_expanded: Optional[float] = None
     indicator_horizontal_padding: float = 16.0
     label_height: float = 20.0
-    horizontal_label_width: float = 110.0
+    horizontal_label_width: Optional[float] = None
+    label_horizontal_inset: float = 8.0
     gap_collapsed: float = 4.0
     gap_expanded: float = 0.0
     label_gap_expanded: float = 8.0
     menu_button_size: float = 56.0
     top_padding: float = 44.0
+
+    def clamp_expanded_width(self, value: float) -> float:
+        """Clamp an expanded width into the allowed MD3 range.
+
+        Returns ``value`` bounded by
+        ``[container_width_expanded_min, container_width_expanded_max]``.
+        """
+        lo = self.container_width_expanded_min
+        hi = max(lo, self.container_width_expanded_max)
+        return max(lo, min(hi, value))
+
+    def expanded_indicator_width(self, expanded_width: float) -> float:
+        """Return the resolved active-indicator width for *expanded_width*.
+
+        If :attr:`indicator_width_expanded` is set, it is returned as-is.
+        Otherwise the pill scales with *expanded_width*, keeping the leading
+        margin ``(container_width_collapsed - indicator_width_collapsed) / 2``
+        and a fixed trailing margin to the rail edge.
+        """
+        if self.indicator_width_expanded is not None:
+            return self.indicator_width_expanded
+        leading_margin = max(
+            0.0,
+            (self.container_width_collapsed - self.indicator_width_collapsed) / 2.0,
+        )
+        return max(
+            0.0,
+            expanded_width - leading_margin - _EXPANDED_INDICATOR_TRAILING_MARGIN,
+        )
+
+    def expanded_label_width(self, expanded_width: float) -> float:
+        """Return the resolved horizontal label width for *expanded_width*.
+
+        If :attr:`horizontal_label_width` is set, it is returned as-is.
+        Otherwise the label fills the resolved indicator pill minus the icon,
+        the icon-label gap, and a symmetric :attr:`indicator_horizontal_padding`
+        inner padding on each side, so it never overflows the pill.
+        """
+        if self.horizontal_label_width is not None:
+            return self.horizontal_label_width
+        return max(
+            0.0,
+            self.expanded_indicator_width(expanded_width)
+            - 2.0 * self.indicator_horizontal_padding
+            - self.icon_size
+            - self.label_gap_expanded,
+        )
 
     def copy_with(self, **changes) -> "NavigationRailStyle":
         """Return a copy of this style with the given changes."""

--- a/tests/navigation/test_navigation_rail.py
+++ b/tests/navigation/test_navigation_rail.py
@@ -149,14 +149,19 @@ def test_navigation_rail_width_calculation():
 
 
 def test_navigation_rail_custom_width():
-    """NavigationRail should respect custom width."""
+    """A fixed width sets the expanded width (within the MD3 range)."""
     items = [
         RailItem(icon="home", label="Home"),
         RailItem(icon="search", label="Search"),
     ]
-    rail = NavigationRail(children=items, width=150)
+    # 280 is inside [220, 360], so it is used verbatim as the expanded width.
+    rail = NavigationRail(children=items, expanded=True, width=280)
 
-    assert rail._calculate_width() == 150
+    assert rail._calculate_width() == 280
+    # Collapsed always returns the collapsed container width, never the custom
+    # expanded width.
+    collapsed = NavigationRail(children=items, expanded=False, width=280)
+    assert collapsed._calculate_width() == 96
 
 
 def test_navigation_rail_no_menu_button():

--- a/tests/navigation/test_navigation_rail_layout.py
+++ b/tests/navigation/test_navigation_rail_layout.py
@@ -4,8 +4,10 @@ from contextlib import contextmanager
 from typing import Callable, Generator
 
 from nuiitivet.material.navigation_rail import NavigationRail, RailItem
+from nuiitivet.material.styles.navigation_rail_style import NavigationRailStyle
 from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.observable import runtime as observable_runtime
+from nuiitivet.rendering.sizing import Sizing
 
 
 # ---------------------------------------------------------------------------
@@ -221,6 +223,82 @@ def test_horizontal_label_position_when_expanded():
     assert h == 20
 
 
+def test_expanded_widths_scale_with_fixed_width():
+    """A fixed width sets the expanded width; pill and label scale to fill it.
+
+    M3 allows the expanded rail to be 220-360dp. Passing width=360 (fixed)
+    widens the pill and label instead of leaving the right side empty, while
+    keeping the label inside the pill (16dp inner pad).
+    """
+    items = [RailItem(icon="home", label="Home")]
+    rail = NavigationRail(children=items, expanded=True, width=Sizing.fixed(360))
+    rail.layout(360, 600)
+
+    button = _get_item_button(rail)
+    assert button._indicator_rect is not None
+    ind_x, _iy, ind_w, _ih = button._indicator_rect
+    assert (ind_x, ind_w) == (20, 314)  # 360 - 20 leading - 26 trailing
+
+    assert button._horizontal_label_container.layout_rect is not None
+    lx, _ly, lw, _lh = button._horizontal_label_container.layout_rect
+    assert (lx, lw) == (68, 250)  # 314 - 2*16 pad - 24 icon - 8 gap
+
+    # Label must stay inside the pill: label right + inner pad == pill right.
+    assert (lx + lw) + NavigationRailStyle().indicator_horizontal_padding == ind_x + ind_w
+
+
+def test_expanded_width_clamped_to_max_with_warning(caplog):
+    """A fixed width above the max is clamped to the max and warns once."""
+    import logging
+
+    from nuiitivet.common.logging_once import _clear_log_once_keys_for_tests
+
+    _clear_log_once_keys_for_tests()
+    items = [RailItem(icon="home", label="Home")]
+    with caplog.at_level(logging.WARNING, logger="nuiitivet.material.navigation_rail"):
+        rail = NavigationRail(children=items, expanded=True, width=Sizing.fixed(500))
+    assert rail._expanded_width == 360.0
+    assert any("clamped" in r.message for r in caplog.records)
+
+
+def test_expanded_width_defaults_to_min_without_warning(caplog):
+    """No width (None) silently uses the minimum expanded width."""
+    import logging
+
+    from nuiitivet.common.logging_once import _clear_log_once_keys_for_tests
+
+    _clear_log_once_keys_for_tests()
+    items = [RailItem(icon="home", label="Home")]
+    with caplog.at_level(logging.WARNING, logger="nuiitivet.material.navigation_rail"):
+        rail = NavigationRail(children=items, expanded=True)
+    assert rail._expanded_width == 220.0
+    assert caplog.records == []
+
+
+def test_non_fixed_width_uses_min_and_warns(caplog):
+    """A non-fixed width cannot be an expanded width: use min and warn."""
+    import logging
+
+    from nuiitivet.common.logging_once import _clear_log_once_keys_for_tests
+
+    _clear_log_once_keys_for_tests()
+    items = [RailItem(icon="home", label="Home")]
+    with caplog.at_level(logging.WARNING, logger="nuiitivet.material.navigation_rail"):
+        rail = NavigationRail(children=items, expanded=True, width=Sizing.flex(1))
+    assert rail._expanded_width == 220.0
+    assert any("not a fixed size" in r.message for r in caplog.records)
+
+
+def test_expanded_widths_honor_explicit_overrides():
+    """Explicit indicator/label widths are used verbatim (no auto-derivation)."""
+    style = NavigationRailStyle(
+        indicator_width_expanded=174.0,
+        horizontal_label_width=110.0,
+    )
+    assert style.expanded_indicator_width(360.0) == 174.0
+    assert style.expanded_label_width(360.0) == 110.0
+
+
 def test_vertical_label_position_when_collapsed():
     """Vertical label should be visible just below the collapsed indicator.
 
@@ -424,7 +502,8 @@ def test_rail_item_button_labels_ellipsize_within_box_width():
     button = rail._item_buttons[0]
 
     for label, expected_w in (
-        (button._vertical_label, 96),
+        # Collapsed label is inset by 8dp per side: 96 - 2 * 8 = 80.
+        (button._vertical_label, 80),
         (button._horizontal_label, 110),
     ):
         assert label._overflow == "ellipsis"


### PR DESCRIPTION
## Summary
- Add an 8dp horizontal inset (`label_horizontal_inset`) to collapsed labels →
  80dp label box (matches the M3 collapsed container width); long labels no
  longer touch the rail edges, short labels unchanged.
- Reinterpret `width` as the expanded width: only a *fixed* value sets it,
  clamped into the MD3 range `[220, 360]`. `None` uses the minimum silently;
  non-fixed/observable values and clamped values warn once via `warning_once`.
- The rail always animates between the 96dp collapsed width and the resolved
  expanded width; `width` never overrides the collapsed width.
- Active-indicator pill and horizontal label auto-derive from the expanded
  width and stay coupled (label never overflows the pill), scaling together
  across 220–360dp. Explicit indicator/label widths still override.
- Drop the fixed `container_width_expanded` field in favor of
  `container_width_expanded_min`/`_max`; the 220dp default reproduces the
  historical 174dp pill and 110dp label exactly.

## Test plan
- [ ] `pytest tests/navigation` (105 passed; 5 new/updated cases)
- [ ] `NavigationRail(width=360)` expanded scales pill/label with no dead space
- [ ] `width=360` collapses to 96dp (animation not bypassed)
- [ ] `width=500` clamps to 360 with a one-time warning; `width=flex(1)` → 220 + warning; `width=None` silent
- [ ] `mypy src/nuiitivet/material/navigation_rail.py` clean

Closes #277