### PR TITLE
docs: clarify per-instance semantics of Observable descriptor sample

### DIFF
--- a/samples/observable/getting_started.py
+++ b/samples/observable/getting_started.py
@@ -37,7 +37,13 @@ class Counter:
 
 
 class Model:
-    """Two independent instances share the same descriptor."""
+    """Class-level Observable descriptor with per-instance state.
+
+    ``value`` is defined once as a class attribute, so every instance shares the
+    same descriptor object. Each instance nonetheless holds its *own* value
+    (stored on the instance), so mutating one instance's ``value`` never affects
+    another's.
+    """
 
     value: Observable[int] = Observable(0)
 


### PR DESCRIPTION
## Summary
- Reword the `Model` docstring in `samples/observable/getting_started.py`; "share the same descriptor" was misleading (read as shared state).
- Clarify that instances share the descriptor object but each holds its own per-instance value.

## Test plan
- [x] `flake8 samples/observable/getting_started.py --max-line-length=120 --extend-ignore=E203` passes
- [x] Docstring-only change; no behavioral impact

Closes #286
