### PR TITLE
feat(runtime): add renderer selection to App.run

### DIFF
--- a/docs/guide/renderer_selection.md
+++ b/docs/guide/renderer_selection.md
@@ -1,0 +1,61 @@
+# Renderer Selection
+
+`App.run()` renders the live window with Skia. By default it uses the GPU
+(OpenGL) and falls back to software (raster) rendering when the GPU is
+unavailable. You can control this with the `renderer` argument.
+
+```python
+import nuiitivet.material as nv
+
+app = nv.App(content=MyScreen())
+
+app.run(renderer="auto")  # default
+app.run(renderer="gpu")   # require the GPU
+app.run(renderer="cpu")   # always render in software
+```
+
+## Modes
+
+| Mode | Behavior |
+|---|---|
+| `"auto"` (default) | Try the GPU, then **silently** fall back to software rendering if it cannot be initialized. Best for most apps. |
+| `"gpu"` | **Require** the GPU. If the GPU backend cannot be initialized — or a frame fails to render on the GPU — a `RuntimeError` is raised. Use this when you want a missing/broken GPU to surface loudly (e.g. remote deployment sanity checks). |
+| `"cpu"` | Always render in software (raster); the GPU is never touched. Use this on GPU-less machines, with software OpenGL (e.g. llvmpipe), or in remote sessions. |
+
+The `renderer` value is typed as
+[`RendererMode`](../../src/nuiitivet/runtime/renderer.py) —
+`Literal["auto", "gpu", "cpu"]`.
+
+## When to use `"cpu"`
+
+Choose `"cpu"` when a GPU path is unreliable but a **display** is still present:
+
+- GPU-less machines.
+- Software OpenGL (Mesa `llvmpipe`, `softpipe`).
+- Remote desktops / forwarded sessions where GPU acceleration is flaky.
+
+`"auto"` already falls back to software when the GPU cannot be initialized, so
+`"cpu"` mainly matters when the GPU initializes but renders incorrectly or too
+slowly — a case that cannot be detected automatically.
+
+## Headless environments
+
+`App.run()` always needs a display: it opens an OS window. **Truly headless
+environments (no display at all) cannot use `run()` in any mode** — window
+creation fails and a clear error is logged. To render without a display, use
+offscreen rendering, which is always software-based:
+
+```python
+app.render_to_png("out.png")
+```
+
+## Logging
+
+Renderer selection emits standard `logging` records under the
+`nuiitivet.backends.pyglet.runner` logger:
+
+- `"auto"`: a one-time **warning** when the GPU is unavailable and software
+  rendering is used instead.
+- `"gpu"`: an **error** before the `RuntimeError` is raised.
+- Window creation failure: an **error** with the underlying exception,
+  regardless of mode.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
           - Window Chrome: guide/window_chrome.md
           - Size and Position: guide/window_size_position.md
           - Operations: guide/window_operations.md
+          - Renderer Selection: guide/renderer_selection.md
       - Modifiers:
           - Overview: guide/modifier.md
           - Decoration: guide/modifier_decoration.md

--- a/samples/renderer_selection/cpu_rendering.py
+++ b/samples/renderer_selection/cpu_rendering.py
@@ -1,0 +1,61 @@
+"""Renderer selection - forcing CPU (software/raster) rendering.
+
+``App.run`` chooses the drawing backend via the ``renderer`` argument:
+
+- ``"auto"`` (default): try the GPU, fall back to software rendering silently.
+- ``"gpu"``: require the GPU; raise if it cannot be initialized.
+- ``"cpu"``: always render in software; never touch the GPU.
+
+``"cpu"`` is useful for GPU-less machines, software-GL, or remote sessions that
+have a display. Truly headless environments (no display at all) cannot run an
+interactive window — render offscreen with ``App.render_to_png`` instead.
+
+Run with an explicit mode, e.g.::
+
+    python cpu_rendering.py cpu
+"""
+
+import sys
+
+import nuiitivet.material as nv
+
+
+class HomeScreen(nv.ComposableWidget):
+    def __init__(self, renderer: nv.RendererMode) -> None:
+        super().__init__()
+        self._renderer = renderer
+
+    def build(self) -> nv.Widget:
+        return nv.Container(
+            alignment="center",
+            width="100%",
+            height="100%",
+            child=nv.Column(
+                gap=16,
+                children=[
+                    nv.Text(f"renderer = {self._renderer!r}"),
+                    nv.Button("Get Started", style=nv.ButtonStyle.filled()),
+                ],
+            ),
+        )
+
+
+def main(png_path: str = "") -> None:
+    renderer: nv.RendererMode = "cpu"
+    if len(sys.argv) > 1 and sys.argv[1] in ("auto", "gpu", "cpu"):
+        renderer = sys.argv[1]  # type: ignore[assignment]
+
+    app = nv.App(
+        content=HomeScreen(renderer),
+        title="Renderer Selection",
+        width=400,
+        height=240,
+    )
+    if png_path:
+        app.render_to_png(png_path)
+    else:
+        app.run(renderer=renderer)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -100,6 +100,7 @@ from nuiitivet.runtime.intents import CloseWindowIntent, MinimizeWindowIntent
 
 # Configuration
 from nuiitivet.rendering.skia.font import set_default_font_family, register_font
+from nuiitivet.runtime.renderer import RendererMode
 
 __all__: list[str] = [
     # Layout
@@ -184,4 +185,5 @@ __all__: list[str] = [
     # Configuration
     "set_default_font_family",
     "register_font",
+    "RendererMode",
 ]

--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -36,7 +36,8 @@ from nuiitivet.input.codes import (
 from .gpu_frame import draw_gpu_frame
 
 from nuiitivet.observable.runtime import set_clock
-from nuiitivet.common.logging_once import debug_once, exception_once
+from nuiitivet.common.logging_once import debug_once, exception_once, warning_once
+from nuiitivet.runtime.renderer import RendererMode
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +54,13 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return True
 
 
-def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
-    """Run an interactive window for the given App-like object."""
+def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode = "auto") -> None:
+    """Run an interactive window for the given App-like object.
+
+    ``renderer`` selects the drawing backend: ``"auto"`` (GPU with raster
+    fallback), ``"gpu"`` (require GPU; raise on failure), or ``"cpu"`` (always
+    raster). See :class:`nuiitivet.runtime.renderer.RendererMode`.
+    """
 
     debug_keys = _env_flag("NUIITIVET_DEBUG_KEYS", default=False)
     debug_keys_filter_raw = os.environ.get("NUIITIVET_DEBUG_KEYS_FILTER", "").strip().lower()
@@ -147,14 +153,23 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
     except Exception:
         exception_once(logger, "pyglet_get_chrome_exc", "Failed to determine window style from chrome")
 
-    window = pyglet.window.Window(
-        width=getattr(app, "width", 0),
-        height=getattr(app, "height", 0),
-        caption=caption,
-        style=style,
-        vsync=False,
-        resizable=getattr(app, "resizable", True),
-    )
+    try:
+        window = pyglet.window.Window(
+            width=getattr(app, "width", 0),
+            height=getattr(app, "height", 0),
+            caption=caption,
+            style=style,
+            vsync=False,
+            resizable=getattr(app, "resizable", True),
+        )
+    except Exception:
+        logger.error(
+            "Failed to create the application window. App.run() requires a display; "
+            "headless environments cannot run an interactive window and should render "
+            "offscreen via App.render_to_png() instead.",
+            exc_info=True,
+        )
+        raise
 
     # Check scale immediately and resize if needed
     try:
@@ -269,7 +284,18 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
     gr_context = None
     GL = None
     skia = get_skia(raise_if_missing=False)
-    if skia is not None:
+    if renderer == "cpu":
+        # Software/raster renderer requested: skip GPU initialization entirely.
+        logger.info("renderer='cpu': using software (raster) rendering")
+    elif skia is None:
+        if renderer == "gpu":
+            raise RuntimeError("renderer='gpu' was requested but the Skia backend is unavailable.")
+        warning_once(
+            logger,
+            "pyglet_renderer_skia_unavailable",
+            "Skia unavailable; using software (raster) rendering",
+        )
+    else:
         try:
             from OpenGL import GL as _GL  # type: ignore
 
@@ -291,6 +317,19 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
                 gr_context = None
 
         gpu_enabled = gr_context is not None and GL is not None
+        if not gpu_enabled:
+            if renderer == "gpu":
+                raise RuntimeError(
+                    "renderer='gpu' was requested but the GPU backend could not be initialized "
+                    "(GrDirectContext.MakeGL failed or OpenGL is unavailable). This environment "
+                    "may lack a usable GPU or OpenGL context."
+                )
+            # renderer == "auto": degrade to software rendering.
+            warning_once(
+                logger,
+                "pyglet_renderer_auto_gpu_unavailable",
+                "GPU renderer unavailable; falling back to software (raster) rendering",
+            )
 
     def _recreate_gl_context(reason: str) -> None:
         nonlocal gr_context, gpu_enabled
@@ -663,6 +702,9 @@ def run_app(app: Any, draw_fps: Optional[float] = None) -> None:
                     ok = False
                 if ok:
                     return
+                if renderer == "gpu":
+                    logger.error("renderer='gpu': GPU frame rendering failed")
+                    raise RuntimeError("renderer='gpu' was requested but GPU frame rendering failed.")
                 gpu_enabled = False
 
         if getattr(app, "_dirty", False) or getattr(app, "_last_image", None) is None:

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -32,6 +32,7 @@ from .chrome import OSChrome, CustomChrome
 from .title_bar import WindowDragArea
 from nuiitivet.observable.protocols import Disposable, ReadOnlyObservableProtocol
 from .window import WindowSizingLike, WindowPosition, parse_window_sizing
+from .renderer import RendererMode, parse_renderer_mode
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 
@@ -1026,12 +1027,27 @@ class App:
             except Exception:
                 exception_once(logger, "app_set_draw_fps_exc", "Event loop set_draw_fps raised")
 
-    def run(self, draw_fps: Optional[float] = None):
-        """Run an interactive window using the pyglet backend."""
+    def run(self, draw_fps: Optional[float] = None, *, renderer: RendererMode = "auto"):
+        """Run an interactive window using the pyglet backend.
+
+        Args:
+            draw_fps: Optional fixed draw rate. ``None`` draws on demand.
+            renderer: Renderer selection.
+
+                - ``"auto"`` (default): try the GPU and silently fall back to
+                  software (raster) rendering when it is unavailable.
+                - ``"gpu"``: require the GPU; raise ``RuntimeError`` if the GPU
+                  backend cannot be initialized or a GPU frame fails to render.
+                - ``"cpu"``: always render in software; the GPU is never touched.
+
+                For GPU-less, software-GL, or remote environments (with a
+                display) prefer ``"cpu"``. Truly headless environments cannot use
+                ``run()`` at all — render offscreen via :meth:`render_to_png`.
+        """
 
         from ..backends.pyglet.runner import run_app
 
-        run_app(self, draw_fps=draw_fps)
+        run_app(self, draw_fps=draw_fps, renderer=parse_renderer_mode(renderer))
 
     def exit(self, exit_code: int = 0) -> None:
         """Exit the application."""

--- a/src/nuiitivet/runtime/renderer.py
+++ b/src/nuiitivet/runtime/renderer.py
@@ -1,0 +1,38 @@
+"""Renderer selection for the interactive window backend."""
+
+from __future__ import annotations
+
+from typing import Literal, Tuple, cast, get_args
+
+RendererMode = Literal["auto", "gpu", "cpu"]
+"""Renderer selection accepted by :meth:`nuiitivet.runtime.app.App.run`.
+
+- ``"auto"``: try the GPU first and silently fall back to software (raster)
+  rendering when the GPU backend is unavailable. This is the default.
+- ``"gpu"``: require the GPU. Initialization or per-frame GPU failures raise a
+  :class:`RuntimeError` instead of degrading, so remote/GPU-less environments
+  surface a clear error rather than running unexpectedly slowly.
+- ``"cpu"``: always render in software (raster); the GPU is never touched.
+
+Note that ``App.run`` always needs a display/window; truly headless environments
+should render offscreen via :meth:`App.render_to_png` instead.
+"""
+
+VALID_RENDERER_MODES: Tuple[RendererMode, ...] = get_args(RendererMode)
+
+
+def parse_renderer_mode(value: RendererMode) -> RendererMode:
+    """Validate a renderer selection, raising ``ValueError`` for unknown modes."""
+
+    if value not in VALID_RENDERER_MODES:
+        raise ValueError(
+            f"renderer must be one of {VALID_RENDERER_MODES!r}, got {value!r}"
+        )
+    return cast(RendererMode, value)
+
+
+__all__ = [
+    "RendererMode",
+    "VALID_RENDERER_MODES",
+    "parse_renderer_mode",
+]

--- a/tests/runtime/test_renderer_selection.py
+++ b/tests/runtime/test_renderer_selection.py
@@ -1,0 +1,57 @@
+"""Tests for renderer selection (App.run(renderer=...))."""
+
+from unittest.mock import patch
+
+import pytest
+
+from nuiitivet.runtime.app import App
+from nuiitivet.runtime.renderer import (
+    VALID_RENDERER_MODES,
+    parse_renderer_mode,
+)
+from nuiitivet.widgeting.widget import Widget
+
+
+class MockWidget(Widget):
+    def build(self):
+        return self
+
+
+@pytest.fixture
+def app():
+    return App(content=MockWidget())
+
+
+def test_valid_modes():
+    assert VALID_RENDERER_MODES == ("auto", "gpu", "cpu")
+
+
+@pytest.mark.parametrize("mode", ["auto", "gpu", "cpu"])
+def test_parse_renderer_mode_accepts_valid(mode):
+    assert parse_renderer_mode(mode) == mode
+
+
+def test_parse_renderer_mode_rejects_unknown():
+    with pytest.raises(ValueError):
+        parse_renderer_mode("software")  # type: ignore[arg-type]
+
+
+def test_run_defaults_to_auto(app):
+    with patch("nuiitivet.backends.pyglet.runner.run_app") as run_app:
+        app.run()
+    run_app.assert_called_once()
+    assert run_app.call_args.kwargs["renderer"] == "auto"
+
+
+@pytest.mark.parametrize("mode", ["auto", "gpu", "cpu"])
+def test_run_forwards_renderer(app, mode):
+    with patch("nuiitivet.backends.pyglet.runner.run_app") as run_app:
+        app.run(renderer=mode)
+    assert run_app.call_args.kwargs["renderer"] == mode
+
+
+def test_run_validates_renderer_before_launch(app):
+    with patch("nuiitivet.backends.pyglet.runner.run_app") as run_app:
+        with pytest.raises(ValueError):
+            app.run(renderer="metal")  # type: ignore[arg-type]
+    run_app.assert_not_called()


### PR DESCRIPTION
## Summary
- Add a typed, discoverable renderer-selection API: `App.run(renderer=...)` with `RendererMode = Literal["auto", "gpu", "cpu"]` (exposed as `nv.RendererMode`), replacing the lost env-var switch.
- `"auto"` (default): GPU with silent raster fallback — matches the previous implicit behavior, no breaking change.
- `"gpu"`: require GPU; log an error and raise `RuntimeError` on init failure or a per-frame GPU draw failure.
- `"cpu"`: always render in software/raster; the GPU is never touched.
- Log a clear error and re-raise when window creation fails (true headless), guiding users to `render_to_png`.
- Docs guide (`docs/guide/renderer_selection.md`, linked under Window in mkdocs), a sample (`samples/renderer_selection/`), and tests.

Design discussion and decisions are recorded in #285 (surface = `run()` arg, no env var, `"gpu"` is strict).

## Test plan
- [x] `pytest tests/runtime/test_renderer_selection.py` (10 passed)
- [x] `pytest tests/runtime tests/rendering` — no regressions (84 passed)
- [x] `mypy` clean on changed source files
- [x] Sample renders to PNG via `render_to_png`
- [ ] Manual: `python samples/renderer_selection/cpu_rendering.py cpu` shows a window with `renderer = 'cpu'`

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)