### PR TITLE
docs: fix requirements and document known limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Logic → UI declaratively, UI → logic imperatively. What matters in both dire
 ### 2.1. Requirements
 
 - Python 3.10 or higher
-- macOS / Windows / Linux(not tested)
+- macOS / Windows / Linux
 
 Main internal libraries used (drawing/rendering):
 
@@ -285,6 +285,18 @@ Browse runnable examples in **[samples/](samples/)** — every snippet in this R
 | [Async & Threading](docs/guide/threading.md) | Safe UI updates from background work. |
 | [Packaging](docs/guide/packaging.md) | Ship your app to users. |
 
-## 4. License
+## 4. Known Limitations
+
+- **No OS accessibility integration.** Everything is drawn with Skia, so the app
+  does not participate in the OS accessibility tree — screen readers and
+  VoiceOver cannot inspect the UI. This is a real constraint for domains that
+  require assistive-technology support.
+- **Requires an OpenGL/GPU context.** Live rendering goes through pyglet +
+  PyOpenGL + skia and needs an OpenGL/GPU context, which has implications for
+  headless, remote, and old-GPU environments. For GPU-less or software-OpenGL
+  setups you can select a CPU/raster renderer — see
+  [Renderer Selection](docs/guide/renderer_selection.md).
+
+## 5. License
 
 Nuiitivet is licensed under the Apache License 2.0. See the LICENSE file for more info.

--- a/docs/guide/renderer_selection.md
+++ b/docs/guide/renderer_selection.md
@@ -42,12 +42,8 @@ slowly — a case that cannot be detected automatically.
 
 `App.run()` always needs a display: it opens an OS window. **Truly headless
 environments (no display at all) cannot use `run()` in any mode** — window
-creation fails and a clear error is logged. To render without a display, use
-offscreen rendering, which is always software-based:
-
-```python
-app.render_to_png("out.png")
-```
+creation fails and a clear error is logged. Nuiitivet is a GUI framework, so
+running without a display is not supported.
 
 ## Logging
 


### PR DESCRIPTION
## Summary
- Mark Linux as supported in Requirements (drop the "not tested" note)
- Add a top-level "Known Limitations" section: no OS accessibility
  integration (Skia-drawn, no screen reader / VoiceOver), and the
  OpenGL/GPU context requirement, cross-linked to the renderer selection
  guide for CPU/raster mode
- Drop the `render_to_png` "headless workaround" from the renderer guide;
  `run()` is a GUI path and does not support display-less environments

Closes #284

## Test plan
- [ ] Rendered README shows the corrected Requirements and a "4. Known Limitations" section
- [ ] Cross-link to `docs/guide/renderer_selection.md` resolves
- [ ] Renderer guide no longer suggests `render_to_png` for headless