### PR TITLE
refactor(material): narrow MaterialOverlay helper input surface (#291)

### DIFF
--- a/docs/guide/material_overlay.md
+++ b/docs/guide/material_overlay.md
@@ -76,9 +76,10 @@ overlay.dialog(
 
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
-| `dialog` | `Widget \| Route \| Any` | required | Dialog widget, route, or intent |
+| `dialog` | `Widget \| Any` | required | Dialog widget, or an intent resolved by the overlay |
 | `dismiss_on_outside_tap` | `bool` | `True` | Dismiss when tapping the scrim |
-| `timeout` | `float \| None` | `None` | Auto-dismiss after seconds |
+
+For a fully custom `Route` (non-standard transition or barrier), call `show_modal()` directly. Dialogs do not auto-dismiss, so there is no `timeout` parameter.
 
 ## Snackbar
 
@@ -98,14 +99,14 @@ overlay.snackbar(Snackbar("Upload complete"))
 
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
-| `message` | `str \| Snackbar \| OverlayRoute` | required | Message text, widget, or route |
+| `message` | `str \| Snackbar` | required | Message text or a `Snackbar` widget |
 | `duration` | `float` | `3.0` | Display duration in seconds |
 
 ![Snackbar](../assets/material_overlay_snackbar.png)
 
 ## Side Sheet
 
-Displays a modal sheet that slides in from a side edge. The `side` parameter on `SideSheet` is the single source of truth for three things at once: the slide direction of the transition, the screen-edge alignment, and which corners are rounded. Keeping these in sync is the reason `side_sheet()` accepts only a `SideSheet` widget rather than an arbitrary `OverlayRoute`.
+Displays a modal sheet that slides in from a side edge. The slide-in edge is a placement concern owned by `side_sheet()`: the `side` argument drives three things at once — the slide direction of the transition, the screen-edge alignment, and which (inner, away-from-edge) corners are rounded. The corner rounding is applied by `side_sheet()` via the `corner_radius` modifier, so the `SideSheet` widget itself renders a square container and no longer takes a `side` parameter.
 
 ```python
 from nuiitivet.material import SideSheet, Text
@@ -114,14 +115,15 @@ overlay.side_sheet(
     SideSheet(
         headline="Settings",
         content=Text("Sheet content here"),
-        side="right",
-    )
+    ),
+    side="right",
 )
 ```
 
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
 | `sheet` | `SideSheet` | required | Side sheet widget |
+| `side` | `"right" \| "left"` | `"right"` | Edge the sheet slides in from |
 | `dismiss_on_outside_tap` | `bool` | `True` | Dismiss when tapping the scrim |
 
 ![Side Sheet](../assets/material_overlay_side_sheet.png)
@@ -190,9 +192,9 @@ Each shortcut applies a pre-configured MD3 transition automatically. All transit
 | `side_sheet` | Slide in from side edge | Slide out to side edge | Fades with content |
 | `loading` | Instant | Instant | None |
 
-For `dialog()`, `snackbar()`, and `loading()`, pass an `OverlayRoute(transition_spec=...)` directly — each shortcut accepts `OverlayRoute` and uses it as-is.
+These shortcuts accept only their typed arguments — a `Widget` (or intent) for `dialog()`/`loading()`, `str`/`Snackbar` for `snackbar()`, and the corresponding sheet widget for `bottom_sheet()`/`side_sheet()`. They do not accept a free-form `Route`/`OverlayRoute`, because each shortcut owns the MD3 transition, screen-edge position, and (for sheets) corner radii, and accepting an arbitrary route would break that consistency. `bottom_sheet()` derives everything from the fact that it is a bottom sheet; `side_sheet()` derives it from its `side` argument.
 
-`bottom_sheet()` and `side_sheet()` intentionally accept only their typed widget arguments. For sheets, the transition direction, screen-edge position, and corner radii must all stay consistent with each other; the shortcut derives all three from the widget's own properties (`BottomSheet` always slides from the bottom, `SideSheet.side` drives everything for side sheets). Accepting a free-form `OverlayRoute` would break that consistency, so these shortcuts do not support it. To display a fully custom sheet with a non-standard transition, call `show_modal` directly.
+To display fully custom overlay content with a non-standard transition or barrier, call `show_modal()` / `show_modeless()` directly.
 
 ## Intent System
 

--- a/samples/material_overlay/side_sheet.py
+++ b/samples/material_overlay/side_sheet.py
@@ -66,6 +66,8 @@ def main(png_path: str = "") -> nv.App:
             alignment="top-right",
             width="100%",
             height="100%",
+            # Corner rounding is applied by MaterialOverlay.side_sheet() at
+            # display time; this static preview mimics it for a right-side sheet.
             child=nv.SideSheet(
                 nv.Box(
                     nv.Column(
@@ -81,7 +83,7 @@ def main(png_path: str = "") -> nv.App:
                     padding=24,
                 ),
                 headline="Settings",
-            ),
+            ).modifier(nv.corner_radius((16.0, 0.0, 0.0, 16.0))),
         )
         app = nv.App(
             content=nv.Stack(width=640, height=400, children=[background, scrim, sheet_overlay]),

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -16,6 +16,7 @@ from nuiitivet.overlay import Overlay
 from nuiitivet.overlay.intent_resolver import IntentResolver
 from nuiitivet.overlay.overlay_handle import OverlayHandle
 from nuiitivet.overlay.overlay_position import OverlayPosition
+from nuiitivet.modifiers.corner_radius import corner_radius
 from nuiitivet.widgeting.widget import Widget
 from .overlay_visual_state import MaterialOverlayLayerComposer
 from .sheet import BottomSheet, SideSheet
@@ -64,7 +65,7 @@ class WhileLoading(AbstractContextManager[None], AbstractAsyncContextManager[Non
             await fetch_data()
     """
 
-    def __init__(self, overlay: "MaterialOverlay", indicator: Widget | Route | Any | None) -> None:
+    def __init__(self, overlay: "MaterialOverlay", indicator: Widget | Any | None) -> None:
         self._overlay = overlay
         self._indicator = indicator
         self._handle: OverlayHandle[Any] | None = None
@@ -153,37 +154,48 @@ class MaterialOverlay(Overlay):
 
     def dialog(
         self,
-        dialog: Widget | Route | Any,
+        dialog: Widget | Any,
         *,
-        dismiss_on_outside_tap: bool | None = None,
-        timeout: float | None = None,
+        dismiss_on_outside_tap: bool = True,
     ) -> OverlayHandle[Any]:
-        if dismiss_on_outside_tap is None:
-            dismiss_on_outside_tap = True
+        """Display a modal Material dialog.
 
+        Args:
+            dialog: A :class:`Widget` to display as the dialog, or an intent
+                resolved by the overlay's intent resolver (e.g.
+                :class:`BasicDialogIntent`). To present a fully custom
+                :class:`Route`, call :meth:`show_modal` directly.
+            dismiss_on_outside_tap: Whether tapping the scrim dismisses the
+                dialog. Defaults to ``True``.
+
+        Returns:
+            An :class:`OverlayHandle` for manual dismissal.
+        """
         route = self._normalize_dialog_to_route(
             dialog,
-            dismiss_on_outside_tap=bool(dismiss_on_outside_tap),
+            dismiss_on_outside_tap=dismiss_on_outside_tap,
         )
 
         return self.show_modal(
             route,
-            dismiss_on_outside_tap=bool(dismiss_on_outside_tap),
-            timeout=timeout,
+            dismiss_on_outside_tap=dismiss_on_outside_tap,
         )
 
     def _normalize_dialog_to_route(
         self,
-        dialog: Widget | Route | Any,
+        dialog: Widget | Any,
         *,
         dismiss_on_outside_tap: bool,
     ) -> Route:
         """Normalize dialog input to a Route.
 
         This is the single boundary adapter for `dialog(...)` input polymorphism.
+        A :class:`Widget` is presented directly; any other value is resolved
+        through the intent resolver, which may yield a :class:`Widget` or a
+        :class:`Route`.
         """
         resolved: Widget | Route
-        if isinstance(dialog, (Widget, Route)):
+        if isinstance(dialog, Widget):
             resolved = dialog
         else:
             resolved = self._intent_resolver.resolve(dialog)
@@ -200,17 +212,19 @@ class MaterialOverlay(Overlay):
 
     def snackbar(
         self,
-        message: str | Snackbar | OverlayRoute,
+        message: str | Snackbar,
         *,
         duration: float = 3.0,
     ) -> OverlayHandle[None]:
-        if isinstance(message, OverlayRoute):
-            route: Route = message
-            return self.show_modeless(
-                route,
-                timeout=float(duration),
-                position=OverlayPosition.alignment("bottom-center", offset=(0.0, -24.0)),
-            )
+        """Display a brief, non-blocking Material snackbar.
+
+        Args:
+            message: The message text, or a pre-built :class:`Snackbar` widget.
+            duration: Seconds before the snackbar auto-dismisses. Defaults to ``3.0``.
+
+        Returns:
+            An :class:`OverlayHandle` for the shown snackbar.
+        """
         widget: Widget = message if isinstance(message, Snackbar) else Snackbar(str(message))
         return self.show_modeless(
             widget,
@@ -221,20 +235,22 @@ class MaterialOverlay(Overlay):
 
     def loading(
         self,
-        indicator: Widget | Route | Any | None = None,
+        indicator: Widget | Any | None = None,
     ) -> OverlayHandle[Any]:
         """Show a loading indicator overlay and return a handle for manual dismissal.
 
         Args:
-            indicator: Widget, Route, or intent to display as the loading indicator.
-                Defaults to the built-in :class:`LoadingIndicator`.
+            indicator: Widget or intent to display as the loading indicator.
+                Defaults to the built-in :class:`LoadingIndicator`, resolved
+                through the :class:`LoadingIntent` (overridable via the app's
+                ``overlay_routes``).
 
         Returns:
             An :class:`OverlayHandle` that can be closed via ``handle.close(None)``.
         """
         if indicator is None:
             resolved: Widget | Route = self._intent_resolver.resolve(LoadingIntent())
-        elif isinstance(indicator, (Widget, Route)):
+        elif isinstance(indicator, Widget):
             resolved = indicator
         else:
             resolved = self._intent_resolver.resolve(indicator)
@@ -246,7 +262,7 @@ class MaterialOverlay(Overlay):
 
     def while_loading(
         self,
-        indicator: Widget | Route | Any | None = None,
+        indicator: Widget | Any | None = None,
     ) -> WhileLoading:
         """Return a context manager that shows a loading indicator for the duration of a block.
 
@@ -261,11 +277,11 @@ class MaterialOverlay(Overlay):
         Internally delegates show/close to :meth:`loading`.
 
         Args:
-            indicator: Widget, Route, or intent to display as the loading indicator.
+            indicator: Widget or intent to display as the loading indicator.
                 Defaults to the built-in :class:`LoadingIndicator`.
 
         Returns:
-            A :class:`LoadingScope` context manager that shows the indicator on entry and closes it on exit.
+            A :class:`WhileLoading` context manager that shows the indicator on entry and closes it on exit.
         """
         return WhileLoading(self, indicator)
 
@@ -273,29 +289,40 @@ class MaterialOverlay(Overlay):
         self,
         sheet: Widget,
         *,
+        side: Literal["right", "left"] = "right",
         dismiss_on_outside_tap: bool = True,
     ) -> OverlayHandle[Any]:
         """Display a modal side sheet.
 
-        The sheet's position, corner radii, and transition direction are derived
-        from ``sheet.side``.  Visual styling (background, size, corner radius) is
-        fully owned by the :class:`SideSheet` widget.
+        The slide-in edge is a placement concern owned by this method: ``side``
+        controls the sheet's alignment, transition direction, and which (inner,
+        away-from-edge) corners are rounded.  The corner rounding is applied here
+        via the :func:`corner_radius` modifier, using the radius from
+        ``SideSheet.style``; the :class:`SideSheet` widget itself renders a
+        square container.
 
         Args:
             sheet: SideSheet widget (or a wrapper such as one produced by
                 ``.modifier(will_pop(...))``) that defines content, headline,
                 and styling.
+            side: Edge the sheet slides in from (``"right"`` or ``"left"``).
+                Defaults to ``"right"``.
             dismiss_on_outside_tap: Whether tapping the scrim dismisses the sheet.
                 Defaults to ``True``.
         """
         inner = _find_descendant(sheet, SideSheet)
         if inner is None:
             raise TypeError("side_sheet() requires a SideSheet widget (possibly wrapped by modifiers)")
-        alignment = "top-right" if inner.side == "right" else "top-left"
+
+        cr = float(inner.style.corner_radius)
+        # Round only the inner (away-from-edge) corners: (tl, tr, br, bl).
+        radius = (cr, 0.0, 0.0, cr) if side == "right" else (0.0, cr, cr, 0.0)
+        presented = sheet.modifier(corner_radius(radius))
+        alignment = "top-right" if side == "right" else "top-left"
 
         route = OverlayRoute(
-            builder=lambda: sheet,
-            transition_spec=MaterialTransitions.side_sheet(side=inner.side),
+            builder=lambda: presented,
+            transition_spec=MaterialTransitions.side_sheet(side=side),
             barrier_dismissible=bool(dismiss_on_outside_tap),
         )
 

--- a/src/nuiitivet/material/sheet.py
+++ b/src/nuiitivet/material/sheet.py
@@ -47,11 +47,12 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
             .modifier(will_pop(on_will_pop=lambda: not has_unsaved_changes))
         )
 
+    The slide-in edge and corner rounding are owned by
+    ``MaterialOverlay.side_sheet(sheet, side=...)``, not by this widget.
+
     Args:
         content: Widget to display below the header.
         headline: Header title text (str or Observable[str]). Required by M3.
-        side: Edge the sheet slides in from (``"right"`` or ``"left"``).
-            Defaults to ``"right"``.
         on_back: Callback invoked when the Back icon button is pressed.
             Back button visibility is controlled separately by *show_back_button*.
         show_back_button: Whether to show the Back icon button.
@@ -67,7 +68,6 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
         content: Widget,
         *,
         headline: Union[str, ReadOnlyObservableProtocol[str]],
-        side: Literal["right", "left"] = "right",
         on_back: Optional[Callable[[], None]] = None,
         show_back_button: Union[bool, ReadOnlyObservableProtocol[bool]] = False,
         style: Optional[SideSheetStyle] = None,
@@ -77,7 +77,6 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
         Args:
             content: Widget to display below the header.
             headline: Header title text (str or Observable[str]).
-            side: Edge the sheet slides in from. Defaults to ``"right"``.
             on_back: Callback for the Back icon button press.
             show_back_button: Back button visibility (bool or Observable[bool]).
                 Defaults to ``False``. Rendered only when truthy **and** *on_back*
@@ -85,10 +84,9 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
             style: Container style. Defaults to :class:`SideSheetStyle`.
         """
         _style = style if style is not None else SideSheetStyle()
-        super().__init__(height=_style.height)
+        super().__init__(width=_style.width, height=_style.height)
         self._content = content
         self._headline = headline
-        self.side = side
         self._on_back = on_back
         self._show_back_button = show_back_button
         self._user_style = style
@@ -151,13 +149,9 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
             cross_alignment="center",
         )
 
-        # Apply per-corner radius: round only the inner (away-from-edge) corners.
-        cr = float(resolved_style.corner_radius)
-        if self.side == "right":
-            corner_radius = (cr, 0.0, 0.0, cr)  # tl, tr, br, bl
-        else:
-            corner_radius = (0.0, cr, cr, 0.0)  # tl, tr, br, bl
-
+        # Corner rounding is applied by ``MaterialOverlay.side_sheet()`` via the
+        # ``corner_radius`` modifier (it depends on the slide-in edge, which this
+        # widget does not know).  The container itself is square.
         return Box(
             Column(
                 [header, self._content],
@@ -165,7 +159,6 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
             ),
             width=resolved_style.width,
             height=resolved_style.height,
-            corner_radius=corner_radius,
             background_color=resolved_style.background_color,
             alignment="top-left",
         )

--- a/src/nuiitivet/widgets/box.py
+++ b/src/nuiitivet/widgets/box.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 import logging
 from typing import TYPE_CHECKING, Callable, Optional, Tuple, Union
@@ -491,3 +492,27 @@ class ModifierBox(Box):
                 self.cross_align = child.cross_align
             except Exception:
                 exception_once(_logger, "modifier_box_cross_align_copy_exc", "Failed to copy child.cross_align")
+
+    async def handle_back_event(self) -> bool:
+        """Forward back events to the wrapped child.
+
+        ``ModifierBox`` is a purely decorative wrapper, so it must be transparent
+        to the back-event pipeline; otherwise a ``will_pop`` scope nested below a
+        modifier (e.g. ``.modifier(corner_radius(...))``) would be silently
+        bypassed. Returns ``True`` (proceed) when the child cannot intercept.
+        """
+        child = self.children[0] if self.children else None
+        if child is None:
+            return True
+        handler = getattr(child, "handle_back_event", None)
+        if not callable(handler):
+            return True
+        try:
+            result = handler()
+            if inspect.isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception:
+            # Fail open to avoid trapping navigation.
+            exception_once(_logger, "modifier_box_handle_back_exc", "Child handle_back_event raised")
+            return True

--- a/tests/material/test_side_sheet.py
+++ b/tests/material/test_side_sheet.py
@@ -84,7 +84,6 @@ def test_side_sheet_defaults():
     """SideSheet stores headline and defaults correctly."""
     content = Box(width=100, height=100)
     sheet = SideSheet(content, headline="Settings")
-    assert sheet.side == "right"
     assert sheet._headline == "Settings"
     assert sheet._on_back is None
 
@@ -102,28 +101,6 @@ def test_side_sheet_style_property_custom():
     assert sheet.style is custom
 
 
-def test_side_sheet_left_side():
-    """SideSheet stores side='left' correctly."""
-    sheet = SideSheet(Box(), headline="Nav", side="left")
-    assert sheet.side == "left"
-
-
-def test_side_sheet_right_corner_radius():
-    """Right-side sheet applies left (inner) corner radius only."""
-    style = SideSheetStyle(corner_radius=16.0)
-    cr = style.corner_radius
-    corner_radius = (cr, 0.0, 0.0, cr)  # tl, tr, br, bl
-    assert corner_radius == (16.0, 0.0, 0.0, 16.0)
-
-
-def test_side_sheet_left_corner_radius():
-    """Left-side sheet applies right (inner) corner radius only."""
-    style = SideSheetStyle(corner_radius=16.0)
-    cr = style.corner_radius
-    corner_radius = (0.0, cr, cr, 0.0)  # tl, tr, br, bl
-    assert corner_radius == (0.0, 16.0, 16.0, 0.0)
-
-
 def test_side_sheet_build_returns_box():
     """SideSheet.build() returns a Box as the outer container."""
     content = Box(width=200, height=100)
@@ -132,22 +109,71 @@ def test_side_sheet_build_returns_box():
     assert isinstance(built, Box)
 
 
-def test_side_sheet_build_right_corner_radius():
-    """SideSheet.build() applies correct corner radii for right side."""
-    sheet = SideSheet(Box(), headline="Settings", side="right", style=SideSheetStyle(corner_radius=16.0))
+def test_side_sheet_build_is_square():
+    """SideSheet.build() no longer rounds corners itself — rounding is owned by
+    MaterialOverlay.side_sheet(). The container Box is square."""
+    sheet = SideSheet(Box(), headline="Settings", style=SideSheetStyle(corner_radius=16.0))
     built = sheet.build()
     assert isinstance(built, Box)
-    cr = 16.0
-    assert built.corner_radius == (cr, 0.0, 0.0, cr)
+    assert built.corner_radius == 0
 
 
-def test_side_sheet_build_left_corner_radius():
-    """SideSheet.build() applies correct corner radii for left side."""
-    sheet = SideSheet(Box(), headline="Nav", side="left", style=SideSheetStyle(corner_radius=16.0))
-    built = sheet.build()
-    assert isinstance(built, Box)
-    cr = 16.0
-    assert built.corner_radius == (0.0, cr, cr, 0.0)
+def _find_box_with_corner_radius(widget, radius):
+    """Depth-first search for a Box whose corner_radius equals *radius*."""
+    if isinstance(widget, Box) and widget.corner_radius == radius:
+        return widget
+    for child in widget.children:
+        found = _find_box_with_corner_radius(child, radius)
+        if found is not None:
+            return found
+    return None
+
+
+def _side_sheet_overlay():
+    from nuiitivet.material.overlay import MaterialOverlay
+    from nuiitivet.overlay import Overlay
+    from nuiitivet.runtime.app import App
+
+    App(content=Box())
+    overlay = MaterialOverlay(intents={})
+    Overlay.set_root(overlay)
+    return overlay
+
+
+def _presented_content(overlay):
+    """Return the built content widget of the overlay's topmost entry."""
+    entry = overlay._top_entry()
+    return overlay._entry_content_widget(entry)
+
+
+def test_side_sheet_right_corner_radius_applied():
+    """side_sheet(side='right') rounds only the inner (left) corners."""
+    from nuiitivet.overlay import Overlay
+
+    overlay = _side_sheet_overlay()
+    try:
+        sheet = SideSheet(Box(), headline="Settings", style=SideSheetStyle(corner_radius=16.0))
+        overlay.side_sheet(sheet, side="right")
+        rounded = _find_box_with_corner_radius(_presented_content(overlay), (16.0, 0.0, 0.0, 16.0))
+        assert rounded is not None
+        assert rounded.clip_content is True
+    finally:
+        Overlay._root_overlay = None
+
+
+def test_side_sheet_left_corner_radius_applied():
+    """side_sheet(side='left') rounds only the inner (right) corners."""
+    from nuiitivet.overlay import Overlay
+
+    overlay = _side_sheet_overlay()
+    try:
+        sheet = SideSheet(Box(), headline="Nav", style=SideSheetStyle(corner_radius=16.0))
+        overlay.side_sheet(sheet, side="left")
+        rounded = _find_box_with_corner_radius(_presented_content(overlay), (0.0, 16.0, 16.0, 0.0))
+        assert rounded is not None
+        assert rounded.clip_content is True
+    finally:
+        Overlay._root_overlay = None
 
 
 def test_side_sheet_build_width_height():

--- a/tests/overlay/test_overlay_intent_and_loading.py
+++ b/tests/overlay/test_overlay_intent_and_loading.py
@@ -67,16 +67,14 @@ def test_material_overlay_dialog_accepts_widget_without_manual_dialog_route() ->
     assert overlay.has_entries() is True
 
 
-def test_material_overlay_dialog_accepts_custom_route_without_wrapping() -> None:
+def test_material_overlay_dialog_rejects_directly_passed_route() -> None:
+    """dialog() no longer accepts a Route directly; a Route is treated as an
+    unknown intent. Callers needing a custom Route should use show_modal()."""
     overlay = MaterialOverlay(intents={})
     route = OverlayRoute(builder=lambda: BasicDialog(title="Custom route"), barrier_dismissible=False)
 
-    normalized = overlay._normalize_dialog_to_route(route, dismiss_on_outside_tap=False)
-
-    assert normalized is route
-
-    overlay.dialog(route, dismiss_on_outside_tap=False)
-    assert overlay.has_entries() is True
+    with pytest.raises(RuntimeError, match=r"No overlay intent is registered: OverlayRoute"):
+        overlay.dialog(route, dismiss_on_outside_tap=False)
 
 
 def test_overlay_loading_returns_handle() -> None:

--- a/tests/overlay/test_overlay_will_pop.py
+++ b/tests/overlay/test_overlay_will_pop.py
@@ -132,8 +132,8 @@ async def test_material_overlay_side_sheet_accepts_wrapped_widget() -> None:
     overlay = MaterialOverlay(intents={})
     Overlay.set_root(overlay)
     try:
-        sheet = SideSheet(Container(width=10, height=10), headline="X", side="left")
-        handle = overlay.side_sheet(sheet.modifier(will_pop(on_will_pop=lambda: True)))
+        sheet = SideSheet(Container(width=10, height=10), headline="X")
+        handle = overlay.side_sheet(sheet.modifier(will_pop(on_will_pop=lambda: True)), side="left")
         assert handle is not None
         assert overlay.has_entries() is True
     finally:


### PR DESCRIPTION
## Summary
- `dialog()`: accept `Widget | Intent` only — drop `Route` and the `timeout` param (MD3 dialogs don't auto-dismiss); use `show_modal()` for custom routes
- `snackbar()`: accept `str | Snackbar` only — drop `OverlayRoute`
- `loading()` / `while_loading()`: accept `Widget | Intent | None` — drop `Route`; `None` still resolves `LoadingIntent` (app-level default stays overridable)
- `side_sheet()`: add `side="right"|"left"` at the call site and remove `side` from `SideSheet`; corner rounding is now owned by `side_sheet()` via the `corner_radius()` modifier, and `SideSheet.build()` returns a square Box (forwarding its width to the base widget)
- `ModifierBox`: forward `handle_back_event` to its child — fixes a latent bug where a `will_pop` scope nested under a modifier (e.g. `corner_radius`) was silently bypassed
- Intent system and `StandardSideSheet` unchanged; docs, sample, and tests updated

Closes #291

## Test plan
- [ ] `pytest tests/` — all pass (1487)
- [ ] `mypy src/nuiitivet` — clean
- [ ] `dialog()` rejects a directly-passed `Route`; intent path still works
- [ ] `side_sheet(sheet, side="right"|"left")` rounds the correct inner corners
- [ ] `will_pop` nested under a `corner_radius` modifier still intercepts dismissal
- [ ] side_sheet sample renders (static PNG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)