### PR TITLE
docs: add Advanced guide group and split threading docs by altitude

### DIFF
--- a/docs/guide/observable/operators.md
+++ b/docs/guide/observable/operators.md
@@ -84,6 +84,33 @@ display = Observable.compute(lambda: (
 ))
 ```
 
+## Keep Transformations Pure
+
+The function you pass to `.map()` / `.compute()` should be a pure transformation:
+derive a value from the observable inputs and return it, with no side effects.
+These functions re-run whenever a dependency changes (and may be deferred to a
+later frame), so side effects performed inside them — mutating other observables,
+driving widgets — fire unpredictably.
+
+Return the derived value and bind it where you need it (for example, pass the
+resulting observable straight to a widget) instead of updating state from inside
+the transform.
+
+```python
+# ❌ bad: the transform mutates a separate observable as a side effect
+label = Observable("")
+Text(label)
+
+def update_label(c):
+    label.value = f"Count: {c}"  # side effect, not a returned value
+
+count.map(update_label)  # the mapped result is unused
+
+# ✅ good: the transform returns a value; bind the widget to it
+count_label = count.map(lambda c: f"Count: {c}")
+Text(count_label)
+```
+
 ## Performance Note
 
 - `.map()` and `.combine()` internally leverage compute-like mechanisms.

--- a/docs/guide/observable/thread-safety.md
+++ b/docs/guide/observable/thread-safety.md
@@ -16,7 +16,9 @@ viewmodel.data.value = result
 
 ## Solution: `.dispatch_to_ui()`
 
-Use `.dispatch_to_ui()` for observables that drive UI rendering.
+Use `.dispatch_to_ui()` for observables that drive UI rendering. Once enabled,
+notifications are marshalled onto the UI thread, so subscribers can safely touch
+widgets even when the value was set from a background thread.
 
 ```python
 import threading
@@ -54,20 +56,21 @@ total = (
 )
 ```
 
-## Important Constraints
+## Rapid Updates Are Coalesced
 
-Inside compute/mapping functions:
+When `.dispatch_to_ui()` is enabled, rapid updates from a background thread are
+automatically coalesced: if the worker produces values faster than the UI can
+process them, subscribers only receive the latest value on the next frame. This
+keeps a busy worker from flooding the UI event loop, but it also means
+intermediate values are dropped rather than queued — subscribers may not observe
+every value the worker sets (e.g. a progress counter can skip numbers).
 
-- ✅ use observable values
-- ❌ avoid direct UI widget access
+## Testing
 
-```python
-# good
-text = count.map(lambda c: f"Count: {c}")
-
-# then update widgets in subscribe callbacks
-text.subscribe(lambda value: set_label_text(value))
-```
+To test code that relies on `.dispatch_to_ui()`, you need to control when the
+queued UI notifications are delivered. Use the `mock_clock` fixture (if your test
+suite provides one) or mock `pyglet.clock.schedule_once` so you can drive the
+dispatch deterministically instead of waiting on a real frame.
 
 ---
 

--- a/docs/guide/threading.md
+++ b/docs/guide/threading.md
@@ -17,50 +17,13 @@ This includes:
 - Layout and Paint operations
 - Mounting and Unmounting widgets
 
-Violating this rule will raise a `RuntimeError` in debug mode.
+Violating this rule raises a `RuntimeError` in debug mode. The rule applies to
+*every* path into the UI — not only Observables, but also asyncio callbacks, raw
+`threading.Thread` workers, and anything scheduled outside the main loop.
 
 ## Working with Background Threads
 
-You can perform expensive operations (network requests, heavy computation) on background threads. However, you must be careful when updating the UI with the results.
-
-### Using Observables
-
-The recommended way to communicate from a background thread to the UI thread is using `Observable` with `dispatch_to_ui()`.
-
-```python
-import threading
-import time
-import nuiitivet as nv
-
-class MyState:
-    def __init__(self):
-        # Define an observable and enable UI dispatching
-        self.progress = nv.Observable(0.0).dispatch_to_ui()
-
-    def start_work(self):
-        threading.Thread(target=self._worker).start()
-
-    def _worker(self):
-        for i in range(101):
-            time.sleep(0.1)
-            # Safe to update from background thread
-            # The framework will coalesce updates and dispatch to UI thread
-            self.progress.value = i / 100.0
-```
-
-### Coalescing
-
-When `dispatch_to_ui()` is enabled, rapid updates from a background thread are automatically coalesced. If the worker thread produces updates faster than the UI can process them, the UI will only receive the latest value when it's ready to process the next frame. This prevents the UI event loop from being flooded.
-
-### Computed Observables
-
-`ComputedObservable` also supports `dispatch_to_ui()`. If a computed observable depends on values that change on background threads, you can enable dispatching on the computed observable to ensure its subscribers (usually UI widgets) are notified on the UI thread.
-
-```python
-# If 'raw_data' updates on background thread
-processed_data = raw_data.map(lambda d: process(d)).dispatch_to_ui()
-```
-
-## Testing
-
-For testing code that involves threading and `dispatch_to_ui`, you can use the `mock_clock` fixture (if available in your test suite) or mock `pyglet.clock.schedule_once` to control when UI events are processed.
+You can run expensive work (network requests, heavy computation) on background
+threads, but the results must reach the UI on the main thread. The framework
+provides `Observable.dispatch_to_ui()` as the supported bridge for this; see the
+[Observable: Thread Safety](observable/thread-safety.md) guide for how to use it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,10 +181,9 @@ nav:
           - Material Widgets: guide/material_widgets.md
           - Theme Extensions: guide/theme_extensions.md
           - Font Configuration: guide/font_configuration.md
-      - Async & Threading:
-          - guide/threading.md
-      - Interaction:
-          - guide/interaction_region.md
+      - Advanced:
+          - Threading Model: guide/threading.md
+          - Interaction Region: guide/interaction_region.md
       - Packaging:
           - guide/packaging.md
   - API Reference:


### PR DESCRIPTION
## Summary
- Group the standalone **Threading Model** and **Interaction Region** pages under a new **Advanced** nav section (removes two lonely single-item sections).
- Split the two overlapping threading docs by altitude:
  - `observable/thread-safety.md` (State Management) owns the `dispatch_to_ui()` how-to, coalescing behavior, and testing guidance.
  - `guide/threading.md` (Advanced) is trimmed to the framework-level threading model (the main-thread Golden Rule) and delegates usage to the thread-safety guide via a single one-way link.
- Remove the mutual cross-links between the two pages, keeping only one Advanced → how-to pointer.
- Move the "keep transformations pure" guidance out of thread-safety (an operators concern, not threading) into `operators.md`, with a corrected example using the public `Text` / `Observable` API.

## Test plan
- [ ] `uv run --group docs mkdocs build` completes with no new warnings
- [ ] Guide nav shows a single **Advanced** group (Threading Model, Interaction Region); no leftover "Async & Threading" / "Interaction" sections
- [ ] No dangling links/anchors (`#coalescing`, `#important-constraints` removed cleanly)

Refs #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)