### PR TITLE
feat(material): embed Collapsible into StandardSideSheet and rework its open/close API

### DIFF
--- a/docs/guide/design-system/material_widgets.md
+++ b/docs/guide/design-system/material_widgets.md
@@ -233,20 +233,30 @@ API References: [Tooltip](../../api/material.md#nuiitivet.material.Tooltip) ・ 
 
 ## StandardSideSheet
 
-Docked side panel that sits beside the main content area. Unlike the modal `SideSheet`, it is a permanent part of the layout. Wrap it in `Collapsible` (with `axis="horizontal"`) to animate it open and closed without any additional API on the sheet itself.
+Docked side panel that sits beside the main content area. Unlike the modal `SideSheet`, it is a permanent part of the layout. Pass a writable `Observable[bool]` as `opened` and the sheet animates its own width open and closed, staying mounted throughout.
 
 ```python
-Collapsible(
-    StandardSideSheet(
-        panel_content,
-        headline="Filters",
-        on_close=vm.close_panel,
-    ),
-    opened=vm.panel_open,
-    axis="horizontal",
-    alignment="top_right",
-)
+opened: Observable[bool] = Observable(True)
+
+Row([
+    main_content,
+    StandardSideSheet(panel_content, headline="Filters", opened=opened),
+])
 ```
+
+The close icon button writes `opened.value = False` by default. Pass `on_close_click` to intercept the press instead — the callback **replaces** the default, so updating `opened` becomes your responsibility:
+
+```python
+def confirm_close() -> None:
+    if vm.has_unsaved_changes:
+        vm.show_confirm_dialog()
+    else:
+        opened.value = False
+
+StandardSideSheet(panel_content, opened=opened, on_close_click=confirm_close)
+```
+
+With a literal `opened=True` and no `on_close_click`, no close button is rendered: a press would have nothing to act on.
 
 ![StandardSideSheet](../../assets/material_widgets_standard_side_sheet.png)
 

--- a/samples/design-system/material_widgets/standard_side_sheet.py
+++ b/samples/design-system/material_widgets/standard_side_sheet.py
@@ -1,4 +1,4 @@
-"""Material Widgets - StandardSideSheet with Collapsible open/close."""
+"""Material Widgets - StandardSideSheet open/close."""
 
 from __future__ import annotations
 
@@ -14,24 +14,19 @@ class StandardSideSheetDemo(nv.ComposableWidget):
         self.opened.value = not self.opened.value
 
     def build(self) -> nv.Widget:
-        sheet = nv.Collapsible(
-            nv.StandardSideSheet(
-                nv.Column(
-                    padding=16,
-                    gap=12,
-                    width="100%",
-                    children=[
-                        nv.Text("Option A"),
-                        nv.Text("Option B"),
-                        nv.Text("Option C"),
-                    ],
-                ),
-                headline="Filters",
-                on_close=self.toggle,
+        sheet = nv.StandardSideSheet(
+            nv.Column(
+                padding=16,
+                gap=12,
+                width="100%",
+                children=[
+                    nv.Text("Option A"),
+                    nv.Text("Option B"),
+                    nv.Text("Option C"),
+                ],
             ),
+            headline="Filters",
             opened=self.opened,
-            axis="horizontal",
-            alignment="top_right",
         )
 
         body = nv.Box(

--- a/src/nuiitivet/material/sheet.py
+++ b/src/nuiitivet/material/sheet.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import logging
 from typing import Callable, Literal, Optional, Union
 
+from nuiitivet.layout.collapsible import Collapsible
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.row import Row
 from nuiitivet.material.buttons import IconButton
 from nuiitivet.material.divider import VerticalDivider
+from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL
 from nuiitivet.material.styles.sheet_style import BottomSheetStyle, SideSheetStyle, StandardSideSheetStyle
 from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.theme.type_scale import TypeScaleToken
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableProtocol, ReadOnlyObservableProtocol
 from nuiitivet.overlay import OverlayAware
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -259,33 +261,40 @@ class StandardSideSheet(ComposableWidget):
     """Material Design 3 standard (docked) side sheet.
 
     A standard side sheet is a permanent part of the layout, sitting beside
-    the main content.  It does **not** manage its own open/close animation;
-    wrap it in :class:`~nuiitivet.layout.collapsible.Collapsible` when
-    animated expand/collapse is needed::
+    the main content.  It owns its open/close animation: the sheet stays
+    mounted while its allocated width animates between the style width and
+    zero::
+
+        opened: Observable[bool] = Observable(True)
 
         Row([
             main_content,
-            Collapsible(
-                StandardSideSheet(
-                    panel_content,
-                    headline="Filters",
-                    on_close=vm.close_panel,
-                ),
-                opened=vm.panel_open,
-                axis="horizontal",
-                alignment="top_right",
-            ),
+            StandardSideSheet(panel_content, headline="Filters", opened=opened),
         ])
+
+    Toggling the sheet is a plain write to *opened*
+    (``opened.value = not opened.value``).  Conditionally rendering the sheet
+    instead would unmount it and skip the animation.
+
+    The close icon button is rendered when the sheet can act on a press, i.e.
+    when *opened* is a writable observable, when *on_close_click* is given, or
+    both.  With a literal ``bool`` *opened* and no callback there is nothing a
+    press could do, so no button is shown.
 
     Args:
         content: Widget to display inside the sheet.
+        opened: ``bool`` or writable ``Observable[bool]`` driving the
+            expand/collapse animation.  Defaults to ``True``.
+        on_close_click: Callback invoked when the close icon button is
+            pressed.  **Supplying it disables the default auto-close**: the
+            sheet no longer writes ``opened.value = False`` and updating
+            *opened* becomes the caller's responsibility.  This is the
+            interception point for confirm-before-close flows.
         headline: Optional header title text (``str`` or
             ``Observable[str]``).  When provided, an M3-compliant header row
             is rendered above *content*.
         side: Edge the sheet is attached to (``"right"`` or ``"left"``).
-            Defaults to ``"right"``.
-        on_close: Callback invoked when the close icon button is pressed.
-            When ``None``, no close button is rendered in the header.
+            Defaults to ``"right"``.  The collapse anchor is derived from it.
         style: Container style.  Defaults to :class:`StandardSideSheetStyle`.
     """
 
@@ -293,33 +302,52 @@ class StandardSideSheet(ComposableWidget):
         self,
         content: Widget,
         *,
+        opened: Union[bool, ObservableProtocol[bool]] = True,
+        on_close_click: Optional[Callable[[], None]] = None,
         headline: Optional[Union[str, ReadOnlyObservableProtocol[str]]] = None,
         side: Literal["right", "left"] = "right",
-        on_close: Optional[Callable[[], None]] = None,
         style: Optional[StandardSideSheetStyle] = None,
     ) -> None:
         """Initialize StandardSideSheet.
 
         Args:
             content: Widget to display inside the sheet.
+            opened: ``bool`` or writable ``Observable[bool]``.  Defaults to
+                ``True``.
+            on_close_click: Callback for the close icon button.  Supplying it
+                disables the default ``opened.value = False`` auto-close.
             headline: Optional header title (str or Observable[str]).
             side: Attachment edge (``"right"`` or ``"left"``).
                 Defaults to ``"right"``.
-            on_close: Callback for the close icon button.  No button is shown
-                when ``None``.
             style: Container style.  Defaults to :class:`StandardSideSheetStyle`.
         """
         super().__init__()
         self._content = content
+        self._opened = opened
+        self._on_close_click = on_close_click
         self._headline = headline
         self.side = side
-        self._on_close = on_close
         self._user_style = style
 
     @property
     def style(self) -> StandardSideSheetStyle:
         """Return the resolved sheet style."""
         return self._user_style if self._user_style is not None else StandardSideSheetStyle()
+
+    def _can_auto_close(self) -> bool:
+        """Return whether *opened* is writable, i.e. the sheet can close itself."""
+        return isinstance(self._opened, ObservableProtocol)
+
+    def _show_close_button(self) -> bool:
+        return self._on_close_click is not None or self._can_auto_close()
+
+    def _handle_close_click(self) -> None:
+        """Close button handler: the callback replaces the default auto-close."""
+        if self._on_close_click is not None:
+            self._on_close_click()
+            return
+        if isinstance(self._opened, ObservableProtocol):
+            self._opened.value = False
 
     def on_mount(self) -> None:
         """Mount and subscribe to headline observable if provided."""
@@ -329,12 +357,13 @@ class StandardSideSheet(ComposableWidget):
             self.bind(sub)
 
     def build(self) -> Widget:
-        """Build the sheet: outer Box with optional header Row and content."""
+        """Build the sheet: a Collapsible wrapping the sheet container Box."""
         resolved_style = self.style
 
         # Optionally build the header row (headline + close button).
         body_parts: list[Widget] = []
-        if self._headline is not None or self._on_close is not None:
+        show_close = self._show_close_button()
+        if self._headline is not None or show_close:
             header_children: list[Widget] = []
             if self._headline is not None:
                 header_children.append(
@@ -348,8 +377,8 @@ class StandardSideSheet(ComposableWidget):
                         padding=(8, 0, 8, 0),
                     )
                 )
-            if self._on_close is not None:
-                header_children.append(IconButton("close", on_click=self._on_close))
+            if show_close:
+                header_children.append(IconButton("close", on_click=self._handle_close_click))
             body_parts.append(
                 Row(
                     header_children,
@@ -373,11 +402,23 @@ class StandardSideSheet(ComposableWidget):
         else:
             inner = content_col
 
-        return Box(
+        container = Box(
             inner,
             width=resolved_style.width,
             height=resolved_style.height,
             background_color=resolved_style.background_color,
+        )
+
+        # The collapse anchor is the edge the sheet is docked to: the child is
+        # laid out at its natural width while the allocated rect shrinks, so
+        # the docked edge must stay pinned.
+        alignment = ("end", "start") if self.side == "right" else ("start", "start")
+        return Collapsible(
+            container,
+            opened=self._opened,
+            axis="horizontal",
+            alignment=alignment,
+            motion=EXPRESSIVE_DEFAULT_SPATIAL,
         )
 
 

--- a/src/nuiitivet/observable/protocols.py
+++ b/src/nuiitivet/observable/protocols.py
@@ -27,8 +27,15 @@ class ReadOnlyObservableProtocol(Protocol, Generic[T]):
     def value(self) -> T: ...
 
 
+@runtime_checkable
 class ObservableProtocol(ReadOnlyObservableProtocol[T], Protocol, Generic[T]):
-    """Mutable observable protocol: supports reading and writing .value."""
+    """Mutable observable protocol: supports reading and writing .value.
+
+    Note:
+        ``isinstance`` against a runtime-checkable protocol only inspects
+        attribute presence, so a read-only observable also matches.  Static
+        typing is what separates the two.
+    """
 
     @property
     def value(self) -> T: ...

--- a/tests/material/test_standard_side_sheet.py
+++ b/tests/material/test_standard_side_sheet.py
@@ -1,11 +1,54 @@
 """Tests for StandardSideSheet widget."""
 
+from typing import Optional
+
 import pytest
 
+from nuiitivet.layout.collapsible import Collapsible
+from nuiitivet.layout.column import Column
+from nuiitivet.layout.row import Row as LayoutRow
+from nuiitivet.material.buttons import IconButton
+from nuiitivet.material.divider import VerticalDivider
+from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_SPATIAL
 from nuiitivet.material.sheet import StandardSideSheet
 from nuiitivet.material.styles.sheet_style import StandardSideSheetStyle
 from nuiitivet.material.theme.color_role import ColorRole
+from nuiitivet.observable import Observable
+from nuiitivet.widgeting.widget import Widget
 from nuiitivet.widgets.box import Box
+from nuiitivet.widgets.interaction import PointerInputNode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _container(built: Widget) -> Box:
+    """Return the sheet container Box inside the built Collapsible."""
+    assert isinstance(built, Collapsible)
+    child = built.children[0]
+    assert isinstance(child, Box)
+    return child
+
+
+def _find_close_button(built: Widget) -> Optional[IconButton]:
+    """Return the header close IconButton, or None when it is not rendered."""
+    if isinstance(built, IconButton):
+        return built
+    for child in built.children:
+        found = _find_close_button(child)
+        if found is not None:
+            return found
+    return None
+
+
+def _press(button: IconButton) -> None:
+    """Fire the button's click callbacks as a real press would."""
+    node = button.get_node(PointerInputNode)
+    assert isinstance(node, PointerInputNode)
+    for callback in node._click_callbacks:
+        callback()
+
 
 # ---------------------------------------------------------------------------
 # StandardSideSheetStyle tests
@@ -43,7 +86,8 @@ def test_standard_side_sheet_defaults():
     sheet = StandardSideSheet(content)
     assert sheet.side == "right"
     assert sheet._headline is None
-    assert sheet._on_close is None
+    assert sheet._on_close_click is None
+    assert sheet._opened is True
 
 
 def test_standard_side_sheet_style_property_default():
@@ -67,56 +111,158 @@ def test_standard_side_sheet_stores_headline():
     assert sheet._headline == "Filters"
 
 
-def test_standard_side_sheet_stores_on_close():
+def test_standard_side_sheet_stores_on_close_click():
     def cb() -> None:
         pass
 
-    sheet = StandardSideSheet(Box(), on_close=cb)
-    assert sheet._on_close is cb
+    sheet = StandardSideSheet(Box(), on_close_click=cb)
+    assert sheet._on_close_click is cb
 
 
 # ---------------------------------------------------------------------------
-# StandardSideSheet.build() tests
+# Embedded Collapsible tests
 # ---------------------------------------------------------------------------
 
 
-def test_standard_side_sheet_build_returns_box():
-    """build() returns a Box directly (no Collapsible wrapping)."""
-    sheet = StandardSideSheet(Box(width=100, height=200))
-    built = sheet.build()
-    assert isinstance(built, Box)
+def test_standard_side_sheet_build_returns_collapsible():
+    """build() wraps the sheet container in a Collapsible."""
+    built = StandardSideSheet(Box(width=100, height=200)).build()
+    assert isinstance(built, Collapsible)
+    assert isinstance(built.children[0], Box)
+
+
+def test_standard_side_sheet_collapsible_axis_is_horizontal():
+    built = StandardSideSheet(Box()).build()
+    assert isinstance(built, Collapsible)
+    assert built._axis == "horizontal"
+
+
+def test_standard_side_sheet_right_side_anchors_to_end():
+    """A right-docked sheet keeps its right edge pinned while collapsing."""
+    built = StandardSideSheet(Box(), side="right").build()
+    assert isinstance(built, Collapsible)
+    assert built._align == ("end", "start")
+
+
+def test_standard_side_sheet_left_side_anchors_to_start():
+    """A left-docked sheet keeps its left edge pinned while collapsing."""
+    built = StandardSideSheet(Box(), side="left").build()
+    assert isinstance(built, Collapsible)
+    assert built._align == ("start", "start")
+
+
+def test_standard_side_sheet_uses_expressive_spatial_motion():
+    """Motion is the M3 expressive default and is not part of the public API."""
+    built = StandardSideSheet(Box()).build()
+    assert isinstance(built, Collapsible)
+    assert built._motion_in is EXPRESSIVE_DEFAULT_SPATIAL
+    assert built._motion_out is EXPRESSIVE_DEFAULT_SPATIAL
+
+
+def test_standard_side_sheet_collapsible_present_for_literal_opened():
+    """The Collapsible is inserted even when opened is a literal True."""
+    assert isinstance(StandardSideSheet(Box(), opened=True).build(), Collapsible)
+
+
+def test_standard_side_sheet_forwards_opened_observable():
+    opened = Observable(False)
+    built = StandardSideSheet(Box(), opened=opened).build()
+    assert isinstance(built, Collapsible)
+    assert built._opened is opened
+
+
+def test_standard_side_sheet_closed_snaps_without_animation():
+    """opened=False snaps the width to zero on the first measure."""
+    built = StandardSideSheet(Box(width=100, height=200), opened=False).build()
+    width, _ = built.preferred_size()
+    assert width == 0
+
+
+def test_standard_side_sheet_opened_measures_style_width():
+    """opened=True snaps to the style width on the first measure."""
+    built = StandardSideSheet(Box(width=100, height=200), opened=True).build()
+    width, _ = built.preferred_size()
+    assert width == StandardSideSheetStyle().width
+
+
+# ---------------------------------------------------------------------------
+# Close button visibility and press behavior
+# ---------------------------------------------------------------------------
+
+
+def test_close_button_writable_opened_without_callback_closes():
+    """Writable opened, no callback: button shown, press writes opened=False."""
+    opened = Observable(True)
+    button = _find_close_button(StandardSideSheet(Box(), opened=opened).build())
+    assert button is not None
+
+    _press(button)
+    assert opened.value is False
+
+
+def test_close_button_writable_opened_with_callback_does_not_auto_close():
+    """Writable opened + callback: the callback replaces the auto-close."""
+    opened = Observable(True)
+    calls: list[int] = []
+    sheet = StandardSideSheet(Box(), opened=opened, on_close_click=lambda: calls.append(1))
+    button = _find_close_button(sheet.build())
+    assert button is not None
+
+    _press(button)
+    assert calls == [1]
+    assert opened.value is True
+
+
+def test_close_button_hidden_for_literal_opened_without_callback():
+    """Literal opened, no callback: a press would have nothing to do, so no button."""
+    assert _find_close_button(StandardSideSheet(Box(), opened=True).build()) is None
+
+
+def test_close_button_shown_for_literal_opened_with_callback():
+    """Literal opened + callback: button shown, press invokes the callback."""
+    calls: list[int] = []
+    sheet = StandardSideSheet(Box(), opened=True, on_close_click=lambda: calls.append(1))
+    button = _find_close_button(sheet.build())
+    assert button is not None
+
+    _press(button)
+    assert calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# StandardSideSheet.build() structure tests
+# ---------------------------------------------------------------------------
 
 
 def test_standard_side_sheet_build_no_header_when_none():
-    """No header row is created when headline and on_close are both None."""
-    from nuiitivet.layout.column import Column
-
-    # Disable divider so Box.children[0] is the Column directly.
-    from nuiitivet.material.styles.sheet_style import StandardSideSheetStyle
-
+    """No header row is created when headline and close button are both absent."""
+    # Disable the divider so the container's child is the body Column directly.
     sheet = StandardSideSheet(Box(), style=StandardSideSheetStyle(show_divider=False))
-    built = sheet.build()
-    assert isinstance(built, Box)
-    # The body Column should contain only the content (no header Row).
-    body_column = built.children[0]
+    body_column = _container(sheet.build()).children[0]
     assert isinstance(body_column, Column)
+    # Only the content, no header Row.
     assert len(body_column.children) == 1
 
 
 def test_standard_side_sheet_build_has_header_when_headline_given():
     """Header Row is present when headline is provided."""
-    from nuiitivet.layout.column import Column
-    from nuiitivet.layout.row import Row
-
-    # Disable divider so Box.children[0] is the Column directly.
-    from nuiitivet.material.styles.sheet_style import StandardSideSheetStyle
-
     sheet = StandardSideSheet(Box(), headline="Filters", style=StandardSideSheetStyle(show_divider=False))
-    built = sheet.build()
-    body_column = built.children[0]
+    body_column = _container(sheet.build()).children[0]
     assert isinstance(body_column, Column)
     assert len(body_column.children) == 2
-    assert isinstance(body_column.children[0], Row)
+    assert isinstance(body_column.children[0], LayoutRow)
+
+
+def test_standard_side_sheet_build_has_header_when_only_close_button():
+    """Header Row is present when the close button alone is rendered."""
+    sheet = StandardSideSheet(
+        Box(),
+        opened=Observable(True),
+        style=StandardSideSheetStyle(show_divider=False),
+    )
+    body_column = _container(sheet.build()).children[0]
+    assert isinstance(body_column, Column)
+    assert len(body_column.children) == 2
 
 
 def test_standard_side_sheet_style_show_divider_default():
@@ -126,35 +272,22 @@ def test_standard_side_sheet_style_show_divider_default():
 
 def test_standard_side_sheet_build_divider_right_side():
     """Right-side sheet: Divider appears as first child of the inner Row."""
-    from nuiitivet.layout.row import Row as LayoutRow
-    from nuiitivet.material.divider import VerticalDivider
-
-    sheet = StandardSideSheet(Box(), side="right")
-    built = sheet.build()
-    inner = built.children[0]
+    inner = _container(StandardSideSheet(Box(), side="right").build()).children[0]
     assert isinstance(inner, LayoutRow)
     assert isinstance(inner.children[0], VerticalDivider)
 
 
 def test_standard_side_sheet_build_divider_left_side():
     """Left-side sheet: Divider appears as last child of the inner Row."""
-    from nuiitivet.layout.row import Row as LayoutRow
-    from nuiitivet.material.divider import VerticalDivider
-
-    sheet = StandardSideSheet(Box(), side="left")
-    built = sheet.build()
-    inner = built.children[0]
+    inner = _container(StandardSideSheet(Box(), side="left").build()).children[0]
     assert isinstance(inner, LayoutRow)
     assert isinstance(inner.children[-1], VerticalDivider)
 
 
 def test_standard_side_sheet_build_no_divider_when_disabled():
-    """When show_divider=False, Box.children[0] is not a Row with a Divider."""
-    from nuiitivet.layout.column import Column
-
+    """When show_divider=False, the container's child is the body Column."""
     sheet = StandardSideSheet(Box(), style=StandardSideSheetStyle(show_divider=False))
-    built = sheet.build()
-    assert isinstance(built.children[0], Column)
+    assert isinstance(_container(sheet.build()).children[0], Column)
 
 
 def test_standard_side_sheet_namespace_export():


### PR DESCRIPTION
## Summary
- `StandardSideSheet` now embeds `Collapsible` in `build()`. `axis` is always `"horizontal"` and `alignment` is derived from `side`, so the invalid combinations callers could previously write (e.g. `side="left", alignment="top_right"`) are no longer expressible. `motion` is internal and defaults to `EXPRESSIVE_DEFAULT_SPATIAL`.
- Added `opened`, accepting a `bool` or a writable `ObservableProtocol[bool]` (defaults to `True`).
- Renamed `on_close` to `on_close_click`. Supplying it **replaces** the default auto-close, giving the docked sheet the interception point that `will_pop` provides for the modal `SideSheet`.
- The close button is rendered only when a press can act on something: a writable `opened`, an `on_close_click`, or both.
- Marked `ObservableProtocol` as `@runtime_checkable` so writability is probed with `isinstance` rather than `hasattr` duck typing (per CLAUDE.md). Note the check is structural and cannot see the `value` setter, so a read-only observable also matches — static typing is what separates the two. This is documented on the protocol.
- `Collapsible` itself is unchanged and remains public for callers needing an unusual axis/anchor combination.

**Breaking change**, consistent with the project's "prefer future compatibility over backward compatibility" policy:

```python
# Before
Collapsible(
    StandardSideSheet(panel, headline="Filters", on_close=vm.toggle),
    opened=vm.opened, axis="horizontal", alignment="top_right",
)

# After
StandardSideSheet(panel, headline="Filters", opened=vm.opened)
```

## Test plan
- [x] `pytest tests/` — 1500 passed
- [x] `mypy src tests` — no issues in 436 source files
- [x] Close button visibility and press behavior covered for all four rows of the `opened` × `on_close_click` matrix
- [x] Anchor derivation verified for both sides: with a 256px child in a 142px allocation, `side="right"` places the child at `x=-114` (right edge pinned) and `side="left"` at `x=0` (left edge pinned)
- [x] `opened=False` snaps to zero width on the first measure (no animation on mount); rendered PNG shows no panel and no divider
- [x] Sample renders correctly in the open state
- [x] `docs/design/SIZE_POLICY.md:71` reviewed — "no public size param" still accurate, unchanged

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)