### PR TITLE
refactor: rename keyboard-modifier `modifiers` to `modifier_keys`

### DIFF
--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -839,7 +839,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
 
     @window.event
     def on_key_press(symbol, modifiers):
-        key_name, norm_mods = _normalize_key(symbol, modifiers)
+        key_name, modifier_keys = _normalize_key(symbol, modifiers)
 
         nonlocal esc_down
         if str(key_name).strip().lower() == "escape":
@@ -858,7 +858,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
                     kn = "escape"
                     if not debug_keys_filter or kn in debug_keys_filter:
                         ts = time.perf_counter()
-                        print(f"[nuiitivet] key_press t={ts:.6f} key={kn} mods={norm_mods} handled=False")
+                        print(f"[nuiitivet] key_press t={ts:.6f} key={kn} mods={modifier_keys} handled=False")
                 # Let pyglet's default ESC handling run (e.g. close window).
                 return False
 
@@ -867,13 +867,13 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
                 kn = "escape"
                 if not debug_keys_filter or kn in debug_keys_filter:
                     ts = time.perf_counter()
-                    print(f"[nuiitivet] key_press t={ts:.6f} key={kn} mods={norm_mods} handled=True")
+                    print(f"[nuiitivet] key_press t={ts:.6f} key={kn} mods={modifier_keys} handled=True")
             # Handle ESC on key release to avoid OS key-repeat glitches and to
             # align with "keyup triggers back" semantics.
             return True
 
         try:
-            handled = bool(app._dispatch_key_press(key_name, norm_mods))
+            handled = bool(app._dispatch_key_press(key_name, modifier_keys))
         except Exception:
             exception_once(logger, "pyglet_on_key_press_dispatch_exc", "Key press dispatch raised")
             handled = False
@@ -882,7 +882,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
             kn = str(key_name).strip().lower()
             if not debug_keys_filter or kn in debug_keys_filter:
                 ts = time.perf_counter()
-                print(f"[nuiitivet] key_press t={ts:.6f} key={kn} mods={norm_mods} handled={handled}")
+                print(f"[nuiitivet] key_press t={ts:.6f} key={kn} mods={modifier_keys} handled={handled}")
 
         if handled:
             try:
@@ -896,7 +896,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
 
     @window.event
     def on_key_release(symbol, modifiers):
-        key_name, norm_mods = _normalize_key(symbol, modifiers)
+        key_name, modifier_keys = _normalize_key(symbol, modifiers)
 
         nonlocal esc_down
         if str(key_name).strip().lower() != "escape":
@@ -917,7 +917,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
                 handled = False
         else:
             try:
-                handled = bool(app._dispatch_key_press("escape", norm_mods))
+                handled = bool(app._dispatch_key_press("escape", modifier_keys))
             except Exception:
                 exception_once(logger, "pyglet_on_key_release_dispatch_exc", "Key release dispatch raised")
                 handled = False
@@ -926,7 +926,7 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
             kn = "escape"
             if not debug_keys_filter or kn in debug_keys_filter:
                 ts = time.perf_counter()
-                print(f"[nuiitivet] key_release t={ts:.6f} key={kn} mods={norm_mods} handled={handled}")
+                print(f"[nuiitivet] key_release t={ts:.6f} key={kn} mods={modifier_keys} handled={handled}")
 
         if handled:
             try:
@@ -1148,27 +1148,27 @@ def _patch_pyglet_cocoa_view() -> None:
         exception_once(logger, "pyglet_cocoa_view_patch_exc", "Failed to patch pyglet cocoa view")
 
 
-def _normalize_key(symbol: int, modifiers: int) -> tuple[str, int]:
+def _normalize_key(symbol: int, pyglet_modifiers: int) -> tuple[str, int]:
     try:
         keymod = pyglet.window.key
 
-        norm_mods = 0
-        if modifiers & keymod.MOD_SHIFT:
-            norm_mods |= MOD_SHIFT
-        if modifiers & keymod.MOD_CTRL:
-            norm_mods |= MOD_CTRL
-        if modifiers & keymod.MOD_ALT:
-            norm_mods |= MOD_ALT
+        modifier_keys = 0
+        if pyglet_modifiers & keymod.MOD_SHIFT:
+            modifier_keys |= MOD_SHIFT
+        if pyglet_modifiers & keymod.MOD_CTRL:
+            modifier_keys |= MOD_CTRL
+        if pyglet_modifiers & keymod.MOD_ALT:
+            modifier_keys |= MOD_ALT
         # Map Command to META on macOS
-        if modifiers & getattr(keymod, "MOD_COMMAND", 0):
-            norm_mods |= MOD_META
+        if pyglet_modifiers & getattr(keymod, "MOD_COMMAND", 0):
+            modifier_keys |= MOD_META
 
         if symbol == keymod.TAB:
-            return "tab", norm_mods
+            return "tab", modifier_keys
         if symbol == keymod.SPACE:
-            return "space", norm_mods
+            return "space", modifier_keys
         if symbol in (keymod.ENTER, keymod.RETURN):
-            return "enter", norm_mods
+            return "enter", modifier_keys
     except Exception:
         exception_once(logger, "pyglet_normalize_key_map_exc", "Failed to normalize key/modifier mapping")
 

--- a/src/nuiitivet/input/events.py
+++ b/src/nuiitivet/input/events.py
@@ -17,7 +17,7 @@ class KeyInputEvent:
     """Normalized key input delivered to widgets."""
 
     key: str
-    modifiers: int = 0
+    modifier_keys: int = 0
 
 
 @dataclass(frozen=True)

--- a/src/nuiitivet/input/pointer.py
+++ b/src/nuiitivet/input/pointer.py
@@ -49,7 +49,7 @@ class PointerEvent:
     button: Optional[int] = None
     timestamp: float = 0.0
     is_primary: bool = True
-    modifiers: int = 0
+    modifier_keys: int = 0
 
     @staticmethod
     def mouse_event(
@@ -62,7 +62,7 @@ class PointerEvent:
         dy: float = 0.0,
         button: Optional[int] = None,
         timestamp: Optional[float] = None,
-        modifiers: int = 0,
+        modifier_keys: int = 0,
     ) -> "PointerEvent":
         return PointerEvent(
             id=pointer_id,
@@ -74,7 +74,7 @@ class PointerEvent:
             dy=dy,
             button=button,
             timestamp=time.time() if timestamp is None else float(timestamp),
-            modifiers=modifiers,
+            modifier_keys=modifier_keys,
         )
 
     @staticmethod
@@ -86,7 +86,7 @@ class PointerEvent:
         scroll_y: float,
         *,
         timestamp: Optional[float] = None,
-        modifiers: int = 0,
+        modifier_keys: int = 0,
     ) -> "PointerEvent":
         return PointerEvent(
             id=pointer_id,
@@ -97,5 +97,5 @@ class PointerEvent:
             scroll_x=scroll_x,
             scroll_y=scroll_y,
             timestamp=time.time() if timestamp is None else float(timestamp),
-            modifiers=modifiers,
+            modifier_keys=modifier_keys,
         )

--- a/src/nuiitivet/material/interactive_widget.py
+++ b/src/nuiitivet/material/interactive_widget.py
@@ -82,7 +82,7 @@ class InteractiveWidget(Clickable):
             node._on_key = self.on_key_event
             node._on_focus_change = self._handle_focus_change
 
-    def on_key_event(self, key: str, modifiers: int = 0) -> bool:
+    def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:
         """Handle key events (Space/Enter to click)."""
         if self.disabled:
             return False

--- a/src/nuiitivet/material/menu.py
+++ b/src/nuiitivet/material/menu.py
@@ -533,7 +533,7 @@ class Menu(InteractiveWidget):
 
         return (resolved_width, resolved_height)
 
-    def on_key_event(self, key: str, modifiers: int = 0) -> bool:
+    def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:
         key_name = str(key).lower()
 
         if key_name == "escape":
@@ -550,7 +550,7 @@ class Menu(InteractiveWidget):
         if key_name in ("enter", "space"):
             if 0 <= self._focus_index < len(self._focusable_items):
                 item = self._focusable_items[self._focus_index]
-                return item.on_key_event(key_name, modifiers)
+                return item.on_key_event(key_name, modifier_keys)
             return False
 
         return False

--- a/src/nuiitivet/material/slider.py
+++ b/src/nuiitivet/material/slider.py
@@ -234,14 +234,14 @@ class _SliderBase(InteractiveWidget):
             self._handle_width_anim.target = target
         return float(self._handle_width_anim.value)
 
-    def on_key_event(self, key: str, modifiers: int = 0) -> bool:
+    def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:
         if self.disabled:
             return False
 
         key_name = (key or "").lower()
 
         if key_name == "tab":
-            return self._handle_tab_key(modifiers)
+            return self._handle_tab_key(modifier_keys)
 
         if key_name == "space":
             self._space_accel_armed = True
@@ -251,15 +251,15 @@ class _SliderBase(InteractiveWidget):
         dec = key_name in ("left", "down")
         if not inc and not dec:
             self._space_accel_armed = False
-            return super().on_key_event(key, modifiers)
+            return super().on_key_event(key, modifier_keys)
 
-        step = self._keyboard_step(modifiers, large=self._space_accel_armed)
+        step = self._keyboard_step(modifier_keys, large=self._space_accel_armed)
         delta = step if inc else -step
         self._step_active_handle(delta)
         self._space_accel_armed = False
         return True
 
-    def _wants_tab(self, modifiers: int = 0) -> bool:
+    def _wants_tab(self, modifier_keys: int = 0) -> bool:
         """Return True if Tab should be consumed internally.
 
         For single-handle sliders this always returns False.
@@ -268,14 +268,14 @@ class _SliderBase(InteractiveWidget):
         """
         if self._handle_count <= 1:
             return False
-        go_back = bool(int(modifiers) & 1)
+        go_back = bool(int(modifier_keys) & 1)
         if go_back:
             return self._active_handle_index > 0
         return self._active_handle_index < self._handle_count - 1
 
-    def _handle_tab_key(self, modifiers: int = 0) -> bool:
+    def _handle_tab_key(self, modifier_keys: int = 0) -> bool:
         """Move active handle index on Tab."""
-        go_back = bool(int(modifiers) & 1)
+        go_back = bool(int(modifier_keys) & 1)
         if go_back:
             self._active_handle_index = max(0, self._active_handle_index - 1)
         else:
@@ -283,7 +283,7 @@ class _SliderBase(InteractiveWidget):
         self.invalidate()
         return True
 
-    def _keyboard_step(self, modifiers: int, *, large: bool = False) -> float:
+    def _keyboard_step(self, modifier_keys: int, *, large: bool = False) -> float:
         span = max(1e-6, self._max_value - self._min_value)
         if self._stops is not None and self._stops >= 2:
             unit = span / float(max(1, self._stops - 1))
@@ -293,7 +293,7 @@ class _SliderBase(InteractiveWidget):
         if large:
             unit *= 10.0
 
-        if modifiers & MOD_SHIFT:
+        if modifier_keys & MOD_SHIFT:
             unit *= 10.0
         return unit
 

--- a/src/nuiitivet/modifiers/focus.py
+++ b/src/nuiitivet/modifiers/focus.py
@@ -56,7 +56,9 @@ def focusable(
     Args:
         enabled: Whether the widget is focusable.
         on_focus_change: Callback invoked when focus state changes.
-        on_key: Callback invoked when a key event occurs while focused.
+        on_key: Callback invoked as ``on_key(key, modifier_keys)`` when a key
+                event occurs while focused. ``modifier_keys`` is a bitmask of
+                the held modifier keys (``MOD_SHIFT``, ``MOD_CTRL``, ...).
                 Return True to stop propagation (bubbling).
     """
     return FocusableModifier(enabled, on_focus_change, on_key)

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -839,7 +839,7 @@ class App:
             exception_once(logger, "app_collect_focus_nodes_root_exc", "Collecting FocusNodes from root raised")
         return res
 
-    def _dispatch_key_press(self, key, modifiers=0):
+    def _dispatch_key_press(self, key, modifier_keys=0):
         """Handle key presses for focus navigation and activation.
 
         Accepts simple string names: 'tab', 'space', 'enter'. Returns True if handled.
@@ -874,13 +874,13 @@ class App:
 
                     # Allow composite widgets to consume Tab internally
                     # (e.g. RangeSlider switching between handles).
-                    if cur.wants_tab(modifiers):
-                        return cur.handle_key_event("tab", modifiers)
+                    if cur.wants_tab(modifier_keys):
+                        return cur.handle_key_event("tab", modifier_keys)
 
                     idx = nodes.index(cur)
 
                     # Treat bit0 as shift (matches pyglet MOD_SHIFT in practice).
-                    go_back = bool(int(modifiers) & 1)
+                    go_back = bool(int(modifier_keys) & 1)
 
                     if go_back:
                         next_idx = (idx - 1) % len(nodes)
@@ -896,7 +896,7 @@ class App:
         # 2. Try FocusNode bubbling (New System)
         if self._focused_node:
             try:
-                if self._focused_node.handle_key_event(kname or str(key), modifiers):
+                if self._focused_node.handle_key_event(kname or str(key), modifier_keys):
                     return True
             except Exception:
                 exception_once(logger, "app_focused_node_handle_key_exc", "Focused node handle_key_event raised")
@@ -975,7 +975,7 @@ class App:
             pointer_type=pivot.pointer_type,
             button=pivot.button,
             timestamp=time.time(),
-            modifiers=pivot.modifiers,
+            modifier_keys=pivot.modifier_keys,
         )
         try:
             widget.dispatch_pointer_event(cancel_event)

--- a/src/nuiitivet/widgeting/widget_input.py
+++ b/src/nuiitivet/widgeting/widget_input.py
@@ -96,14 +96,14 @@ class InputHubMixin:
             )
 
     # --- Key delivery ------------------------------------------------------
-    def handle_key_event(self, key: str, modifiers: int = 0) -> bool:
+    def handle_key_event(self, key: str, modifier_keys: int = 0) -> bool:
         with batch():
-            event = KeyInputEvent(key=key, modifiers=modifiers)
+            event = KeyInputEvent(key=key, modifier_keys=modifier_keys)
             if self._dispatch_input("key", event):
                 return True
-            return bool(self.on_key_event(key, modifiers))
+            return bool(self.on_key_event(key, modifier_keys))
 
-    def on_key_event(self, key: str, modifiers: int = 0) -> bool:  # pragma: no cover - default no-op
+    def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:  # pragma: no cover - default no-op
         return False
 
     # --- Focus delivery ----------------------------------------------------

--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -518,8 +518,8 @@ class EditableText(InteractionHostMixin, Widget):
 
         return False
 
-    def _handle_key(self, key: str, modifiers: int) -> bool:
-        is_ctrl = bool(modifiers & (MOD_CTRL | MOD_META))
+    def _handle_key(self, key: str, modifier_keys: int) -> bool:
+        is_ctrl = bool(modifier_keys & (MOD_CTRL | MOD_META))
 
         if not is_ctrl:
             return False

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -546,7 +546,7 @@ class FocusNode(InteractionNode):
         self._parent: Optional["FocusNode"] = None
         self._wants_tab: Optional[Callable[[int], bool]] = None
 
-    def wants_tab(self, modifiers: int = 0) -> bool:
+    def wants_tab(self, modifier_keys: int = 0) -> bool:
         """Return True if this node wants to consume Tab internally.
 
         Composite widgets (e.g. RangeSlider) override this via the
@@ -554,10 +554,10 @@ class FocusNode(InteractionNode):
         focus to the next node in the traversal list.
 
         Args:
-            modifiers: Keyboard modifier flags (e.g. Shift).
+            modifier_keys: Keyboard modifier key flags (e.g. Shift).
         """
         if self._wants_tab is not None:
-            return self._wants_tab(modifiers)
+            return self._wants_tab(modifier_keys)
         return False
 
     def request_focus(self, source: FocusSource = FocusSource.KEYBOARD) -> None:
@@ -603,15 +603,15 @@ class FocusNode(InteractionNode):
                 owner_name=owner_name,
             )
 
-    def handle_key_event(self, key: str, modifiers: int) -> bool:
+    def handle_key_event(self, key: str, modifier_keys: int) -> bool:
         if self._on_key:
-            if self._on_key(key, modifiers):
+            if self._on_key(key, modifier_keys):
                 return True
 
         # Bubbling: Try parent
         p = self.parent
         if p:
-            return p.handle_key_event(key, modifiers)
+            return p.handle_key_event(key, modifier_keys)
         return False
 
     def handle_text_event(self, text: str) -> bool:

--- a/tests/helpers/pointer.py
+++ b/tests/helpers/pointer.py
@@ -40,7 +40,7 @@ def send_pointer_event_for_test(
     button: Optional[int] = None,
     scroll_x: float = 0.0,
     scroll_y: float = 0.0,
-    modifiers: int = 0,
+    modifier_keys: int = 0,
 ) -> bool:
     """Test helper: dispatch a synthetic pointer event directly to the given widget.
 
@@ -53,7 +53,7 @@ def send_pointer_event_for_test(
     convenience.
     """
     if event_type is PointerEventType.SCROLL:
-        event = PointerEvent.scroll_event(pointer_id, x, y, scroll_x, scroll_y, modifiers=modifiers)
+        event = PointerEvent.scroll_event(pointer_id, x, y, scroll_x, scroll_y, modifier_keys=modifier_keys)
     else:
         event = PointerEvent.mouse_event(
             pointer_id,
@@ -63,7 +63,7 @@ def send_pointer_event_for_test(
             dx=dx,
             dy=dy,
             button=button,
-            modifiers=modifiers,
+            modifier_keys=modifier_keys,
         )
 
     _ensure_layout_rect_from_last_rect(widget)
@@ -86,7 +86,7 @@ def send_pointer_event_for_test_via_app_routing(
     button: Optional[int] = None,
     scroll_x: float = 0.0,
     scroll_y: float = 0.0,
-    modifiers: int = 0,
+    modifier_keys: int = 0,
 ) -> bool:
     """Test helper: dispatch a synthetic pointer event via App-style routing.
 
@@ -95,7 +95,7 @@ def send_pointer_event_for_test_via_app_routing(
     - Bubble the event up the `_parent` chain until handled.
     """
     if event_type is PointerEventType.SCROLL:
-        event = PointerEvent.scroll_event(pointer_id, x, y, scroll_x, scroll_y, modifiers=modifiers)
+        event = PointerEvent.scroll_event(pointer_id, x, y, scroll_x, scroll_y, modifier_keys=modifier_keys)
     else:
         event = PointerEvent.mouse_event(
             pointer_id,
@@ -105,7 +105,7 @@ def send_pointer_event_for_test_via_app_routing(
             dx=dx,
             dy=dy,
             button=button,
-            modifiers=modifiers,
+            modifier_keys=modifier_keys,
         )
 
     _ensure_layout_rect_from_last_rect(root)

--- a/tests/input/test_focus_integration.py
+++ b/tests/input/test_focus_integration.py
@@ -26,7 +26,7 @@ def test_focus_traversal_and_shift_tab():
         fake_window = types.SimpleNamespace(key=fake_key)
         fake_pyglet = types.SimpleNamespace(window=fake_window)
         sys.modules["pyglet"] = fake_pyglet
-        handled = app._dispatch_key_press("tab", modifiers=1)
+        handled = app._dispatch_key_press("tab", modifier_keys=1)
         assert handled is True
         assert app._focused_target is cb1
         assert cb1.state.focused is True

--- a/tests/input/test_focus_node.py
+++ b/tests/input/test_focus_node.py
@@ -76,7 +76,7 @@ def test_focus_traversal():
 def test_key_event_routing():
     received_keys = []
 
-    def on_key(key, modifiers):
+    def on_key(key, modifier_keys):
         received_keys.append(key)
         return True
 
@@ -100,11 +100,11 @@ def test_key_event_bubbling():
     child_keys = []
     parent_keys = []
 
-    def on_child_key(key, modifiers):
+    def on_child_key(key, modifier_keys):
         child_keys.append(key)
         return False  # Bubble up
 
-    def on_parent_key(key, modifiers):
+    def on_parent_key(key, modifier_keys):
         parent_keys.append(key)
         return True  # Handle it
 

--- a/tests/material/test_slider.py
+++ b/tests/material/test_slider.py
@@ -268,7 +268,7 @@ def test_range_slider_shift_tab_moves_back() -> None:
     r = HorizontalRangeSlider(value_start=0.2, value_end=0.8, min_value=0.0, max_value=1.0)
     r._active_handle_index = 1
 
-    result = r.on_key_event("tab", 1)  # modifiers=1 (MOD_SHIFT)
+    result = r.on_key_event("tab", 1)  # modifier_keys=1 (MOD_SHIFT)
 
     assert result is True
     assert r._active_handle_index == 0

--- a/tests/widgeting/test_widget_auto_batch.py
+++ b/tests/widgeting/test_widget_auto_batch.py
@@ -21,7 +21,7 @@ class DummyWidget(Widget):
         self.vm_val.value = 1
         return True
 
-    def on_key_event(self, key, modifiers):
+    def on_key_event(self, key, modifier_keys):
         self.vm_val.value = 2
         return True
 
@@ -66,7 +66,7 @@ def test_pointer_event_auto_batch():
 
 def test_key_event_auto_batch():
     class VerifyingWidget(DummyWidget):
-        def on_key_event(self, key, modifiers):
+        def on_key_event(self, key, modifier_keys):
             self.vm_val.value = 20
             assert self.computations == 1, "Computation should be deferred inside handler"
             return True

--- a/tests/widgeting/test_widget_hosts.py
+++ b/tests/widgeting/test_widget_hosts.py
@@ -7,8 +7,8 @@ class DummyWidget(Widget):
     def build(self):  # pragma: no cover - builder host not exercised here
         return self
 
-    def on_key_event(self, key: str, modifiers: int = 0) -> bool:
-        self._key_events.append((key, modifiers))
+    def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:
+        self._key_events.append((key, modifier_keys))
         return False
 
     def on_focus_event(self, event: FocusEvent) -> bool:
@@ -49,11 +49,11 @@ def test_key_hook_short_circuits_default_handler():
     events = []
 
     def key_hook(event):
-        events.append((event.key, event.modifiers))
+        events.append((event.key, event.modifier_keys))
         return True
 
     widget.register_input_hook("key", key_hook)
-    handled = widget.handle_key_event("space", modifiers=1)
+    handled = widget.handle_key_event("space", modifier_keys=1)
 
     assert handled is True
     assert events == [("space", 1)]


### PR DESCRIPTION
## Summary
- Rename the keyboard modifier-key bitmask from `modifiers` to `modifier_keys` across the pointer and keyboard paths, resolving the lexical collision with the widget `Modifier` decoration mechanism (`nuiitivet.modifiers`, `Widget.modifier(...)`).
- Breaking API changes: `PointerEvent.modifiers`, `KeyInputEvent.modifiers`, the `modifiers=` keyword of `mouse_event()` / `scroll_event()`, the `handle_key_event()` / `on_key_event()` parameter, and the `focusable(on_key=...)` callback contract.
- The pyglet event handlers keep pyglet's own parameter names (`def on_key_press(symbol, modifiers)`); the value is normalized into `modifier_keys` at the backend boundary via `_normalize_key(symbol, pyglet_modifiers)`.
- `MOD_SHIFT` / `MOD_CTRL` / `MOD_ALT` / `MOD_META` keep their names — `e.modifier_keys & MOD_CTRL` reads cleanly.
- The widget `Modifier` mechanism is untouched. Documented the `on_key(key, modifier_keys)` signature in the `focusable()` docstring, which previously left the callback's arguments unnamed.
- Names only — no behavior change. Lands before #305, #306 and #308 so their diffs stay focused on the actual defects.

## Test plan
- [x] `pytest` — 1540 passed, no behavior change
- [x] `mypy src/nuiitivet` — no issues in 237 source files
- [x] Verified the pyglet boundary directly: `_normalize_key(TAB, pyglet.MOD_SHIFT)` returns `("tab", MOD_SHIFT)`
- [x] Verified modifier keys still take effect, not just renamed: Slider arrow-key step is `0.01` unmodified vs `0.1` with Shift; RangeSlider Tab advances to handle 1 and Shift+Tab returns to handle 0
- [x] Confirmed acceptance-criteria greps: no `modifiers` symbol refers to keyboard keys in `src/`/`tests/` (only pyglet handler params), and `src/nuiitivet/modifiers/` matches only widget-mechanism usage

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)