### PR TITLE
fix: preserve key modifiers for all keys in pyglet _normalize_key

### DIFF
--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -1148,7 +1148,8 @@ def _patch_pyglet_cocoa_view() -> None:
         exception_once(logger, "pyglet_cocoa_view_patch_exc", "Failed to patch pyglet cocoa view")
 
 
-def _normalize_key(symbol: int, pyglet_modifiers: int) -> tuple[str, int]:
+def _normalize_modifiers(pyglet_modifiers: int) -> int:
+    """Translate a pyglet modifier bitmask into nuiitivet's MOD_* mask."""
     try:
         keymod = pyglet.window.key
 
@@ -1162,23 +1163,36 @@ def _normalize_key(symbol: int, pyglet_modifiers: int) -> tuple[str, int]:
         # Map Command to META on macOS
         if pyglet_modifiers & getattr(keymod, "MOD_COMMAND", 0):
             modifier_keys |= MOD_META
-
-        if symbol == keymod.TAB:
-            return "tab", modifier_keys
-        if symbol == keymod.SPACE:
-            return "space", modifier_keys
-        if symbol in (keymod.ENTER, keymod.RETURN):
-            return "enter", modifier_keys
+        return modifier_keys
     except Exception:
-        exception_once(logger, "pyglet_normalize_key_map_exc", "Failed to normalize key/modifier mapping")
+        exception_once(logger, "pyglet_normalize_modifiers_exc", "Failed to normalize modifier mapping")
+        return 0
+
+
+def _normalize_key(symbol: int, pyglet_modifiers: int) -> tuple[str, int]:
+    """Translate a pyglet key symbol and modifier mask into nuiitivet's key name and MOD_* mask.
+
+    The modifier mask is resolved independently of the key name so that a failure
+    to name the key never silently drops the modifiers, and vice versa.
+    """
+    modifier_keys = _normalize_modifiers(pyglet_modifiers)
 
     try:
         keymod = pyglet.window.key
-        name = keymod.symbol_string(symbol)
-        return name.lower(), 0
+
+        if symbol == keymod.TAB:
+            name = "tab"
+        elif symbol == keymod.SPACE:
+            name = "space"
+        elif symbol in (keymod.ENTER, keymod.RETURN):
+            name = "enter"
+        else:
+            name = keymod.symbol_string(symbol).lower()
     except Exception:
-        exception_once(logger, "pyglet_normalize_key_symbol_string_exc", "key.symbol_string failed")
-        return "", 0
+        exception_once(logger, "pyglet_normalize_key_name_exc", "Failed to normalize key name")
+        name = ""
+
+    return name, modifier_keys
 
 
 def _normalize_text_motion(motion: int) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,13 @@ import pathlib
 import sys
 import warnings
 
+import pyglet
+
+# Importing pyglet.window creates a shadow window, which needs a display
+# connection and raises NoSuchDisplayException under headless CI. Tests never
+# open a real window, so disable it before any test module imports pyglet.window.
+pyglet.options["shadow_window"] = False
+
 
 _ROOT = pathlib.Path(__file__).resolve().parents[1]
 _SRC = _ROOT / "src"

--- a/tests/runtime/test_app_events.py
+++ b/tests/runtime/test_app_events.py
@@ -157,9 +157,13 @@ def test_draw_raster_frame_success(monkeypatch):
         image=FakePygletImage,
         app=types.SimpleNamespace(exit=lambda: None),
     )
-    monkeypatch.setitem(__import__("sys").modules, "pyglet", fake_pyglet)
 
     from nuiitivet.backends.pyglet import runner as pyglet_runner
+
+    # _draw_raster_frame resolves pyglet through the runner module's global, so
+    # patch that binding directly. Patching sys.modules would only work if this
+    # test happened to be the first to import the runner.
+    monkeypatch.setattr(pyglet_runner, "pyglet", fake_pyglet)
 
     ok = pyglet_runner._draw_raster_frame(app, skia=None)
     assert ok is True

--- a/tests/runtime/test_normalize_key.py
+++ b/tests/runtime/test_normalize_key.py
@@ -1,0 +1,129 @@
+"""Tests for the pyglet backend's key/modifier normalization.
+
+These exercise the backend-to-widget boundary: widgets receive whatever
+``_normalize_key`` returns, so a dropped modifier mask here silently disables
+every modifier-gated branch downstream (Ctrl+A in EditableText, Shift+Arrow in
+Slider, and so on).
+"""
+
+import pytest
+from pyglet.window import key as pyglet_key
+
+from nuiitivet.backends.pyglet.runner import _normalize_key, _normalize_modifiers
+from nuiitivet.input.codes import MOD_ALT, MOD_CTRL, MOD_META, MOD_SHIFT
+
+
+@pytest.mark.parametrize(
+    "symbol, expected_name",
+    [
+        (pyglet_key.A, "a"),
+        (pyglet_key.RIGHT, "right"),
+        (pyglet_key.LEFT, "left"),
+        (pyglet_key.UP, "up"),
+        (pyglet_key.DOWN, "down"),
+        (pyglet_key.ESCAPE, "escape"),
+        (pyglet_key.TAB, "tab"),
+        (pyglet_key.SPACE, "space"),
+        (pyglet_key.ENTER, "enter"),
+        (pyglet_key.RETURN, "enter"),
+    ],
+)
+def test_normalize_key_without_modifiers(symbol: int, expected_name: str) -> None:
+    assert _normalize_key(symbol, 0) == (expected_name, 0)
+
+
+@pytest.mark.parametrize(
+    "symbol, expected_name",
+    [
+        (pyglet_key.A, "a"),
+        (pyglet_key.RIGHT, "right"),
+        (pyglet_key.LEFT, "left"),
+        (pyglet_key.UP, "up"),
+        (pyglet_key.DOWN, "down"),
+        (pyglet_key.ESCAPE, "escape"),
+        (pyglet_key.TAB, "tab"),
+        (pyglet_key.SPACE, "space"),
+        (pyglet_key.ENTER, "enter"),
+        (pyglet_key.RETURN, "enter"),
+    ],
+)
+@pytest.mark.parametrize(
+    "pyglet_modifiers, expected_modifier_keys",
+    [
+        (pyglet_key.MOD_SHIFT, MOD_SHIFT),
+        (pyglet_key.MOD_CTRL, MOD_CTRL),
+        (pyglet_key.MOD_ALT, MOD_ALT),
+        (pyglet_key.MOD_COMMAND, MOD_META),
+        (pyglet_key.MOD_CTRL | pyglet_key.MOD_SHIFT, MOD_CTRL | MOD_SHIFT),
+    ],
+)
+def test_normalize_key_preserves_modifiers(
+    symbol: int,
+    expected_name: str,
+    pyglet_modifiers: int,
+    expected_modifier_keys: int,
+) -> None:
+    """Every named key must carry its modifier mask, not only tab/space/enter."""
+    assert _normalize_key(symbol, pyglet_modifiers) == (expected_name, expected_modifier_keys)
+
+
+def test_normalize_key_ctrl_a_reaches_editable_text_shortcut() -> None:
+    """Ctrl+A must arrive as the ("a", MOD_CTRL) pair EditableText gates its shortcuts on."""
+    name, modifier_keys = _normalize_key(pyglet_key.A, pyglet_key.MOD_CTRL)
+    assert name == "a"
+    assert bool(modifier_keys & (MOD_CTRL | MOD_META))
+
+
+def test_normalize_key_cmd_a_reaches_editable_text_shortcut() -> None:
+    """Cmd+A (macOS) maps to META and must satisfy the same gate."""
+    name, modifier_keys = _normalize_key(pyglet_key.A, pyglet_key.MOD_COMMAND)
+    assert name == "a"
+    assert bool(modifier_keys & (MOD_CTRL | MOD_META))
+
+
+def test_normalize_key_shift_arrow_reaches_slider_coarse_step() -> None:
+    """Shift+Arrow must arrive with MOD_SHIFT so Slider takes its 10x step."""
+    name, modifier_keys = _normalize_key(pyglet_key.RIGHT, pyglet_key.MOD_SHIFT)
+    assert name == "right"
+    assert bool(modifier_keys & MOD_SHIFT)
+
+
+def test_normalize_key_ignores_unknown_modifier_bits() -> None:
+    """Modifier bits nuiitivet does not model must not leak into the mask."""
+    assert _normalize_key(pyglet_key.A, pyglet_key.MOD_CAPSLOCK) == ("a", 0)
+
+
+def test_normalize_key_names_unknown_symbol_but_keeps_modifiers() -> None:
+    """An unmapped symbol still yields a name from pyglet and keeps its modifiers."""
+    name, modifier_keys = _normalize_key(999999, pyglet_key.MOD_CTRL)
+    assert name == "999999"
+    assert modifier_keys == MOD_CTRL
+
+
+def test_normalize_key_keeps_modifiers_when_name_lookup_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure naming the key must not zero out an already-resolved modifier mask."""
+
+    def boom(_symbol: int) -> str:
+        raise RuntimeError("symbol_string failed")
+
+    monkeypatch.setattr(pyglet_key, "symbol_string", boom)
+
+    assert _normalize_key(pyglet_key.A, pyglet_key.MOD_CTRL) == ("", MOD_CTRL)
+
+
+@pytest.mark.parametrize(
+    "pyglet_modifiers, expected_modifier_keys",
+    [
+        (0, 0),
+        (pyglet_key.MOD_SHIFT, MOD_SHIFT),
+        (pyglet_key.MOD_CTRL, MOD_CTRL),
+        (pyglet_key.MOD_ALT, MOD_ALT),
+        (pyglet_key.MOD_COMMAND, MOD_META),
+        (
+            pyglet_key.MOD_SHIFT | pyglet_key.MOD_CTRL | pyglet_key.MOD_ALT | pyglet_key.MOD_COMMAND,
+            MOD_SHIFT | MOD_CTRL | MOD_ALT | MOD_META,
+        ),
+    ],
+)
+def test_normalize_modifiers(pyglet_modifiers: int, expected_modifier_keys: int) -> None:
+    assert _normalize_modifiers(pyglet_modifiers) == expected_modifier_keys


### PR DESCRIPTION
## Summary
- Fix `_normalize_key` dropping the modifier mask for every key except `tab`/`space`/`enter`. Modifier normalization is split into `_normalize_modifiers` and resolved independently of the key name, so the mask is returned on every path.
- Revives features that were dead on the pyglet backend: TextField Ctrl+A/C/V/X (and the Cmd equivalents), Slider Shift+Arrow 10x coarse step, and escape's modifier propagation to the back handler.
- Add `tests/runtime/test_normalize_key.py` covering the backend-to-widget boundary: a letter key, arrow keys, escape, and the three special-cased keys, each with and without modifiers, plus the name-lookup-failure path.
- Also fix a pre-existing import-order dependency in `test_draw_raster_frame_success` (patch the runner's `pyglet` global directly instead of `sys.modules`).

## Test plan
- [x] `python -m pytest tests/` — 1612 passed
- [x] New tests fail 34x against the old behavior and pass 72x after the fix (confirms the change catches the defect)
- [x] Drove widgets end-to-end: Ctrl+A/Cmd+A select-all, Shift+Right takes the 10x step
- [x] `python -m mypy src/nuiitivet/backends/pyglet/runner.py` — clean

Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)