### PR TITLE
fix: deliver key-release events to widgets and track a modifier-key mask

### DIFF
--- a/samples/modifiers/interaction/focusable.py
+++ b/samples/modifiers/interaction/focusable.py
@@ -1,17 +1,16 @@
 import nuiitivet.material as nv
-from nuiitivet.input import MOD_ALT, MOD_CTRL, MOD_META, MOD_SHIFT
 
 
 def _format_modifier_keys(modifier_keys: int) -> str:
     """Render a modifier-key bitmask as a human-readable string like 'CTRL|SHIFT'."""
     names = []
-    if modifier_keys & MOD_SHIFT:
+    if modifier_keys & nv.MOD_SHIFT:
         names.append("SHIFT")
-    if modifier_keys & MOD_CTRL:
+    if modifier_keys & nv.MOD_CTRL:
         names.append("CTRL")
-    if modifier_keys & MOD_ALT:
+    if modifier_keys & nv.MOD_ALT:
         names.append("ALT")
-    if modifier_keys & MOD_META:
+    if modifier_keys & nv.MOD_META:
         names.append("META")
     return "|".join(names) if names else "-"
 

--- a/samples/modifiers/interaction/focusable.py
+++ b/samples/modifiers/interaction/focusable.py
@@ -1,33 +1,86 @@
 import nuiitivet.material as nv
+from nuiitivet.input import MOD_ALT, MOD_CTRL, MOD_META, MOD_SHIFT
+
+
+def _format_modifier_keys(modifier_keys: int) -> str:
+    """Render a modifier-key bitmask as a human-readable string like 'CTRL|SHIFT'."""
+    names = []
+    if modifier_keys & MOD_SHIFT:
+        names.append("SHIFT")
+    if modifier_keys & MOD_CTRL:
+        names.append("CTRL")
+    if modifier_keys & MOD_ALT:
+        names.append("ALT")
+    if modifier_keys & MOD_META:
+        names.append("META")
+    return "|".join(names) if names else "-"
 
 
 class FocusDemo(nv.ComposableWidget):
-    def __init__(self):
+    def __init__(self, label: str):
         super().__init__()
+        self.label = label
         self.is_focused = nv.Observable(False)
+        # Last observed key event, shown live in the widget so behavior is
+        # visible without watching the console.
+        self.last_event = nv.Observable("(no key yet)")
 
-    def _set_focused(self, focused: bool) -> None:
+    def _set_focused(self, focused: bool, source) -> None:
+        # ``on_focus_change`` is invoked as ``(focused, source)``; ``source`` is a
+        # FocusSource enum (KEYBOARD / POINTER).
         self.is_focused.value = focused
+        print(f"[{self.label}] focus_change   focused={focused} source={getattr(source, 'value', source)}")
+
+    def _on_key(self, key: str, modifier_keys: int) -> bool:
+        mods = _format_modifier_keys(modifier_keys)
+        print(f"[{self.label}] key_DOWN       key={key!r:<10} mods={mods}")
+        self.last_event.value = f"DOWN {key} [{mods}]"
+        return True
+
+    def _on_key_up(self, key: str, modifier_keys: int) -> bool:
+        mods = _format_modifier_keys(modifier_keys)
+        print(f"[{self.label}] key_UP         key={key!r:<10} mods={mods}")
+        self.last_event.value = f"UP {key} [{mods}]"
+        return True
 
     def build(self):
         border_color = self.is_focused.map(lambda f: "#2196F3" if f else "#00000000")
 
         return nv.Container(
-            width=200,
-            height=50,
-            child=nv.Text("Focus with Tab"),
+            width=280,
+            height=64,
+            child=nv.Column(
+                children=[
+                    nv.Text(self.label),
+                    nv.Text(self.last_event),
+                ],
+                gap=4,
+            ),
             alignment="center",
         ).modifier(
             nv.background("#E0E0E0")
             | nv.corner_radius(8)
             | nv.border(color=border_color, width=2)
-            | nv.focusable(on_focus_change=self._set_focused)
+            | nv.focusable(
+                on_focus_change=self._set_focused,
+                on_key=self._on_key,
+                on_key_up=self._on_key_up,
+            )
         )
 
 
 def main(png: str = ""):
+    print("=" * 68)
+    print("Focusable key-event demo (#310)")
+    print("  1. Press Tab to focus a field (watch focus_change).")
+    print("  2. Type letters / arrows -> key_DOWN then key_UP for each.")
+    print("  3. Hold Shift/Ctrl/Alt/Cmd while typing -> mods shows the mask.")
+    print("  4. Press & release Escape -> back-navigation, no phantom DOWN.")
+    print("  5. Cmd/Alt+Tab away and back -> mask is cleared on deactivate.")
+    print("=" * 68)
+
     content = nv.Column(
-        children=[FocusDemo(), FocusDemo()],
+        children=[FocusDemo("field-1"), FocusDemo("field-2")],
         gap=16,
         padding=16,
     )

--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -47,6 +47,9 @@ from nuiitivet.overlay import OverlayAware
 # State Management
 from nuiitivet.observable import Observable, batch, combine, clock
 
+# Input (keyboard-modifier masks for ``on_key`` / ``on_key_up`` handlers)
+from nuiitivet.input.codes import MOD_ALT, MOD_CTRL, MOD_META, MOD_SHIFT
+
 # Theme
 from nuiitivet.theme.theme import Theme
 from nuiitivet.theme.type_scale import TypeScale, TypeScaleToken
@@ -175,6 +178,11 @@ __all__: list[str] = [
     "translate",
     "visible",
     "will_pop",
+    # Input
+    "MOD_SHIFT",
+    "MOD_CTRL",
+    "MOD_ALT",
+    "MOD_META",
     # Window / runtime
     "AppScope",
     "OSChrome",

--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -5,7 +5,6 @@ This module owns the pyglet dependency so the core package remains backend-agnos
 
 from __future__ import annotations
 
-import asyncio
 import io
 import logging
 import math
@@ -752,7 +751,16 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
 
     @window.event
     def on_deactivate():
-        pass
+        # Focus left the window, so key-up events for anything currently held
+        # will be delivered to another app and never reach us. Clear the
+        # authoritative modifier-key mask and the Escape latch so a key released
+        # while inactive cannot leave permanently-wrong state behind.
+        nonlocal esc_down
+        esc_down = False
+        try:
+            app._clear_modifier_keys()
+        except Exception:
+            exception_once(logger, "pyglet_on_deactivate_clear_modifier_keys_exc", "Failed to clear modifier-key mask")
 
     @window.event
     def on_resize(width, height):
@@ -841,6 +849,11 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
     def on_key_press(symbol, modifiers):
         key_name, modifier_keys = _normalize_key(symbol, modifiers)
 
+        try:
+            app._set_modifier_keys(modifier_keys)
+        except Exception:
+            exception_once(logger, "pyglet_on_key_press_set_modifier_keys_exc", "Failed to update modifier-key mask")
+
         nonlocal esc_down
         if str(key_name).strip().lower() == "escape":
             can_handle = False
@@ -898,32 +911,31 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
     def on_key_release(symbol, modifiers):
         key_name, modifier_keys = _normalize_key(symbol, modifiers)
 
-        nonlocal esc_down
-        if str(key_name).strip().lower() != "escape":
-            return False
-        if not esc_down:
-            return True
-        esc_down = False
+        try:
+            app._set_modifier_keys(modifier_keys)
+        except Exception:
+            exception_once(logger, "pyglet_on_key_release_set_modifier_keys_exc", "Failed to update modifier-key mask")
 
-        handler = getattr(app, "handle_back_event", None)
-        if callable(handler):
-            try:
-                # ESC was already captured as handled on key_press; schedule the
-                # async back handler as a task and treat the key as handled.
-                asyncio.create_task(handler())
-                handled = True
-            except Exception:
-                exception_once(logger, "pyglet_on_key_release_back_handler_exc", "Back handler raised")
-                handled = False
-        else:
-            try:
-                handled = bool(app._dispatch_key_press("escape", modifier_keys))
-            except Exception:
-                exception_once(logger, "pyglet_on_key_release_dispatch_exc", "Key release dispatch raised")
-                handled = False
+        nonlocal esc_down
+        if str(key_name).strip().lower() == "escape":
+            # Back-navigation fires on the Escape release, gated by the press
+            # latch: a release without a matching press (e.g. focus returned
+            # mid-tap) must not trigger it.
+            if not esc_down:
+                return True
+            esc_down = False
+
+        try:
+            # Escape is routed to handle_back_event inside _dispatch_key_release;
+            # every other key is delivered to the focused node as a release. No
+            # press is ever synthesized from a release.
+            handled = bool(app._dispatch_key_release(key_name, modifier_keys))
+        except Exception:
+            exception_once(logger, "pyglet_on_key_release_dispatch_exc", "Key release dispatch raised")
+            handled = False
 
         if debug_keys:
-            kn = "escape"
+            kn = str(key_name).strip().lower()
             if not debug_keys_filter or kn in debug_keys_filter:
                 ts = time.perf_counter()
                 print(f"[nuiitivet] key_release t={ts:.6f} key={kn} mods={modifier_keys} handled={handled}")

--- a/src/nuiitivet/input/events.py
+++ b/src/nuiitivet/input/events.py
@@ -18,6 +18,8 @@ class KeyInputEvent:
 
     key: str
     modifier_keys: int = 0
+    released: bool = False
+    """True when the event is a key release rather than a key press."""
 
 
 @dataclass(frozen=True)

--- a/src/nuiitivet/modifiers/focus.py
+++ b/src/nuiitivet/modifiers/focus.py
@@ -11,10 +11,12 @@ class FocusableModifier(ModifierElement):
         enabled: bool = True,
         on_focus_change: Optional[FocusChangeCallback] = None,
         on_key: Optional[Callable[[str, int], bool]] = None,
+        on_key_up: Optional[Callable[[str, int], bool]] = None,
     ) -> None:
         self.enabled = enabled
         self.on_focus_change = on_focus_change
         self.on_key = on_key
+        self.on_key_up = on_key_up
 
     def apply(self, widget: Widget) -> Widget:
         if not self.enabled:
@@ -29,6 +31,7 @@ class FocusableModifier(ModifierElement):
             node = FocusNode(
                 on_focus_change=self.on_focus_change,
                 on_key=self.on_key,
+                on_key_up=self.on_key_up,
             )
             region.add_node(node)
         else:
@@ -49,6 +52,7 @@ def focusable(
     enabled: bool = True,
     on_focus_change: Optional[FocusChangeCallback] = None,
     on_key: Optional[Callable[[str, int], bool]] = None,
+    on_key_up: Optional[Callable[[str, int], bool]] = None,
 ) -> FocusableModifier:
     """
     Mark the widget as focusable.
@@ -56,9 +60,12 @@ def focusable(
     Args:
         enabled: Whether the widget is focusable.
         on_focus_change: Callback invoked when focus state changes.
-        on_key: Callback invoked as ``on_key(key, modifier_keys)`` when a key
-                event occurs while focused. ``modifier_keys`` is a bitmask of
-                the held modifier keys (``MOD_SHIFT``, ``MOD_CTRL``, ...).
-                Return True to stop propagation (bubbling).
+        on_key: Callback invoked as ``on_key(key, modifier_keys)`` when a key is
+                pressed while focused. ``modifier_keys`` is a bitmask of the held
+                modifier keys (``MOD_SHIFT``, ``MOD_CTRL``, ...). Return True to
+                stop propagation (bubbling).
+        on_key_up: Callback invoked as ``on_key_up(key, modifier_keys)`` when a
+                key is released while focused. Bubbles to ancestor focusables and
+                stops on a truthy return, exactly like ``on_key``.
     """
-    return FocusableModifier(enabled, on_focus_change, on_key)
+    return FocusableModifier(enabled, on_focus_change, on_key, on_key_up)

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -289,6 +289,7 @@ class App:
         self._last_hover_target = None
         self._focused_target: Optional[InteractionHostMixin] = None
         self._focused_node: Optional[FocusNode] = None
+        self._modifier_keys: int = 0
         self._pointer_capture_manager = PointerCaptureManager()
         self._pointer_capture_manager.set_cancel_callback(self._handle_pointer_cancel)
         self._primary_pointer_id = 1
@@ -902,6 +903,71 @@ class App:
                 exception_once(logger, "app_focused_node_handle_key_exc", "Focused node handle_key_event raised")
 
         return False
+
+    def _dispatch_key_release(self, key, modifier_keys=0) -> bool:
+        """Handle key releases, mirroring :meth:`_dispatch_key_press`.
+
+        Back-navigation keys off the Escape *release* (the press only latches
+        intent), so Escape is routed to :meth:`handle_back_event` here rather
+        than to the focused node. Every other key is routed to the focused
+        :class:`FocusNode` via :meth:`FocusNode.handle_key_release_event`, with
+        the same bubbling semantics as key press. Unlike a press there is no Tab
+        traversal — traversal is a press-time action. Returns True if handled.
+        """
+        kname = None
+        try:
+            if isinstance(key, str):
+                kname = key.lower()
+        except Exception:
+            debug_once(logger, "app_key_release_name_lower_exc", "Failed to normalize key name")
+            kname = None
+
+        if kname == "escape":
+            import asyncio
+
+            asyncio.create_task(self.handle_back_event())
+            return True
+
+        if self._focused_node:
+            try:
+                if self._focused_node.handle_key_release_event(kname or str(key), modifier_keys):
+                    return True
+            except Exception:
+                exception_once(
+                    logger,
+                    "app_focused_node_handle_key_release_exc",
+                    "Focused node handle_key_release_event raised",
+                )
+
+        return False
+
+    @property
+    def modifier_keys(self) -> int:
+        """The keyboard-modifier keys currently held down.
+
+        A bitmask of ``MOD_SHIFT``/``MOD_CTRL``/``MOD_ALT``/``MOD_META``. This is
+        the single authoritative source of "which modifier keys are down",
+        maintained by the backend on every key press and release and cleared on
+        window deactivation. It is exposed for framework internals only and must
+        not be treated as mutable application state.
+        """
+        return self._modifier_keys
+
+    def _set_modifier_keys(self, modifier_keys: int) -> None:
+        """Update the authoritative modifier-key mask (framework-internal)."""
+        try:
+            self._modifier_keys = int(modifier_keys)
+        except Exception:
+            debug_once(logger, "app_set_modifier_keys_exc", "Failed to set modifier-key mask")
+            self._modifier_keys = 0
+
+    def _clear_modifier_keys(self) -> None:
+        """Clear the authoritative modifier-key mask (framework-internal).
+
+        Called when the window loses focus so that a modifier released while the
+        app was inactive cannot leave a permanently stuck mask.
+        """
+        self._modifier_keys = 0
 
     def _dispatch_text(self, text: str) -> bool:
         """Handle text input events."""

--- a/src/nuiitivet/widgeting/widget_input.py
+++ b/src/nuiitivet/widgeting/widget_input.py
@@ -106,6 +106,16 @@ class InputHubMixin:
     def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:  # pragma: no cover - default no-op
         return False
 
+    def handle_key_release_event(self, key: str, modifier_keys: int = 0) -> bool:
+        with batch():
+            event = KeyInputEvent(key=key, modifier_keys=modifier_keys, released=True)
+            if self._dispatch_input("key", event):
+                return True
+            return bool(self.on_key_release_event(key, modifier_keys))
+
+    def on_key_release_event(self, key: str, modifier_keys: int = 0) -> bool:  # pragma: no cover - default no-op
+        return False
+
     # --- Focus delivery ----------------------------------------------------
     def handle_focus_event(self, event: FocusEvent) -> bool:
         with batch():

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -532,6 +532,7 @@ class FocusNode(InteractionNode):
         *,
         on_focus_change: Optional[FocusChangeCallback] = None,
         on_key: Optional[Callable[[str, int], bool]] = None,
+        on_key_up: Optional[Callable[[str, int], bool]] = None,
         on_text: Optional[Callable[[str], bool]] = None,
         on_text_motion: Optional[Callable[[int, bool], bool]] = None,
         on_ime_composition: Optional[Callable[[str, int, int], bool]] = None,
@@ -539,6 +540,7 @@ class FocusNode(InteractionNode):
         super().__init__()
         self._on_focus_change = on_focus_change
         self._on_key = on_key
+        self._on_key_up = on_key_up
         self._on_text = on_text
         self._on_text_motion = on_text_motion
         self._on_ime_composition = on_ime_composition
@@ -612,6 +614,23 @@ class FocusNode(InteractionNode):
         p = self.parent
         if p:
             return p.handle_key_event(key, modifier_keys)
+        return False
+
+    def handle_key_release_event(self, key: str, modifier_keys: int) -> bool:
+        """Handle a key release, bubbling to ancestors like key press.
+
+        Mirrors :meth:`handle_key_event`: the ``on_key_up`` callback may return
+        True to consume the release and stop propagation; otherwise it bubbles to
+        the nearest ancestor :class:`FocusNode`.
+        """
+        if self._on_key_up:
+            if self._on_key_up(key, modifier_keys):
+                return True
+
+        # Bubbling: Try parent
+        p = self.parent
+        if p:
+            return p.handle_key_release_event(key, modifier_keys)
         return False
 
     def handle_text_event(self, text: str) -> bool:

--- a/tests/input/test_key_release.py
+++ b/tests/input/test_key_release.py
@@ -1,8 +1,8 @@
 """Tests for key-release delivery and the authoritative modifier-key mask.
 
-Key release had no dispatch path at all before #310: the runner dropped every
-symbol except ``escape`` and forwarded that one as a *press*. These tests cover
-the release path end to end at the framework boundary — ``_dispatch_key_release``,
+Key release had no dispatch path before #310: the runner dropped every symbol
+except ``escape`` and forwarded that one as a *press*. These tests cover the
+release path end to end at the framework boundary — ``_dispatch_key_release``,
 ``FocusNode.handle_key_release_event``, ``focusable(on_key_up=...)`` — plus the
 App-owned modifier-key mask that release maintenance and window deactivation feed.
 """
@@ -10,6 +10,7 @@ App-owned modifier-key mask that release maintenance and window deactivation fee
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 from pyglet.window import key as pyglet_key
@@ -22,7 +23,7 @@ from nuiitivet.navigation import Navigator
 from nuiitivet.overlay import Overlay
 from nuiitivet.runtime.app import App
 from nuiitivet.widgets.box import Box
-from nuiitivet.widgets.interaction import FocusNode
+from nuiitivet.widgets.interaction import FocusNode, InteractionHostMixin
 from nuiitivet.widgeting.widget import Widget
 
 
@@ -31,10 +32,24 @@ class _LeafWidget(Widget):
         pass
 
 
+def _record(sink: list[Any], value: Any, result: bool) -> bool:
+    """Append ``value`` to ``sink`` and return ``result`` (a valid bool callback)."""
+    sink.append(value)
+    return result
+
+
 def _mounted_app(root: Widget) -> App:
     app = App(root)
     app.root.mount(app)
     return app
+
+
+def _focus(widget: Widget) -> None:
+    """Focus the FocusNode hosted by ``widget`` (which ``focusable()`` wrapped)."""
+    assert isinstance(widget, InteractionHostMixin)
+    node = widget.get_node(FocusNode)
+    assert isinstance(node, FocusNode)
+    node.request_focus()
 
 
 # ---------------------------------------------------------------------------
@@ -48,14 +63,14 @@ def test_letter_press_and_release_reach_separate_callbacks() -> None:
 
     child = _LeafWidget().modifier(
         focusable(
-            on_key=lambda k, m: presses.append((k, m)) or True,
-            on_key_up=lambda k, m: releases.append((k, m)) or True,
+            on_key=lambda k, m: _record(presses, (k, m), True),
+            on_key_up=lambda k, m: _record(releases, (k, m), True),
         )
     )
     root = Box()
     root.add_child(child)
     app = _mounted_app(root)
-    child.get_node(FocusNode).request_focus()
+    _focus(child)
 
     assert app._dispatch_key_press("a") is True
     assert app._dispatch_key_release("a") is True
@@ -70,11 +85,11 @@ def test_release_does_not_synthesize_a_press() -> None:
     """A node with only on_key must never see its press callback fire on release."""
     presses: list[str] = []
 
-    child = _LeafWidget().modifier(focusable(on_key=lambda k, m: presses.append(k) or True))
+    child = _LeafWidget().modifier(focusable(on_key=lambda k, m: _record(presses, k, True)))
     root = Box()
     root.add_child(child)
     app = _mounted_app(root)
-    child.get_node(FocusNode).request_focus()
+    _focus(child)
 
     assert app._dispatch_key_release("a") is False  # nothing consumes it
     assert presses == []  # crucially: no phantom press
@@ -90,13 +105,11 @@ def test_release_does_not_synthesize_a_press() -> None:
 def test_modifier_key_release_carries_mask() -> None:
     releases: list[tuple[str, int]] = []
 
-    child = _LeafWidget().modifier(
-        focusable(on_key_up=lambda k, m: releases.append((k, m)) or True)
-    )
+    child = _LeafWidget().modifier(focusable(on_key_up=lambda k, m: _record(releases, (k, m), True)))
     root = Box()
     root.add_child(child)
     app = _mounted_app(root)
-    child.get_node(FocusNode).request_focus()
+    _focus(child)
 
     assert app._dispatch_key_release("lctrl", MOD_CTRL) is True
     assert releases == [("lctrl", MOD_CTRL)]
@@ -114,13 +127,13 @@ def test_release_bubbles_to_parent_focus_node() -> None:
     parent_releases: list[str] = []
 
     child = _LeafWidget().modifier(
-        focusable(on_key_up=lambda k, m: child_releases.append(k) or False)  # bubble up
+        focusable(on_key_up=lambda k, m: _record(child_releases, k, False))  # bubble up
     )
-    parent = Box().modifier(focusable(on_key_up=lambda k, m: parent_releases.append(k) or True))
+    parent = Box().modifier(focusable(on_key_up=lambda k, m: _record(parent_releases, k, True)))
     parent.add_child(child)
     app = _mounted_app(parent)
 
-    child.get_node(FocusNode).request_focus()
+    _focus(child)
     assert app._dispatch_key_release("b") is True
 
     assert child_releases == ["b"]
@@ -134,13 +147,13 @@ def test_release_bubbling_stops_on_truthy_return() -> None:
     parent_releases: list[str] = []
 
     child = _LeafWidget().modifier(
-        focusable(on_key_up=lambda k, m: child_releases.append(k) or True)  # consume
+        focusable(on_key_up=lambda k, m: _record(child_releases, k, True))  # consume
     )
-    parent = Box().modifier(focusable(on_key_up=lambda k, m: parent_releases.append(k) or True))
+    parent = Box().modifier(focusable(on_key_up=lambda k, m: _record(parent_releases, k, True)))
     parent.add_child(child)
     app = _mounted_app(parent)
 
-    child.get_node(FocusNode).request_focus()
+    _focus(child)
     assert app._dispatch_key_release("b") is True
 
     assert child_releases == ["b"]
@@ -174,11 +187,11 @@ async def test_escape_release_does_not_reach_focus_node() -> None:
     """Escape is consumed for back-navigation, mirroring the press path."""
     releases: list[str] = []
 
-    child = _LeafWidget().modifier(focusable(on_key_up=lambda k, m: releases.append(k) or True))
+    child = _LeafWidget().modifier(focusable(on_key_up=lambda k, m: _record(releases, k, True)))
     root = Box()
     root.add_child(child)
     app = _mounted_app(root)
-    child.get_node(FocusNode).request_focus()
+    _focus(child)
 
     app._dispatch_key_release("escape")
     await asyncio.sleep(0)

--- a/tests/input/test_key_release.py
+++ b/tests/input/test_key_release.py
@@ -1,0 +1,222 @@
+"""Tests for key-release delivery and the authoritative modifier-key mask.
+
+Key release had no dispatch path at all before #310: the runner dropped every
+symbol except ``escape`` and forwarded that one as a *press*. These tests cover
+the release path end to end at the framework boundary — ``_dispatch_key_release``,
+``FocusNode.handle_key_release_event``, ``focusable(on_key_up=...)`` — plus the
+App-owned modifier-key mask that release maintenance and window deactivation feed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pyglet.window import key as pyglet_key
+
+from nuiitivet.backends.pyglet.runner import _normalize_key
+from nuiitivet.input.codes import MOD_CTRL, MOD_SHIFT
+from nuiitivet.layout.container import Container
+from nuiitivet.modifiers.focus import focusable
+from nuiitivet.navigation import Navigator
+from nuiitivet.overlay import Overlay
+from nuiitivet.runtime.app import App
+from nuiitivet.widgets.box import Box
+from nuiitivet.widgets.interaction import FocusNode
+from nuiitivet.widgeting.widget import Widget
+
+
+class _LeafWidget(Widget):
+    def paint(self, canvas, x, y, w, h):  # pragma: no cover - never painted
+        pass
+
+
+def _mounted_app(root: Widget) -> App:
+    app = App(root)
+    app.root.mount(app)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Letter key: press/release pair
+# ---------------------------------------------------------------------------
+
+
+def test_letter_press_and_release_reach_separate_callbacks() -> None:
+    presses: list[tuple[str, int]] = []
+    releases: list[tuple[str, int]] = []
+
+    child = _LeafWidget().modifier(
+        focusable(
+            on_key=lambda k, m: presses.append((k, m)) or True,
+            on_key_up=lambda k, m: releases.append((k, m)) or True,
+        )
+    )
+    root = Box()
+    root.add_child(child)
+    app = _mounted_app(root)
+    child.get_node(FocusNode).request_focus()
+
+    assert app._dispatch_key_press("a") is True
+    assert app._dispatch_key_release("a") is True
+
+    assert presses == [("a", 0)]
+    assert releases == [("a", 0)]
+
+    app.root.unmount()
+
+
+def test_release_does_not_synthesize_a_press() -> None:
+    """A node with only on_key must never see its press callback fire on release."""
+    presses: list[str] = []
+
+    child = _LeafWidget().modifier(focusable(on_key=lambda k, m: presses.append(k) or True))
+    root = Box()
+    root.add_child(child)
+    app = _mounted_app(root)
+    child.get_node(FocusNode).request_focus()
+
+    assert app._dispatch_key_release("a") is False  # nothing consumes it
+    assert presses == []  # crucially: no phantom press
+
+    app.root.unmount()
+
+
+# ---------------------------------------------------------------------------
+# Modifier key: press/release pair carries the mask
+# ---------------------------------------------------------------------------
+
+
+def test_modifier_key_release_carries_mask() -> None:
+    releases: list[tuple[str, int]] = []
+
+    child = _LeafWidget().modifier(
+        focusable(on_key_up=lambda k, m: releases.append((k, m)) or True)
+    )
+    root = Box()
+    root.add_child(child)
+    app = _mounted_app(root)
+    child.get_node(FocusNode).request_focus()
+
+    assert app._dispatch_key_release("lctrl", MOD_CTRL) is True
+    assert releases == [("lctrl", MOD_CTRL)]
+
+    app.root.unmount()
+
+
+# ---------------------------------------------------------------------------
+# Bubbling to a parent FocusNode
+# ---------------------------------------------------------------------------
+
+
+def test_release_bubbles_to_parent_focus_node() -> None:
+    child_releases: list[str] = []
+    parent_releases: list[str] = []
+
+    child = _LeafWidget().modifier(
+        focusable(on_key_up=lambda k, m: child_releases.append(k) or False)  # bubble up
+    )
+    parent = Box().modifier(focusable(on_key_up=lambda k, m: parent_releases.append(k) or True))
+    parent.add_child(child)
+    app = _mounted_app(parent)
+
+    child.get_node(FocusNode).request_focus()
+    assert app._dispatch_key_release("b") is True
+
+    assert child_releases == ["b"]
+    assert parent_releases == ["b"]
+
+    app.root.unmount()
+
+
+def test_release_bubbling_stops_on_truthy_return() -> None:
+    child_releases: list[str] = []
+    parent_releases: list[str] = []
+
+    child = _LeafWidget().modifier(
+        focusable(on_key_up=lambda k, m: child_releases.append(k) or True)  # consume
+    )
+    parent = Box().modifier(focusable(on_key_up=lambda k, m: parent_releases.append(k) or True))
+    parent.add_child(child)
+    app = _mounted_app(parent)
+
+    child.get_node(FocusNode).request_focus()
+    assert app._dispatch_key_release("b") is True
+
+    assert child_releases == ["b"]
+    assert parent_releases == []  # child consumed it, no bubbling
+
+    app.root.unmount()
+
+
+# ---------------------------------------------------------------------------
+# Escape: release drives back-navigation, no press is synthesized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escape_release_triggers_back_navigation() -> None:
+    app = App(content=Container())
+    Overlay.root()
+    navigator = Navigator.root()
+    navigator.push(Container())
+
+    assert navigator.can_pop() is True
+
+    handled = app._dispatch_key_release("escape")
+    assert handled is True
+    await asyncio.sleep(0)  # allow back event task to run
+    assert navigator.can_pop() is False
+
+
+@pytest.mark.asyncio
+async def test_escape_release_does_not_reach_focus_node() -> None:
+    """Escape is consumed for back-navigation, mirroring the press path."""
+    releases: list[str] = []
+
+    child = _LeafWidget().modifier(focusable(on_key_up=lambda k, m: releases.append(k) or True))
+    root = Box()
+    root.add_child(child)
+    app = _mounted_app(root)
+    child.get_node(FocusNode).request_focus()
+
+    app._dispatch_key_release("escape")
+    await asyncio.sleep(0)
+    assert releases == []
+
+    app.root.unmount()
+
+
+# ---------------------------------------------------------------------------
+# Authoritative modifier-key mask
+# ---------------------------------------------------------------------------
+
+
+def test_modifier_key_mask_is_exposed_and_read_only_default() -> None:
+    app = App(content=Container())
+    assert app.modifier_keys == 0
+
+    app._set_modifier_keys(MOD_CTRL | MOD_SHIFT)
+    assert app.modifier_keys == MOD_CTRL | MOD_SHIFT
+
+
+def test_modifier_key_mask_cleared_on_deactivate() -> None:
+    """Mimics on_deactivate: a modifier held when focus is lost must not stick."""
+    app = App(content=Container())
+    app._set_modifier_keys(MOD_CTRL)
+    assert app.modifier_keys == MOD_CTRL
+
+    app._clear_modifier_keys()
+    assert app.modifier_keys == 0
+
+
+# ---------------------------------------------------------------------------
+# _normalize_key is exercised on the release path, not only press
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_key_resolves_modifier_release() -> None:
+    """The release handler forwards whatever _normalize_key returns for a modifier."""
+    name, modifier_keys = _normalize_key(pyglet_key.LCTRL, pyglet_key.MOD_CTRL)
+    assert name == "lctrl"
+    assert modifier_keys == MOD_CTRL


### PR DESCRIPTION
## Summary
- Add `Application._dispatch_key_release`, mirroring `_dispatch_key_press`: escape drives `handle_back_event`, every other key bubbles to the focused `FocusNode` via `handle_key_release_event`
- Add `on_key_up` to `FocusNode`, `focusable()`, and a `WidgetInput.on_key_release_event` counterpart; tag `KeyInputEvent.released`
- Rewrite the pyglet runner's `on_key_release` to normalize and forward every symbol, removing the phantom press synthesized from escape's release
- Maintain an authoritative `App.modifier_keys` mask (read-only for framework internals), updated on every press/release and cleared with the escape latch on window deactivation
- Extend the `focusable` sample to print key down/up and the modifier mask

Closes #310. Depends on #306 (merged) and #309 (merged).

## Test plan
- [x] `pytest` full suite green (1622 passed), incl. new `tests/input/test_key_release.py`
- [x] `mypy` clean on changed files
- [ ] Run `python samples/modifiers/interaction/focusable.py`: Tab focuses a field; letters/arrows print `key_DOWN`/`key_UP`; Shift/Ctrl show the mask; Escape triggers back-nav with no phantom press

🤖 Generated with [Claude Code](https://claude.com/claude-code)