### PR TITLE
fix: route mouse button and modifiers into PointerEvent (#305)

### DIFF
--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -47,8 +47,17 @@ from nuiitivet.overlay import OverlayAware
 # State Management
 from nuiitivet.observable import Observable, batch, combine, clock
 
-# Input (keyboard-modifier masks for ``on_key`` / ``on_key_up`` handlers)
-from nuiitivet.input.codes import MOD_ALT, MOD_CTRL, MOD_META, MOD_SHIFT
+# Input (keyboard-modifier masks for ``on_key`` / ``on_key_up`` handlers and
+# backend-neutral pointer button codes for ``PointerEvent.button``)
+from nuiitivet.input.codes import (
+    BUTTON_LEFT,
+    BUTTON_MIDDLE,
+    BUTTON_RIGHT,
+    MOD_ALT,
+    MOD_CTRL,
+    MOD_META,
+    MOD_SHIFT,
+)
 
 # Theme
 from nuiitivet.theme.theme import Theme
@@ -183,6 +192,9 @@ __all__: list[str] = [
     "MOD_CTRL",
     "MOD_ALT",
     "MOD_META",
+    "BUTTON_LEFT",
+    "BUTTON_MIDDLE",
+    "BUTTON_RIGHT",
     # Window / runtime
     "AppScope",
     "OSChrome",

--- a/src/nuiitivet/backends/pyglet/runner.py
+++ b/src/nuiitivet/backends/pyglet/runner.py
@@ -20,6 +20,9 @@ from nuiitivet.platform import IMEManager
 from nuiitivet.rendering.skia import get_skia
 
 from nuiitivet.input.codes import (
+    BUTTON_LEFT,
+    BUTTON_MIDDLE,
+    BUTTON_RIGHT,
     MOD_ALT,
     MOD_CTRL,
     MOD_META,
@@ -807,16 +810,20 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
     @window.event
     def on_mouse_press(x, y, button, modifiers):
         x_log, y_conv = _to_logical(x, y)
+        button_n = _normalize_mouse_button(button)
+        modifier_keys = _normalize_modifiers(modifiers)
         try:
-            app._dispatch_mouse_press(x_log, y_conv)
+            app._dispatch_mouse_press(x_log, y_conv, button=button_n, modifier_keys=modifier_keys)
         except Exception:
             exception_once(logger, "pyglet_on_mouse_press_dispatch_exc", "Mouse press dispatch raised")
 
     @window.event
     def on_mouse_release(x, y, button, modifiers):
         x_log, y_conv = _to_logical(x, y)
+        button_n = _normalize_mouse_button(button)
+        modifier_keys = _normalize_modifiers(modifiers)
         try:
-            app._dispatch_mouse_release(x_log, y_conv)
+            app._dispatch_mouse_release(x_log, y_conv, button=button_n, modifier_keys=modifier_keys)
         except Exception:
             exception_once(logger, "pyglet_on_mouse_release_dispatch_exc", "Mouse release dispatch raised")
 
@@ -831,8 +838,10 @@ def run_app(app: Any, draw_fps: Optional[float] = None, renderer: RendererMode =
     @window.event
     def on_mouse_drag(x, y, dx, dy, buttons, modifiers):
         x_log, y_conv = _to_logical(x, y)
+        buttons_n = _normalize_mouse_buttons(buttons)
+        modifier_keys = _normalize_modifiers(modifiers)
         try:
-            app._dispatch_mouse_motion(x_log, y_conv)
+            app._dispatch_mouse_motion(x_log, y_conv, buttons=buttons_n, modifier_keys=modifier_keys)
         except Exception:
             exception_once(logger, "pyglet_on_mouse_drag_dispatch_exc", "Mouse drag dispatch raised")
 
@@ -1178,6 +1187,44 @@ def _normalize_modifiers(pyglet_modifiers: int) -> int:
         return modifier_keys
     except Exception:
         exception_once(logger, "pyglet_normalize_modifiers_exc", "Failed to normalize modifier mapping")
+        return 0
+
+
+def _normalize_mouse_button(pyglet_button: int) -> Optional[int]:
+    """Translate a single pyglet mouse button into a backend-neutral ``BUTTON_*``.
+
+    Returns ``None`` for an unrecognized button so the event carries no button
+    rather than leaking a raw pyglet value.
+    """
+    try:
+        mouse = pyglet.window.mouse
+
+        if pyglet_button == mouse.LEFT:
+            return BUTTON_LEFT
+        if pyglet_button == mouse.MIDDLE:
+            return BUTTON_MIDDLE
+        if pyglet_button == mouse.RIGHT:
+            return BUTTON_RIGHT
+    except Exception:
+        exception_once(logger, "pyglet_normalize_mouse_button_exc", "Failed to normalize mouse button")
+    return None
+
+
+def _normalize_mouse_buttons(pyglet_buttons: int) -> int:
+    """Translate a pyglet held-button bit mask into a ``BUTTON_*`` bit mask."""
+    try:
+        mouse = pyglet.window.mouse
+
+        buttons = 0
+        if pyglet_buttons & mouse.LEFT:
+            buttons |= BUTTON_LEFT
+        if pyglet_buttons & mouse.MIDDLE:
+            buttons |= BUTTON_MIDDLE
+        if pyglet_buttons & mouse.RIGHT:
+            buttons |= BUTTON_RIGHT
+        return buttons
+    except Exception:
+        exception_once(logger, "pyglet_normalize_mouse_buttons_exc", "Failed to normalize mouse buttons")
         return 0
 
 

--- a/src/nuiitivet/input/__init__.py
+++ b/src/nuiitivet/input/__init__.py
@@ -6,10 +6,14 @@ This package contains backend-agnostic, mostly pure input event types.
 from .events import FocusEvent, InputHandler, InputKind, KeyInputEvent
 from .pointer import PointerEvent, PointerEventType, PointerType
 from .codes import (
+    BUTTON_LEFT,
+    BUTTON_MIDDLE,
+    BUTTON_RIGHT,
     MOD_ALT,
     MOD_CTRL,
     MOD_META,
     MOD_SHIFT,
+    is_primary_button,
     TEXT_MOTION_BACKSPACE,
     TEXT_MOTION_DELETE,
     TEXT_MOTION_END,
@@ -19,6 +23,9 @@ from .codes import (
 )
 
 __all__ = [
+    "BUTTON_LEFT",
+    "BUTTON_MIDDLE",
+    "BUTTON_RIGHT",
     "FocusEvent",
     "InputHandler",
     "InputKind",
@@ -30,6 +37,7 @@ __all__ = [
     "PointerEvent",
     "PointerEventType",
     "PointerType",
+    "is_primary_button",
     "TEXT_MOTION_BACKSPACE",
     "TEXT_MOTION_DELETE",
     "TEXT_MOTION_END",

--- a/src/nuiitivet/input/codes.py
+++ b/src/nuiitivet/input/codes.py
@@ -5,11 +5,35 @@ These codes are normalized by the active backend (e.g. pyglet).
 
 from __future__ import annotations
 
+from typing import Optional
+
 # Modifier bit masks (backend-agnostic)
 MOD_SHIFT: int = 1 << 0
 MOD_CTRL: int = 1 << 1
 MOD_ALT: int = 1 << 2
 MOD_META: int = 1 << 3
+
+# Pointer button codes (backend-agnostic).
+#
+# These double as bit masks so a single button (``PointerEvent.button``) and a
+# set of held buttons (``PointerEvent.buttons``) share one encoding. The values
+# intentionally match pyglet's ``mouse.LEFT``/``MIDDLE``/``RIGHT`` ordering, but
+# the mapping is performed explicitly by the backend so no pyglet value ever
+# leaks through the public ``PointerEvent``.
+BUTTON_LEFT: int = 1 << 0
+BUTTON_MIDDLE: int = 1 << 1
+BUTTON_RIGHT: int = 1 << 2
+
+
+def is_primary_button(button: Optional[int]) -> bool:
+    """Return True if ``button`` counts as a primary (activating) button.
+
+    The left button is primary. ``None`` is also treated as primary so that
+    synthesized events and non-mouse pointers (touch/pen), which carry no
+    button, keep activating widgets.
+    """
+    return button is None or button == BUTTON_LEFT
+
 
 # Text motion codes (backend-agnostic)
 TEXT_MOTION_BACKSPACE: int = 1

--- a/src/nuiitivet/input/pointer.py
+++ b/src/nuiitivet/input/pointer.py
@@ -35,7 +35,20 @@ class PointerEventType(str, Enum):
 
 @dataclass(frozen=True)
 class PointerEvent:
-    """Immutable pointer event payload delivered to widgets."""
+    """Immutable pointer event payload delivered to widgets.
+
+    Button semantics:
+        ``button`` is the single button that *caused* this event — set on
+        ``PRESS`` and ``RELEASE`` (and carried through the synthesized
+        ``CANCEL``) to a backend-neutral ``BUTTON_*`` code, and ``None``
+        otherwise (``MOVE``/``HOVER``/``ENTER``/``LEAVE``/``SCROLL``, or a
+        synthetic/non-mouse event that carries no button).
+
+        ``buttons`` is a bit mask of the buttons currently *held down*, using
+        the same ``BUTTON_*`` codes OR-ed together. It is populated on ``MOVE``
+        (drag) events so a consumer can tell a right-drag from a left-drag; it
+        is ``0`` when no button is held.
+    """
 
     id: int
     type: PointerEventType
@@ -47,6 +60,7 @@ class PointerEvent:
     scroll_x: float = 0.0
     scroll_y: float = 0.0
     button: Optional[int] = None
+    buttons: int = 0
     timestamp: float = 0.0
     is_primary: bool = True
     modifier_keys: int = 0
@@ -61,6 +75,7 @@ class PointerEvent:
         dx: float = 0.0,
         dy: float = 0.0,
         button: Optional[int] = None,
+        buttons: int = 0,
         timestamp: Optional[float] = None,
         modifier_keys: int = 0,
     ) -> "PointerEvent":
@@ -73,6 +88,7 @@ class PointerEvent:
             dx=dx,
             dy=dy,
             button=button,
+            buttons=buttons,
             timestamp=time.time() if timestamp is None else float(timestamp),
             modifier_keys=modifier_keys,
         )

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -779,8 +779,8 @@ class App:
             raise RuntimeError("makeImageSnapshot() returned None")
         return img
 
-    def _dispatch_mouse_motion(self, x: int, y: int):
-        _dispatch_mouse_motion_fn(self, x, y)
+    def _dispatch_mouse_motion(self, x: int, y: int, *, buttons: int = 0, modifier_keys: int = 0):
+        _dispatch_mouse_motion_fn(self, x, y, buttons=buttons, modifier_keys=modifier_keys)
 
     # --- Keyboard / focus helpers ---------------------------------
     def request_focus(self, node: Optional[FocusNode], source: FocusSource = FocusSource.KEYBOARD) -> None:
@@ -1008,11 +1008,11 @@ class App:
                 )
         return False
 
-    def _dispatch_mouse_press(self, x: int, y: int):
-        _dispatch_mouse_press_fn(self, x, y)
+    def _dispatch_mouse_press(self, x: int, y: int, *, button: Optional[int] = None, modifier_keys: int = 0):
+        _dispatch_mouse_press_fn(self, x, y, button=button, modifier_keys=modifier_keys)
 
-    def _dispatch_mouse_release(self, x: int, y: int):
-        _dispatch_mouse_release_fn(self, x, y)
+    def _dispatch_mouse_release(self, x: int, y: int, *, button: Optional[int] = None, modifier_keys: int = 0):
+        _dispatch_mouse_release_fn(self, x, y, button=button, modifier_keys=modifier_keys)
 
     def _dispatch_mouse_scroll(self, x: int, y: int, scroll_x: float, scroll_y: float):
         _dispatch_mouse_scroll_fn(self, x, y, scroll_x, scroll_y)
@@ -1040,6 +1040,7 @@ class App:
             y=pivot.y,
             pointer_type=pivot.pointer_type,
             button=pivot.button,
+            buttons=pivot.buttons,
             timestamp=time.time(),
             modifier_keys=pivot.modifier_keys,
         )

--- a/src/nuiitivet/runtime/app_events.py
+++ b/src/nuiitivet/runtime/app_events.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Optional
 
 from .pointer import PointerCaptureManager
+from nuiitivet.input.codes import is_primary_button
 from nuiitivet.input.pointer import PointerEvent, PointerEventType
 from nuiitivet.common.logging_once import exception_once
 
@@ -75,13 +76,17 @@ def _deliver_pointer_event(app: Any, target: Any, event: PointerEvent) -> Option
     return handler
 
 
-def dispatch_mouse_motion(app: Any, x: int, y: int):
+def dispatch_mouse_motion(app: Any, x: int, y: int, *, buttons: int = 0, modifier_keys: int = 0):
     manager = _pointer_manager(app)
     pointer_id = _primary_pointer_id(app)
     owner = manager.owner_of(pointer_id) if manager is not None else None
 
     if owner is not None:
-        event = PointerEvent.mouse_event(pointer_id, PointerEventType.MOVE, x, y)
+        # Drag: carry the held-button mask so a consumer can distinguish a
+        # right-drag from a left-drag.
+        event = PointerEvent.mouse_event(
+            pointer_id, PointerEventType.MOVE, x, y, buttons=buttons, modifier_keys=modifier_keys
+        )
         _deliver_pointer_event(app, owner, event)
         if manager is not None:
             manager.update_event(event)
@@ -98,16 +103,24 @@ def dispatch_mouse_motion(app: Any, x: int, y: int):
 
     if prev is cur:
         if cur is not None:
-            hover_event = PointerEvent.mouse_event(pointer_id, PointerEventType.HOVER, x, y)
+            hover_event = PointerEvent.mouse_event(
+                pointer_id, PointerEventType.HOVER, x, y, buttons=buttons, modifier_keys=modifier_keys
+            )
             _deliver_pointer_event(app, cur, hover_event)
     else:
         if prev is not None:
-            leave_event = PointerEvent.mouse_event(pointer_id, PointerEventType.LEAVE, x, y)
+            leave_event = PointerEvent.mouse_event(
+                pointer_id, PointerEventType.LEAVE, x, y, modifier_keys=modifier_keys
+            )
             _deliver_pointer_event(app, prev, leave_event)
         if cur is not None:
-            enter_event = PointerEvent.mouse_event(pointer_id, PointerEventType.ENTER, x, y)
+            enter_event = PointerEvent.mouse_event(
+                pointer_id, PointerEventType.ENTER, x, y, modifier_keys=modifier_keys
+            )
             _deliver_pointer_event(app, cur, enter_event)
-            hover_event = PointerEvent.mouse_event(pointer_id, PointerEventType.HOVER, x, y)
+            hover_event = PointerEvent.mouse_event(
+                pointer_id, PointerEventType.HOVER, x, y, buttons=buttons, modifier_keys=modifier_keys
+            )
             _deliver_pointer_event(app, cur, hover_event)
         try:
             app._last_hover_target = cur
@@ -170,9 +183,14 @@ def _handler_hosts_focused_node(handler: Any, focused_node: Any) -> bool:
     return False
 
 
-def dispatch_mouse_press(app: Any, x: int, y: int):
+def dispatch_mouse_press(app: Any, x: int, y: int, *, button: Optional[int] = None, modifier_keys: int = 0):
     if app.root is None:
         return
+
+    # Only a primary (left / synthetic) press activates and moves focus. A
+    # secondary button (right / middle) must not blur a focused node or
+    # activate a widget.
+    primary = is_primary_button(button)
 
     target = None
     try:
@@ -185,8 +203,8 @@ def dispatch_mouse_press(app: Any, x: int, y: int):
     focused_before = getattr(app, "_focused_node", None)
 
     if target is None:
-        # Click on empty area: blur any currently-focused node.
-        if focused_before is not None:
+        # Click on empty area: blur any currently-focused node (primary only).
+        if primary and focused_before is not None:
             try:
                 app.request_focus(None)
             except Exception:
@@ -198,7 +216,9 @@ def dispatch_mouse_press(app: Any, x: int, y: int):
         return
 
     pointer_id = _primary_pointer_id(app)
-    press_event = PointerEvent.mouse_event(pointer_id, PointerEventType.PRESS, x, y)
+    press_event = PointerEvent.mouse_event(
+        pointer_id, PointerEventType.PRESS, x, y, button=button, modifier_keys=modifier_keys
+    )
     handler = _deliver_pointer_event(app, target, press_event)
     manager = _pointer_manager(app)
     if handler is not None and manager is not None:
@@ -219,7 +239,8 @@ def dispatch_mouse_press(app: Any, x: int, y: int):
     #   host (e.g. TextField containing a focused EditableText). Restricted
     #   to ``handler`` so unrelated layout ancestors do not preserve focus.
     if (
-        focused_before is not None
+        primary
+        and focused_before is not None
         and focused_after is focused_before
         and not _press_target_contains_focused_node(target, focused_before)
         and not _handler_hosts_focused_node(handler, focused_before)
@@ -234,7 +255,7 @@ def dispatch_mouse_press(app: Any, x: int, y: int):
             )
 
 
-def dispatch_mouse_release(app: Any, x: int, y: int):
+def dispatch_mouse_release(app: Any, x: int, y: int, *, button: Optional[int] = None, modifier_keys: int = 0):
     pointer_id = _primary_pointer_id(app)
     manager = _pointer_manager(app)
     owner = manager.owner_of(pointer_id) if manager is not None else None
@@ -252,7 +273,9 @@ def dispatch_mouse_release(app: Any, x: int, y: int):
             manager.release(pointer_id)
         return
 
-    release_event = PointerEvent.mouse_event(pointer_id, PointerEventType.RELEASE, x, y)
+    release_event = PointerEvent.mouse_event(
+        pointer_id, PointerEventType.RELEASE, x, y, button=button, modifier_keys=modifier_keys
+    )
     handler = _deliver_pointer_event(app, target, release_event)
     if manager is not None:
         if owner is not None:

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Awaitable
 from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast
 
+from ..input.codes import is_primary_button
 from ..input.pointer import PointerEvent, PointerEventType
 from ..widgeting.widget import Widget
 from ..rendering.sizing import SizingLike
@@ -117,6 +118,7 @@ class PointerInputNode(InteractionNode):
         self._hover_enabled = False
         self._click_enabled = False
         self._active_pointer_id: Optional[int] = None
+        self._active_button: Optional[int] = None
 
     @property
     def state(self) -> InteractionState:
@@ -225,6 +227,11 @@ class PointerInputNode(InteractionNode):
         return False
 
     def _handle_press(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
+        # Only a primary (left / synthetic) button activates a click. Secondary
+        # buttons (right / middle) must not press, focus, or capture.
+        if not is_primary_button(event.button):
+            return False
+
         inside = True if bounds is None else self._point_inside(bounds, event.x, event.y)
         if not inside:
             return False
@@ -234,6 +241,7 @@ class PointerInputNode(InteractionNode):
             self.region.request_focus_from_pointer()
 
         self._active_pointer_id = event.id
+        self._active_button = event.button
         self.state.press_position = (event.x, event.y)
         self._set_pressed(True)
         try:
@@ -255,6 +263,11 @@ class PointerInputNode(InteractionNode):
     def _handle_release(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
         if self._active_pointer_id != event.id:
             return False
+        # Ignore a release from a different button than the one that opened the
+        # press (all buttons share one pointer id today). A synthetic release
+        # (button is None) always matches.
+        if event.button is not None and event.button != self._active_button:
+            return False
         inside = True if bounds is None else self._point_inside(bounds, event.x, event.y)
         self._set_pressed(False)
         try:
@@ -269,6 +282,7 @@ class PointerInputNode(InteractionNode):
                 owner_name,
             )
         self._active_pointer_id = None
+        self._active_button = None
 
         for cb in list(self._release_callbacks):
             self._invoke_callback(cb, event, error_key="release_callback", error_msg="Release callback raised")
@@ -282,6 +296,7 @@ class PointerInputNode(InteractionNode):
             return False
         self._set_pressed(False)
         self._active_pointer_id = None
+        self._active_button = None
         return True
 
     def _emit_click(self) -> None:
@@ -354,6 +369,7 @@ class DraggableNode(InteractionNode):
         self._on_drag_end = on_drag_end
         self._hit_test = hit_test
         self._active_pointer_id: Optional[int] = None
+        self._active_button: Optional[int] = None
         self._last_pos: Optional[Tuple[float, float]] = None
 
     def _invoke_callback(self, cb: Callable[..., Any], *args: Any, error_key: str, error_msg: str) -> None:
@@ -373,6 +389,7 @@ class DraggableNode(InteractionNode):
         if self._active_pointer_id is not None:
             return
         self._active_pointer_id = event.id
+        self._active_button = event.button
         self._last_pos = (event.x, event.y)
         self.state.dragging = True
         self.state.pressed = True
@@ -417,11 +434,17 @@ class DraggableNode(InteractionNode):
         if self._active_pointer_id is not None:
             return False
 
+        # Only a primary (left / synthetic) button starts a drag. A right-drag
+        # over e.g. a Slider must not move it.
+        if not is_primary_button(event.button):
+            return False
+
         inside = self._point_inside(bounds, event.x, event.y)
         if not inside:
             return False
 
         self._active_pointer_id = event.id
+        self._active_button = event.button
         self._last_pos = (event.x, event.y)
         self.state.dragging = True
         self.state.pressed = True  # Sync with pressed state usually
@@ -472,6 +495,10 @@ class DraggableNode(InteractionNode):
     def _handle_release(self, event: PointerEvent) -> bool:
         if self._active_pointer_id != event.id:
             return False
+        # A release from a different button than the one that opened the drag
+        # (all buttons share one pointer id) must not end the drag.
+        if event.button is not None and event.button != self._active_button:
+            return False
 
         self._end_drag(event)
         return True
@@ -485,6 +512,7 @@ class DraggableNode(InteractionNode):
 
     def _end_drag(self, event: PointerEvent) -> None:
         self._active_pointer_id = None
+        self._active_button = None
         self._last_pos = None
         self.state.dragging = False
         self.state.pressed = False

--- a/tests/backends/test_pyglet_mouse_normalization.py
+++ b/tests/backends/test_pyglet_mouse_normalization.py
@@ -1,0 +1,42 @@
+"""Tests for the pyglet runner's mouse button/modifier normalization (issue #305).
+
+These exercise the runner's raw-pyglet -> backend-neutral mapping directly; the
+end-to-end dispatch of the normalized values is covered in
+``tests/runtime/test_mouse_button_dispatch.py``.
+"""
+
+import pyglet.window.key as pygkey
+import pyglet.window.mouse as pygmouse
+
+from nuiitivet.backends.pyglet import runner
+from nuiitivet.input.codes import (
+    BUTTON_LEFT,
+    BUTTON_MIDDLE,
+    BUTTON_RIGHT,
+    MOD_CTRL,
+    MOD_SHIFT,
+)
+
+
+def test_normalize_mouse_button_maps_known_buttons():
+    assert runner._normalize_mouse_button(pygmouse.LEFT) == BUTTON_LEFT
+    assert runner._normalize_mouse_button(pygmouse.MIDDLE) == BUTTON_MIDDLE
+    assert runner._normalize_mouse_button(pygmouse.RIGHT) == BUTTON_RIGHT
+
+
+def test_normalize_mouse_button_unknown_is_none():
+    # An unrecognized raw value must not leak through as a button.
+    assert runner._normalize_mouse_button(1 << 20) is None
+
+
+def test_normalize_mouse_buttons_bitmask():
+    assert runner._normalize_mouse_buttons(0) == 0
+    assert runner._normalize_mouse_buttons(pygmouse.LEFT) == BUTTON_LEFT
+    combined = pygmouse.LEFT | pygmouse.RIGHT
+    assert runner._normalize_mouse_buttons(combined) == (BUTTON_LEFT | BUTTON_RIGHT)
+
+
+def test_normalize_modifiers_maps_bits():
+    assert runner._normalize_modifiers(pygkey.MOD_SHIFT) == MOD_SHIFT
+    both = pygkey.MOD_SHIFT | pygkey.MOD_CTRL
+    assert runner._normalize_modifiers(both) == (MOD_SHIFT | MOD_CTRL)

--- a/tests/runtime/test_mouse_button_dispatch.py
+++ b/tests/runtime/test_mouse_button_dispatch.py
@@ -1,0 +1,111 @@
+"""End-to-end dispatch of mouse button / modifiers through app_events (issue #305).
+
+Covers that ``button``/``modifier_keys`` reach the delivered ``PointerEvent`` and
+that a secondary (right/middle) press neither activates nor blurs focus.
+"""
+
+from nuiitivet.runtime import app_events
+from nuiitivet.runtime.pointer import PointerCaptureManager
+from nuiitivet.input.codes import BUTTON_LEFT, BUTTON_RIGHT, MOD_SHIFT
+from nuiitivet.input.pointer import PointerEvent, PointerEventType
+from nuiitivet.widgeting.widget import Widget
+
+
+class _RecordWidget(Widget):
+    def __init__(self):
+        super().__init__()
+        self.events = []
+
+    def on_pointer_event(self, event: PointerEvent) -> bool:
+        self.events.append(event)
+        return True
+
+    def paint(self, canvas, x, y, w, h):
+        pass
+
+
+class _Root:
+    def __init__(self, widget, *, hit=True):
+        self._w = widget
+        self._hit = hit
+
+    def hit_test(self, x, y):
+        return self._w if self._hit else None
+
+    def unmount(self):
+        pass
+
+
+class _FakeApp:
+    def __init__(self, root):
+        self.root = root
+        self._dirty = False
+        self._last_hover_target = None
+        self._pressed_target = None
+        self._focused_node = None
+        self._pointer_capture_manager = PointerCaptureManager()
+        self.focus_requests = []
+
+    def invalidate(self):
+        self._dirty = True
+
+    def request_focus(self, node):
+        self.focus_requests.append(node)
+        self._focused_node = node
+
+
+def test_press_delivers_button_and_modifiers():
+    w = _RecordWidget()
+    app = _FakeApp(_Root(w))
+
+    app_events.dispatch_mouse_press(app, 5, 5, button=BUTTON_RIGHT, modifier_keys=MOD_SHIFT)
+
+    press = next(e for e in w.events if e.type is PointerEventType.PRESS)
+    assert press.button == BUTTON_RIGHT
+    assert press.modifier_keys == MOD_SHIFT
+
+
+def test_release_delivers_button_and_modifiers():
+    w = _RecordWidget()
+    app = _FakeApp(_Root(w))
+
+    app_events.dispatch_mouse_release(app, 5, 5, button=BUTTON_LEFT, modifier_keys=MOD_SHIFT)
+
+    release = next(e for e in w.events if e.type is PointerEventType.RELEASE)
+    assert release.button == BUTTON_LEFT
+    assert release.modifier_keys == MOD_SHIFT
+
+
+def test_right_press_on_empty_area_does_not_blur():
+    w = _RecordWidget()
+    app = _FakeApp(_Root(w, hit=False))
+    sentinel = object()
+    app._focused_node = sentinel
+
+    app_events.dispatch_mouse_press(app, 5, 5, button=BUTTON_RIGHT)
+
+    assert app.focus_requests == []
+    assert app._focused_node is sentinel
+
+
+def test_left_press_on_empty_area_blurs():
+    w = _RecordWidget()
+    app = _FakeApp(_Root(w, hit=False))
+    app._focused_node = object()
+
+    app_events.dispatch_mouse_press(app, 5, 5, button=BUTTON_LEFT)
+
+    assert app.focus_requests == [None]
+
+
+def test_motion_carries_held_buttons_during_capture():
+    w = _RecordWidget()
+    app = _FakeApp(_Root(w))
+    # Capture the pointer so motion routes to the owner as a drag MOVE.
+    app._pointer_capture_manager.capture(w, PointerEvent.mouse_event(1, PointerEventType.PRESS, 0, 0))
+
+    app_events.dispatch_mouse_motion(app, 20, 20, buttons=BUTTON_LEFT, modifier_keys=MOD_SHIFT)
+
+    move = next(e for e in w.events if e.type is PointerEventType.MOVE)
+    assert move.buttons == BUTTON_LEFT
+    assert move.modifier_keys == MOD_SHIFT

--- a/tests/widgets/test_pointer_button_gating.py
+++ b/tests/widgets/test_pointer_button_gating.py
@@ -1,0 +1,92 @@
+"""Node-level pointer button gating (issue #305).
+
+Only a primary (left / synthetic) button activates a click or starts a drag;
+secondary buttons must not. A release from a different button than the one that
+opened the press must not terminate the interaction.
+"""
+
+from nuiitivet.input.codes import BUTTON_LEFT, BUTTON_MIDDLE, BUTTON_RIGHT, MOD_SHIFT
+from nuiitivet.input.pointer import PointerEvent, PointerEventType as T
+from nuiitivet.widgets.interaction import DraggableNode, InteractionState, PointerInputNode
+
+_BOUNDS = (0, 0, 100, 40)
+
+
+def _press_release(node, button):
+    for et in (T.PRESS, T.RELEASE):
+        node.handle_pointer_event(PointerEvent.mouse_event(1, et, 10, 10, button=button), _BOUNDS)
+
+
+def test_only_primary_button_fires_click():
+    results = {}
+    for label, btn in [("left", BUTTON_LEFT), ("right", BUTTON_RIGHT), ("middle", BUTTON_MIDDLE), ("none", None)]:
+        clicks = []
+        node = PointerInputNode()
+        node.enable_click(on_click=lambda: clicks.append(1))
+        _press_release(node, btn)
+        results[label] = len(clicks)
+
+    assert results["left"] == 1
+    assert results["none"] == 1  # synthetic / touch still activates
+    assert results["right"] == 0
+    assert results["middle"] == 0
+
+
+def test_modifiers_reach_press_callback():
+    seen = []
+    node = PointerInputNode()
+    node.enable_click(on_press=lambda e: seen.append(e.modifier_keys))
+    node.handle_pointer_event(
+        PointerEvent.mouse_event(1, T.PRESS, 10, 10, button=BUTTON_LEFT, modifier_keys=MOD_SHIFT),
+        _BOUNDS,
+    )
+    assert seen == [MOD_SHIFT]
+
+
+def test_secondary_release_does_not_end_left_press():
+    clicks = []
+    node = PointerInputNode(state=InteractionState())
+    node.enable_click(on_click=lambda: clicks.append(1))
+
+    # Left press opens the interaction.
+    assert node.handle_pointer_event(PointerEvent.mouse_event(1, T.PRESS, 10, 10, button=BUTTON_LEFT), _BOUNDS)
+    assert node.state.pressed is True
+
+    # A right release (same shared pointer id) must be ignored.
+    handled = node.handle_pointer_event(PointerEvent.mouse_event(1, T.RELEASE, 10, 10, button=BUTTON_RIGHT), _BOUNDS)
+    assert handled is False
+    assert node.state.pressed is True
+    assert clicks == []
+
+    # The matching left release completes the click.
+    assert node.handle_pointer_event(PointerEvent.mouse_event(1, T.RELEASE, 10, 10, button=BUTTON_LEFT), _BOUNDS)
+    assert node.state.pressed is False
+    assert clicks == [1]
+
+
+def test_draggable_only_primary_starts_drag():
+    for btn, expected in [(BUTTON_LEFT, True), (BUTTON_RIGHT, False), (BUTTON_MIDDLE, False), (None, True)]:
+        starts = []
+        node = DraggableNode(on_drag_start=lambda e: starts.append(1))
+        handled = node.handle_pointer_event(PointerEvent.mouse_event(1, T.PRESS, 10, 10, button=btn), _BOUNDS)
+        assert handled is expected
+        assert bool(starts) is expected
+
+
+def test_draggable_secondary_release_does_not_end_drag():
+    events = []
+    node = DraggableNode(
+        on_drag_start=lambda e: events.append("start"),
+        on_drag_end=lambda e: events.append("end"),
+    )
+    node.handle_pointer_event(PointerEvent.mouse_event(1, T.PRESS, 10, 10, button=BUTTON_LEFT), _BOUNDS)
+    assert events == ["start"]
+
+    # A right release must not end the left drag.
+    handled = node.handle_pointer_event(PointerEvent.mouse_event(1, T.RELEASE, 10, 10, button=BUTTON_RIGHT), _BOUNDS)
+    assert handled is False
+    assert events == ["start"]
+
+    # The matching left release ends it.
+    node.handle_pointer_event(PointerEvent.mouse_event(1, T.RELEASE, 10, 10, button=BUTTON_LEFT), _BOUNDS)
+    assert events == ["start", "end"]


### PR DESCRIPTION
## Summary
- Add backend-neutral `BUTTON_LEFT/MIDDLE/RIGHT` codes and `is_primary_button()` in `input.codes`, exported from `nuiitivet` and `nuiitivet.input`
- Add a held-buttons bit mask (`PointerEvent.buttons`) alongside the single-button `PointerEvent.button`, with documented semantics
- Normalize pyglet's button/buttons/modifiers in the runner and thread them through `_dispatch_mouse_press/release/motion` into `PointerEvent.mouse_event`
- Gate activation and focus/blur on the primary button (`PointerInputNode`, `DraggableNode`, `dispatch_mouse_press`); require a release to match the button that opened the press
- Carry `button`/`buttons` through the synthesized `CANCEL` event

Fixes #305.

## Test plan
- [x] `pytest` — full suite green (1636 passed), incl. new runner-normalization, node-gating, and dispatch-path tests
- [x] `mypy src/nuiitivet` clean
- [ ] Manual: LEFT-click activates Button; RIGHT/MIDDLE do not
- [ ] Manual: RIGHT-click outside a focused TextField does not blur it
- [ ] Manual: RIGHT-drag over a Slider does not change its value
- [ ] Manual: RIGHT release during a LEFT drag does not end the drag
- [ ] Manual: modifier mask reaches `PointerEvent` on mouse events

🤖 Generated with [Claude Code](https://claude.com/claude-code)