### PR TITLE
feat: add pointer_input() modifier exposing the raw pointer stream (#308)

### DIFF
--- a/docs/guide/modifiers/interaction.md
+++ b/docs/guide/modifiers/interaction.md
@@ -89,3 +89,95 @@ class FocusDemo(nv.ComposableWidget):
 ```
 
 ![Focusable](../../assets/modifier_interaction_focusable.png)
+
+## Raw pointer input
+
+`clickable` and `hoverable` are convenience layers: they collapse a press and
+release into a single click, and reduce hover to a `bool`. When you need the
+individual pointer events — for example to draw strokes on a canvas — use
+`pointer_input`. It is the low-level "Listener" layer, mirroring Compose's
+`Modifier.pointerInput` and Flutter's `Listener`.
+
+Each callback receives a `PointerEvent` and may be sync or async:
+
+```python
+import nuiitivet as nv
+from nuiitivet.input import BUTTON_LEFT, MOD_CTRL
+from nuiitivet.input.pointer import PointerEvent
+from nuiitivet.modifiers import corner_radius, pointer_input
+
+def on_press(e: PointerEvent) -> None:
+    if e.modifier_keys & MOD_CTRL:
+        pick_color(e.local_x, e.local_y)
+    else:
+        begin_stroke(e.local_x, e.local_y)
+
+def on_move(e: PointerEvent) -> None:
+    if e.buttons & BUTTON_LEFT:      # a button is held — a stroke is in progress
+        extend_stroke(e.local_x, e.local_y)
+
+canvas = nv.Image(png_bytes, fit="fill", width=320, height=240).modifier(
+    corner_radius(8)
+    | pointer_input(
+        on_press=on_press,
+        on_move=on_move,
+        on_release=lambda e: end_stroke(),
+        buttons=(BUTTON_LEFT,),   # only the left button triggers press/release
+        capture=True,             # keep delivering move/release off the widget
+    )
+)
+```
+
+### Coordinates: local vs screen
+
+A `PointerEvent` carries two coordinate pairs:
+
+- `local_x` / `local_y` are **widget-relative** — measured from the top-left of
+  the widget that received the event. Use these to map a press onto your content.
+- `x` / `y` are **screen (window)** coordinates.
+
+For an `Image` that scales its source bitmap, `local_x` / `local_y` are relative
+to the displayed rect; mapping them back to source-image pixels (accounting for
+your fit / aspect-ratio choice) stays your responsibility.
+
+### Held buttons
+
+`event.buttons` is a bitmask of the buttons currently held down (OR-ed
+`BUTTON_*` codes). Because a plain hover move and a drag both arrive as moves,
+check `event.buttons` inside `on_move` to tell whether a stroke is actually in
+progress. `event.button` (singular) is only the button that caused *this*
+press/release.
+
+### Capture
+
+With `capture=True` (the default) the pointer is captured on press, so `on_move`
+and `on_release` keep arriving even after the pointer leaves the widget bounds —
+essential for a stroke that runs off the edge. With `capture=False`, moving
+outside the bounds delivers `on_leave` and stops `on_move`.
+
+### Reacting to modifier keys while stationary
+
+Reading `event.modifier_keys` handles `Ctrl`+click for free — the mask rides on
+every pointer event, so you never track modifier state yourself (that state
+desyncs on focus change and window deactivation). The one case it misses is the
+pointer sitting **still** while the user presses a modifier: no pointer event is
+generated. `on_modifier_keys_change` fills that gap — it fires whenever the held
+modifier-key mask changes while the pointer is inside or captured, delivering a
+`PointerEvent` synthesized at the current position:
+
+```python
+from nuiitivet.input import MOD_ALT
+
+def on_modifier_keys_change(e: PointerEvent) -> None:
+    set_cursor(EYEDROPPER if e.modifier_keys & MOD_ALT else BRUSH)
+
+canvas.modifier(pointer_input(on_modifier_keys_change=on_modifier_keys_change))
+```
+
+It fires during a capture too (i.e. mid-stroke, even when the pointer is outside
+the widget), and never fires for non-modifier keys or when the pointer is
+neither inside nor captured. See the runnable
+[paint sample](https://github.com/yuksblog/nuiitivet/blob/main/samples/modifiers/interaction/pointer_input.py).
+
+`pointer_input` composes with `clickable` on the same widget without either
+clobbering the other, so you can keep a semantic click alongside the raw stream.

--- a/samples/modifiers/interaction/pointer_input.py
+++ b/samples/modifiers/interaction/pointer_input.py
@@ -1,0 +1,119 @@
+"""Raw pointer handling with ``pointer_input()``: a tiny paint canvas.
+
+The framework ships no canvas widget on purpose — you produce the bitmap
+yourself (here with Pillow) and display it through :class:`Image`. ``pointer_input``
+surfaces the raw press/move/release stream with widget-local coordinates so the
+strokes land where the pointer is.
+
+Interactions:
+    - Drag with the left button to draw.
+    - Hold Ctrl and click to pick the color under the pointer instead of drawing.
+    - ``capture=True`` keeps the stroke going even if the pointer runs off the
+      image edge.
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image as PILImage, ImageDraw
+
+import nuiitivet.material as nv
+
+BUTTON_LEFT = nv.BUTTON_LEFT
+MOD_CTRL = nv.MOD_CTRL
+
+_CANVAS_W = 320
+_CANVAS_H = 240
+
+
+class PaintDemo(nv.ComposableWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self._bitmap = PILImage.new("RGB", (_CANVAS_W, _CANVAS_H), "#FFFFFF")
+        self._draw = ImageDraw.Draw(self._bitmap)
+        self._brush = "#1565C0"
+        self._last_point: tuple[float, float] | None = None
+        self.png = nv.Observable(self._encode())
+        self.status = nv.Observable("Drag to draw · Ctrl+click to pick a color")
+
+    def _encode(self) -> bytes:
+        buf = io.BytesIO()
+        self._bitmap.save(buf, format="PNG")
+        return buf.getvalue()
+
+    def _publish(self) -> None:
+        self.png.value = self._encode()
+
+    def _clamp(self, e: nv.PointerEvent) -> tuple[int, int]:
+        # The Image is shown 1:1 here (fixed size == source size), so local
+        # coordinates map straight to source pixels. Clamp to stay in bounds.
+        x = int(min(max(e.local_x, 0), _CANVAS_W - 1))
+        y = int(min(max(e.local_y, 0), _CANVAS_H - 1))
+        return x, y
+
+    def _on_press(self, e: nv.PointerEvent) -> None:
+        x, y = self._clamp(e)
+        if e.modifier_keys & MOD_CTRL:
+            px = self._bitmap.getpixel((x, y))
+            if isinstance(px, tuple):
+                r, g, b = int(px[0]), int(px[1]), int(px[2])
+                self._brush = "#%02X%02X%02X" % (r, g, b)
+                self.status.value = f"Picked {self._brush}"
+            self._last_point = None
+            return
+        self._draw.ellipse((x - 2, y - 2, x + 2, y + 2), fill=self._brush)
+        self._last_point = (x, y)
+        self._publish()
+
+    def _on_move(self, e: nv.PointerEvent) -> None:
+        # Only extend the stroke while the left button is held down.
+        if not (e.buttons & BUTTON_LEFT):
+            return
+        x, y = self._clamp(e)
+        if self._last_point is not None:
+            self._draw.line((self._last_point[0], self._last_point[1], x, y), fill=self._brush, width=5)
+        self._last_point = (x, y)
+        self._publish()
+
+    def _on_release(self, e: nv.PointerEvent) -> None:
+        self._last_point = None
+
+    def build(self):
+        canvas = nv.Image(
+            self.png,
+            fit="fill",
+            width=_CANVAS_W,
+            height=_CANVAS_H,
+        ).modifier(
+            nv.corner_radius(8)
+            | nv.pointer_input(
+                on_press=self._on_press,
+                on_move=self._on_move,
+                on_release=self._on_release,
+                buttons=(BUTTON_LEFT,),
+                capture=True,
+            )
+        )
+
+        return nv.Column(
+            children=[
+                nv.Text(self.status),
+                canvas,
+            ],
+            gap=12,
+            padding=16,
+        )
+
+
+def main(png: str = ""):
+    app = nv.App(content=PaintDemo(), title="pointer_input — paint canvas")
+    if png:
+        app.render_to_png(png)
+        print(f"Rendered {png}")
+        return
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nuiitivet/__init__.py
+++ b/src/nuiitivet/__init__.py
@@ -58,6 +58,7 @@ from nuiitivet.input.codes import (
     MOD_META,
     MOD_SHIFT,
 )
+from nuiitivet.input.pointer import PointerEvent, PointerEventType
 
 # Theme
 from nuiitivet.theme.theme import Theme
@@ -95,6 +96,7 @@ from nuiitivet.modifiers import (
     light_dismiss,
     modeless,
     opacity,
+    pointer_input,
     rotate,
     scale,
     shadow,
@@ -179,6 +181,7 @@ __all__: list[str] = [
     "light_dismiss",
     "modeless",
     "opacity",
+    "pointer_input",
     "rotate",
     "scale",
     "shadow",
@@ -195,6 +198,8 @@ __all__: list[str] = [
     "BUTTON_LEFT",
     "BUTTON_MIDDLE",
     "BUTTON_RIGHT",
+    "PointerEvent",
+    "PointerEventType",
     # Window / runtime
     "AppScope",
     "OSChrome",

--- a/src/nuiitivet/input/pointer.py
+++ b/src/nuiitivet/input/pointer.py
@@ -48,6 +48,12 @@ class PointerEvent:
         the same ``BUTTON_*`` codes OR-ed together. It is populated on ``MOVE``
         (drag) events so a consumer can tell a right-drag from a left-drag; it
         is ``0`` when no button is held.
+
+    Coordinate semantics:
+        ``x`` / ``y`` are screen (window) coordinates. ``local_x`` / ``local_y``
+        are relative to the top-left of the widget that *receives* the event and
+        are populated at dispatch time; on an event that has not been routed to a
+        widget they default to the screen coordinates' offset of ``0.0``.
     """
 
     id: int
@@ -64,6 +70,8 @@ class PointerEvent:
     timestamp: float = 0.0
     is_primary: bool = True
     modifier_keys: int = 0
+    local_x: float = 0.0
+    local_y: float = 0.0
 
     @staticmethod
     def mouse_event(

--- a/src/nuiitivet/modifiers/__init__.py
+++ b/src/nuiitivet/modifiers/__init__.py
@@ -6,6 +6,7 @@ from .corner_radius import corner_radius
 from .focus import focusable
 from .hover import hoverable
 from .ignore_pointer import ignore_pointer
+from .pointer_input import pointer_input
 from .popup import modeless, light_dismiss
 from .tooltip import tooltip
 from .shadow import shadow
@@ -23,6 +24,7 @@ __all__ = [
     "focusable",
     "hoverable",
     "ignore_pointer",
+    "pointer_input",
     "opacity",
     "modeless",
     "light_dismiss",

--- a/src/nuiitivet/modifiers/pointer_input.py
+++ b/src/nuiitivet/modifiers/pointer_input.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from ..widgeting.modifier import ModifierElement
+from ..widgeting.widget import Widget
+from ..widgets.interaction import (
+    InteractionRegion,
+    PointerEventCallback,
+    PointerListenerNode,
+    ensure_interaction_region,
+)
+
+
+class PointerInputModifier(ModifierElement):
+    """Attach a raw pointer-stream listener to a widget.
+
+    This is the low-level "Listener" layer (cf. Compose ``Modifier.pointerInput``,
+    Flutter ``Listener``): it surfaces the individual pointer events — press,
+    move, release, enter, leave, scroll — rather than the semantic click/hover
+    that :func:`clickable` / :func:`hoverable` provide. Each callback receives a
+    :class:`~nuiitivet.input.pointer.PointerEvent` whose ``local_x`` / ``local_y``
+    are relative to the widget's top-left (``x`` / ``y`` remain screen
+    coordinates).
+    """
+
+    def __init__(
+        self,
+        *,
+        on_press: Optional[PointerEventCallback] = None,
+        on_move: Optional[PointerEventCallback] = None,
+        on_release: Optional[PointerEventCallback] = None,
+        on_enter: Optional[PointerEventCallback] = None,
+        on_leave: Optional[PointerEventCallback] = None,
+        on_scroll: Optional[PointerEventCallback] = None,
+        on_modifier_keys_change: Optional[PointerEventCallback] = None,
+        buttons: Optional[Sequence[int]] = None,
+        capture: bool = True,
+    ) -> None:
+        self.on_press = on_press
+        self.on_move = on_move
+        self.on_release = on_release
+        self.on_enter = on_enter
+        self.on_leave = on_leave
+        self.on_scroll = on_scroll
+        self.on_modifier_keys_change = on_modifier_keys_change
+        self.buttons = buttons
+        self.capture = capture
+
+    def apply(self, widget: Widget) -> Widget:
+        region: InteractionRegion = ensure_interaction_region(widget)
+
+        node = region.get_node(PointerListenerNode)
+        if isinstance(node, PointerListenerNode):
+            # Recomposition re-applies the modifier; reconfigure the existing
+            # node (setter semantics) rather than stacking a second one.
+            node.configure(
+                on_press=self.on_press,
+                on_move=self.on_move,
+                on_release=self.on_release,
+                on_enter=self.on_enter,
+                on_leave=self.on_leave,
+                on_scroll=self.on_scroll,
+                on_modifier_keys_change=self.on_modifier_keys_change,
+                buttons=self.buttons,
+                capture=self.capture,
+            )
+        else:
+            region.add_node(
+                PointerListenerNode(
+                    on_press=self.on_press,
+                    on_move=self.on_move,
+                    on_release=self.on_release,
+                    on_enter=self.on_enter,
+                    on_leave=self.on_leave,
+                    on_scroll=self.on_scroll,
+                    on_modifier_keys_change=self.on_modifier_keys_change,
+                    buttons=self.buttons,
+                    capture=self.capture,
+                )
+            )
+        return region
+
+
+def pointer_input(
+    *,
+    on_press: Optional[PointerEventCallback] = None,
+    on_move: Optional[PointerEventCallback] = None,
+    on_release: Optional[PointerEventCallback] = None,
+    on_enter: Optional[PointerEventCallback] = None,
+    on_leave: Optional[PointerEventCallback] = None,
+    on_scroll: Optional[PointerEventCallback] = None,
+    on_modifier_keys_change: Optional[PointerEventCallback] = None,
+    buttons: Optional[Sequence[int]] = None,
+    capture: bool = True,
+) -> PointerInputModifier:
+    """Observe the raw pointer stream on any widget.
+
+    Each callback may be sync or async and receives a
+    :class:`~nuiitivet.input.pointer.PointerEvent`. The event's ``local_x`` /
+    ``local_y`` are relative to the widget's top-left; ``x`` / ``y`` are screen
+    coordinates. ``event.buttons`` is the bitmask of buttons currently held down
+    (populated during a drag), letting an ``on_move`` handler tell whether a
+    stroke is in progress.
+
+    Args:
+        on_press: Called on a pointer press inside the widget.
+        on_move: Called as the pointer moves inside the widget, and — while
+            captured — anywhere, so a stroke that runs off the edge keeps
+            reporting.
+        on_release: Called when the press that this node is tracking is released.
+        on_enter: Called when the pointer enters the widget bounds.
+        on_leave: Called when the pointer leaves the widget bounds.
+        on_scroll: Called on a scroll (wheel) event over the widget.
+        on_modifier_keys_change: Called when the held modifier-key mask changes
+            while the pointer is inside or captured — even if the pointer is
+            stationary. Reads ``event.modifier_keys`` for the new mask. This lets
+            a widget (e.g. a canvas) swap its cursor the instant Alt is pressed
+            without the pointer moving.
+        buttons: The ``BUTTON_*`` codes that trigger ``on_press`` / ``on_release``.
+            ``None`` (default) accepts every button.
+        capture: When True (default), the pointer is captured on press so
+            ``on_move`` / ``on_release`` keep arriving after it leaves the widget
+            bounds. When False, moving outside delivers ``on_leave`` and stops
+            ``on_move``.
+
+    Returns:
+        A :class:`PointerInputModifier` to attach via ``.modifier(...)``.
+    """
+    return PointerInputModifier(
+        on_press=on_press,
+        on_move=on_move,
+        on_release=on_release,
+        on_enter=on_enter,
+        on_leave=on_leave,
+        on_scroll=on_scroll,
+        on_modifier_keys_change=on_modifier_keys_change,
+        buttons=buttons,
+        capture=capture,
+    )

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -7,7 +7,7 @@ import time
 import traceback
 import warnings
 import weakref
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
 from ..widgeting.widget import ComposableWidget, Widget
 from .pointer import PointerCaptureManager
@@ -290,6 +290,10 @@ class App:
         self._focused_target: Optional[InteractionHostMixin] = None
         self._focused_node: Optional[FocusNode] = None
         self._modifier_keys: int = 0
+        # Last known pointer position / held buttons (screen coords), used to
+        # synthesize the pointer event delivered on a modifier-key mask change.
+        self._last_pointer_pos: Optional[Tuple[float, float]] = None
+        self._last_pointer_buttons: int = 0
         self._pointer_capture_manager = PointerCaptureManager()
         self._pointer_capture_manager.set_cancel_callback(self._handle_pointer_cancel)
         self._primary_pointer_id = 1
@@ -954,12 +958,22 @@ class App:
         return self._modifier_keys
 
     def _set_modifier_keys(self, modifier_keys: int) -> None:
-        """Update the authoritative modifier-key mask (framework-internal)."""
+        """Update the authoritative modifier-key mask (framework-internal).
+
+        When the mask actually changes, a synthetic pointer event is delivered
+        to the widget under (or capturing) the pointer via
+        :meth:`_dispatch_modifier_keys_change` so ``pointer_input`` handlers can
+        react to a modifier press/release even while the pointer is stationary.
+        """
         try:
-            self._modifier_keys = int(modifier_keys)
+            new_mask = int(modifier_keys)
         except Exception:
             debug_once(logger, "app_set_modifier_keys_exc", "Failed to set modifier-key mask")
-            self._modifier_keys = 0
+            new_mask = 0
+        if new_mask == self._modifier_keys:
+            return
+        self._modifier_keys = new_mask
+        self._dispatch_modifier_keys_change()
 
     def _clear_modifier_keys(self) -> None:
         """Clear the authoritative modifier-key mask (framework-internal).
@@ -967,7 +981,60 @@ class App:
         Called when the window loses focus so that a modifier released while the
         app was inactive cannot leave a permanently stuck mask.
         """
+        if self._modifier_keys == 0:
+            return
         self._modifier_keys = 0
+        self._dispatch_modifier_keys_change()
+
+    def _dispatch_modifier_keys_change(self) -> None:
+        """Notify ``pointer_input`` handlers that the modifier-key mask changed.
+
+        The synthetic event is placed at the last known pointer position and
+        routed to the widget currently capturing the pointer, or failing that
+        the widget under the pointer. Only :class:`PointerListenerNode` instances
+        that are inside or captured respond (see
+        :meth:`InteractionHostMixin.dispatch_modifier_keys_change`).
+        """
+        pos = self._last_pointer_pos
+        if pos is None:
+            return
+
+        manager = self._pointer_capture_manager
+        target: Any = None
+        if manager is not None:
+            target = manager.owner_of(self._primary_pointer_id)
+        if target is None:
+            target = self._last_hover_target
+        if target is None:
+            return
+
+        event = PointerEvent.mouse_event(
+            self._primary_pointer_id,
+            PointerEventType.MOVE,
+            pos[0],
+            pos[1],
+            buttons=self._last_pointer_buttons,
+            modifier_keys=self._modifier_keys,
+        )
+
+        current = target
+        visited: set[int] = set()
+        while current is not None and id(current) not in visited:
+            visited.add(id(current))
+            dispatcher = getattr(current, "dispatch_modifier_keys_change", None)
+            if callable(dispatcher):
+                try:
+                    if dispatcher(event):
+                        self.invalidate()
+                        return
+                except Exception:
+                    exception_once(
+                        logger,
+                        "app_dispatch_modifier_keys_change_exc",
+                        "dispatch_modifier_keys_change raised (target=%s)",
+                        type(current).__name__,
+                    )
+            current = getattr(current, "_parent", None)
 
     def _dispatch_text(self, text: str) -> bool:
         """Handle text input events."""

--- a/src/nuiitivet/runtime/app_events.py
+++ b/src/nuiitivet/runtime/app_events.py
@@ -76,7 +76,21 @@ def _deliver_pointer_event(app: Any, target: Any, event: PointerEvent) -> Option
     return handler
 
 
+def _track_pointer_pos(app: Any, x: int, y: int, buttons: int) -> None:
+    """Record the latest pointer position / held-button mask on the app.
+
+    Used to synthesize the event delivered on a modifier-key mask change so
+    ``pointer_input`` handlers can react while the pointer is stationary.
+    """
+    try:
+        app._last_pointer_pos = (float(x), float(y))
+        app._last_pointer_buttons = int(buttons)
+    except Exception:
+        exception_once(logger, "app_events_track_pointer_pos_exc", "Failed to record pointer position")
+
+
 def dispatch_mouse_motion(app: Any, x: int, y: int, *, buttons: int = 0, modifier_keys: int = 0):
+    _track_pointer_pos(app, x, y, buttons)
     manager = _pointer_manager(app)
     pointer_id = _primary_pointer_id(app)
     owner = manager.owner_of(pointer_id) if manager is not None else None
@@ -184,6 +198,8 @@ def _handler_hosts_focused_node(handler: Any, focused_node: Any) -> bool:
 
 
 def dispatch_mouse_press(app: Any, x: int, y: int, *, button: Optional[int] = None, modifier_keys: int = 0):
+    held = getattr(app, "_last_pointer_buttons", 0) | (button or 0)
+    _track_pointer_pos(app, x, y, held)
     if app.root is None:
         return
 
@@ -256,6 +272,8 @@ def dispatch_mouse_press(app: Any, x: int, y: int, *, button: Optional[int] = No
 
 
 def dispatch_mouse_release(app: Any, x: int, y: int, *, button: Optional[int] = None, modifier_keys: int = 0):
+    held = getattr(app, "_last_pointer_buttons", 0) & ~(button or 0)
+    _track_pointer_pos(app, x, y, held)
     pointer_id = _primary_pointer_id(app)
     manager = _pointer_manager(app)
     owner = manager.owner_of(pointer_id) if manager is not None else None

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 import logging
 from collections.abc import Awaitable
@@ -94,6 +94,16 @@ class InteractionNode:
 
     def handle_pointer_event(self, event: PointerEvent, bounds: Optional[Sequence[float]] = None) -> bool:
         """Handle a pointer event. Return True if consumed."""
+        return False
+
+    def handle_modifier_keys_change(
+        self, event: PointerEvent, bounds: Optional[Sequence[float]] = None
+    ) -> bool:
+        """Handle a modifier-key mask change synthesized at the pointer position.
+
+        Delivered by the :class:`Application` whenever the held modifier-key mask
+        changes while a pointer is inside or captured. Returns True if consumed.
+        """
         return False
 
 
@@ -350,6 +360,277 @@ class PointerInputNode(InteractionNode):
             return False
         rx, ry, rw, rh = rect
         return rx <= x <= rx + rw and ry <= y <= ry + rh
+
+
+class PointerListenerNode(InteractionNode):
+    """Raw pointer-stream node backing the ``pointer_input()`` modifier.
+
+    Where :class:`PointerInputNode` collapses press+release into an
+    argument-less click and reduces hover to a ``bool``, this node surfaces the
+    individual pointer events — press, move, release, enter, leave, scroll —
+    each delivering the full :class:`PointerEvent` with widget-local
+    coordinates (``local_x`` / ``local_y``) populated. It optionally captures the
+    pointer on press so a stroke that runs off the widget keeps delivering move
+    and release, and it delivers ``on_modifier_keys_change`` while the pointer is
+    inside or captured.
+
+    It is a *separate* node from the default :class:`PointerInputNode`, so it
+    composes with ``clickable`` / ``hoverable`` on the same widget without either
+    clobbering the other.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_press: Optional[PointerEventCallback] = None,
+        on_move: Optional[PointerEventCallback] = None,
+        on_release: Optional[PointerEventCallback] = None,
+        on_enter: Optional[PointerEventCallback] = None,
+        on_leave: Optional[PointerEventCallback] = None,
+        on_scroll: Optional[PointerEventCallback] = None,
+        on_modifier_keys_change: Optional[PointerEventCallback] = None,
+        buttons: Optional[Sequence[int]] = None,
+        capture: bool = True,
+        hit_test: Optional[Callable[[float, float], bool]] = None,
+    ) -> None:
+        super().__init__()
+        self._hit_test = hit_test
+        self._active_pointer_id: Optional[int] = None
+        self._active_button: Optional[int] = None
+        self._inside = False
+        self.configure(
+            on_press=on_press,
+            on_move=on_move,
+            on_release=on_release,
+            on_enter=on_enter,
+            on_leave=on_leave,
+            on_scroll=on_scroll,
+            on_modifier_keys_change=on_modifier_keys_change,
+            buttons=buttons,
+            capture=capture,
+        )
+
+    def configure(
+        self,
+        *,
+        on_press: Optional[PointerEventCallback] = None,
+        on_move: Optional[PointerEventCallback] = None,
+        on_release: Optional[PointerEventCallback] = None,
+        on_enter: Optional[PointerEventCallback] = None,
+        on_leave: Optional[PointerEventCallback] = None,
+        on_scroll: Optional[PointerEventCallback] = None,
+        on_modifier_keys_change: Optional[PointerEventCallback] = None,
+        buttons: Optional[Sequence[int]] = None,
+        capture: bool = True,
+    ) -> None:
+        """Replace the callbacks and options (setter semantics).
+
+        Recomposition re-applies the modifier; replacing rather than appending
+        keeps a single handler per event instead of accumulating N copies.
+        """
+        self._on_press = on_press
+        self._on_move = on_move
+        self._on_release = on_release
+        self._on_enter = on_enter
+        self._on_leave = on_leave
+        self._on_scroll = on_scroll
+        self._on_modifier_keys_change = on_modifier_keys_change
+        self._buttons: Optional[frozenset[int]] = frozenset(buttons) if buttons is not None else None
+        self._capture = capture
+
+    def _invoke_callback(self, cb: Callable[..., Any], *args: Any, error_key: str, error_msg: str) -> None:
+        owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
+        invoke_event_handler(cb, *args, error_key=error_key, error_msg=error_msg, owner_name=owner_name)
+
+    def _button_allowed(self, button: Optional[int]) -> bool:
+        # A synthetic event (button is None) is never filtered out; explicit
+        # button codes are checked against the filter when one is set.
+        if self._buttons is None or button is None:
+            return True
+        return button in self._buttons
+
+    def _resolve_rect(self, bounds: Optional[Sequence[float]]) -> Optional[Sequence[float]]:
+        rect = bounds
+        if rect is None and self.owner:
+            rect = getattr(self.owner, "last_rect", None) or getattr(self.owner, "global_layout_rect", None)
+        return rect
+
+    def _with_local(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> PointerEvent:
+        rect = self._resolve_rect(bounds)
+        if rect is None:
+            return event
+        return replace(event, local_x=event.x - rect[0], local_y=event.y - rect[1])
+
+    def _point_inside(self, bounds: Optional[Sequence[float]], x: float, y: float) -> bool:
+        if self._hit_test:
+            return self._hit_test(x, y)
+        rect = self._resolve_rect(bounds)
+        if rect is None:
+            return False
+        rx, ry, rw, rh = rect
+        return rx <= x <= rx + rw and ry <= y <= ry + rh
+
+    def handle_pointer_event(self, event: PointerEvent, bounds: Optional[Sequence[float]] = None) -> bool:
+        if self.state.disabled:
+            if self._active_pointer_id is not None:
+                self._active_pointer_id = None
+                self._active_button = None
+            self._inside = False
+            return False
+
+        etype = event.type
+        if etype == PointerEventType.PRESS:
+            return self._handle_press(event, bounds)
+        if etype in (PointerEventType.MOVE, PointerEventType.HOVER):
+            return self._handle_move(event, bounds)
+        if etype == PointerEventType.RELEASE:
+            return self._handle_release(event, bounds)
+        if etype == PointerEventType.ENTER:
+            return self._handle_enter(event, bounds)
+        if etype == PointerEventType.LEAVE:
+            return self._handle_leave(event, bounds)
+        if etype == PointerEventType.SCROLL:
+            return self._handle_scroll(event, bounds)
+        if etype == PointerEventType.CANCEL:
+            return self._handle_cancel(event)
+        return False
+
+    def _handle_press(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
+        if not self._button_allowed(event.button):
+            return False
+        if not self._point_inside(bounds, event.x, event.y):
+            return False
+
+        self._active_pointer_id = event.id
+        self._active_button = event.button
+        if self._capture and self.owner:
+            try:
+                self.owner.capture_pointer(event, passive=False)
+            except Exception:
+                owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
+                exception_once(
+                    logger,
+                    f"pointer_listener_capture_pointer_exc:{owner_name}",
+                    "capture_pointer raised (owner=%s)",
+                    owner_name,
+                )
+
+        if self._on_press:
+            self._invoke_callback(
+                self._on_press,
+                self._with_local(event, bounds),
+                error_key="pointer_listener_press",
+                error_msg="pointer_input on_press raised",
+            )
+        return True
+
+    def _handle_move(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
+        captured = self._capture and self._active_pointer_id is not None and self._active_pointer_id == event.id
+        inside = self._point_inside(bounds, event.x, event.y)
+        self._inside = inside
+        if not captured and not inside:
+            return False
+        if self._on_move:
+            self._invoke_callback(
+                self._on_move,
+                self._with_local(event, bounds),
+                error_key="pointer_listener_move",
+                error_msg="pointer_input on_move raised",
+            )
+        return True
+
+    def _handle_release(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
+        if self._active_pointer_id != event.id:
+            return False
+        # Ignore a release from a different button than the one that opened the
+        # press (all buttons share one pointer id today). A synthetic release
+        # (button is None) always matches.
+        if event.button is not None and event.button != self._active_button:
+            return False
+
+        if self._capture and self.owner:
+            try:
+                self.owner.release_pointer(event.id)
+            except Exception:
+                owner_name = type(self.owner).__name__ if self.owner is not None else "<none>"
+                exception_once(
+                    logger,
+                    f"pointer_listener_release_pointer_exc:{owner_name}",
+                    "release_pointer raised (owner=%s)",
+                    owner_name,
+                )
+        self._active_pointer_id = None
+        self._active_button = None
+
+        if self._on_release:
+            self._invoke_callback(
+                self._on_release,
+                self._with_local(event, bounds),
+                error_key="pointer_listener_release",
+                error_msg="pointer_input on_release raised",
+            )
+        return True
+
+    def _handle_enter(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
+        self._inside = True
+        if self._on_enter:
+            self._invoke_callback(
+                self._on_enter,
+                self._with_local(event, bounds),
+                error_key="pointer_listener_enter",
+                error_msg="pointer_input on_enter raised",
+            )
+            return True
+        return False
+
+    def _handle_leave(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
+        self._inside = False
+        if self._on_leave:
+            self._invoke_callback(
+                self._on_leave,
+                self._with_local(event, bounds),
+                error_key="pointer_listener_leave",
+                error_msg="pointer_input on_leave raised",
+            )
+            return True
+        return False
+
+    def _handle_scroll(self, event: PointerEvent, bounds: Optional[Sequence[float]]) -> bool:
+        if not self._point_inside(bounds, event.x, event.y):
+            return False
+        if self._on_scroll:
+            self._invoke_callback(
+                self._on_scroll,
+                self._with_local(event, bounds),
+                error_key="pointer_listener_scroll",
+                error_msg="pointer_input on_scroll raised",
+            )
+            return True
+        return False
+
+    def _handle_cancel(self, event: PointerEvent) -> bool:
+        if self._active_pointer_id != event.id:
+            return False
+        self._active_pointer_id = None
+        self._active_button = None
+        return True
+
+    def handle_modifier_keys_change(
+        self, event: PointerEvent, bounds: Optional[Sequence[float]] = None
+    ) -> bool:
+        if self.state.disabled or self._on_modifier_keys_change is None:
+            return False
+        # Deliver only while the pointer is inside or captured — never for a
+        # widget the pointer is neither over nor holding.
+        if self._active_pointer_id is None and not self._inside:
+            return False
+        self._invoke_callback(
+            self._on_modifier_keys_change,
+            self._with_local(event, bounds),
+            error_key="pointer_listener_modifier_keys_change",
+            error_msg="pointer_input on_modifier_keys_change raised",
+        )
+        return True
 
 
 class DraggableNode(InteractionNode):
@@ -779,6 +1060,19 @@ class InteractionHostMixin:
         bounds = getattr(self, "last_rect", None) or getattr(self, "global_layout_rect", None)
         for node in self._nodes:
             consumed = node.handle_pointer_event(event, bounds) or consumed
+        return consumed
+
+    def dispatch_modifier_keys_change(self, event: PointerEvent) -> bool:
+        """Deliver a modifier-key mask change to this region's nodes.
+
+        Called by the :class:`Application` when the held modifier-key mask
+        changes; only :class:`PointerListenerNode` responds, and only while the
+        pointer is inside or captured. Returns True if any node consumed it.
+        """
+        consumed = False
+        bounds = getattr(self, "last_rect", None) or getattr(self, "global_layout_rect", None)
+        for node in self._nodes:
+            consumed = node.handle_modifier_keys_change(event, bounds) or consumed
         return consumed
 
 

--- a/tests/modifiers/test_pointer_input.py
+++ b/tests/modifiers/test_pointer_input.py
@@ -1,0 +1,84 @@
+"""Tests for the ``pointer_input()`` modifier (issue #308).
+
+Covers the modifier's node wiring: it attaches a ``PointerListenerNode``,
+composes with ``clickable`` without either clobbering the other, and reconfigures
+(rather than stacking) a second node when re-applied during recomposition.
+"""
+
+from __future__ import annotations
+
+import nuiitivet as nv
+from nuiitivet.input.codes import BUTTON_LEFT
+from nuiitivet.input.pointer import PointerEvent, PointerEventType as T
+from nuiitivet.modifiers.pointer_input import PointerInputModifier, pointer_input
+from nuiitivet.rendering.sizing import Sizing
+from nuiitivet.widgets.box import Box
+from nuiitivet.widgets.interaction import InteractionRegion, PointerInputNode, PointerListenerNode
+
+
+def _make_child() -> Box:
+    return Box(width=Sizing.fixed(100), height=Sizing.fixed(50))
+
+
+def _press(region: InteractionRegion, x: float, y: float) -> None:
+    region.set_last_rect(0, 0, 100, 50)
+    region.on_pointer_event(PointerEvent.mouse_event(1, T.PRESS, x, y, button=BUTTON_LEFT))
+
+
+def test_exported_from_modifiers_and_root() -> None:
+    from nuiitivet.modifiers import pointer_input as from_modifiers
+
+    assert nv.pointer_input is from_modifiers
+
+
+def test_pointer_input_attaches_listener_node() -> None:
+    presses = []
+    wrapped = _make_child().modifier(
+        pointer_input(on_press=lambda e: presses.append((e.local_x, e.local_y)), capture=False)
+    )
+    assert isinstance(wrapped, InteractionRegion)
+    node = wrapped.get_node(PointerListenerNode)
+    assert isinstance(node, PointerListenerNode)
+
+    _press(wrapped, 30, 25)
+    assert presses == [(30.0, 25.0)]
+
+
+def test_composes_with_clickable_without_clobbering() -> None:
+    presses, clicks = [], []
+    wrapped = (
+        _make_child()
+        .modifier(pointer_input(on_press=lambda e: presses.append(1), capture=False))
+        .modifier(nv.clickable(on_click=lambda: clicks.append(1)))
+    )
+    region = wrapped
+    assert isinstance(region, InteractionRegion)
+    # Both nodes live on the same region.
+    assert isinstance(region.get_node(PointerListenerNode), PointerListenerNode)
+    assert isinstance(region.get_node(PointerInputNode), PointerInputNode)
+
+    region.set_last_rect(0, 0, 100, 50)
+    region.on_pointer_event(PointerEvent.mouse_event(1, T.PRESS, 30, 25, button=BUTTON_LEFT))
+    region.on_pointer_event(PointerEvent.mouse_event(1, T.RELEASE, 30, 25, button=BUTTON_LEFT))
+
+    # pointer_input saw the press; clickable still emitted its click.
+    assert presses == [1]
+    assert clicks == [1]
+
+
+def test_reapplying_reconfigures_single_node() -> None:
+    region = InteractionRegion(_make_child())
+
+    first = pointer_input(on_press=lambda e: None, capture=False)
+    first.apply(region)
+    second = pointer_input(on_press=lambda e: None, capture=True)
+    second.apply(region)
+
+    # Only one listener node exists; the second apply reconfigured it.
+    nodes = [n for n in region._nodes if isinstance(n, PointerListenerNode)]
+    assert len(nodes) == 1
+    assert nodes[0]._capture is True
+
+
+def test_factory_returns_modifier() -> None:
+    assert isinstance(pointer_input(), PointerInputModifier)

--- a/tests/runtime/test_modifier_keys_change_dispatch.py
+++ b/tests/runtime/test_modifier_keys_change_dispatch.py
@@ -1,0 +1,103 @@
+"""Application-level routing of modifier-key mask changes (issue #308).
+
+When the held modifier-key mask changes, the app synthesizes a pointer event at
+the last known position and routes it to the widget under (or capturing) the
+pointer so ``pointer_input(on_modifier_keys_change=...)`` fires even while the
+pointer is stationary. The mask is cleared on window deactivation.
+"""
+
+from nuiitivet.runtime.app import App
+from nuiitivet.runtime.pointer import PointerCaptureManager
+from nuiitivet.input.codes import BUTTON_LEFT, MOD_ALT
+from nuiitivet.input.pointer import PointerEvent, PointerEventType as T
+from nuiitivet.modifiers.pointer_input import pointer_input
+from nuiitivet.rendering.sizing import Sizing
+from nuiitivet.widgets.box import Box
+from nuiitivet.widgets.interaction import InteractionRegion
+
+
+class _FakeApp:
+    """Minimal host that borrows the real modifier-key routing methods."""
+
+    _set_modifier_keys = App._set_modifier_keys
+    _clear_modifier_keys = App._clear_modifier_keys
+    _dispatch_modifier_keys_change = App._dispatch_modifier_keys_change
+
+    def __init__(self, hover_target=None):
+        self._modifier_keys = 0
+        self._last_pointer_pos = None
+        self._last_pointer_buttons = 0
+        self._pointer_capture_manager = PointerCaptureManager()
+        self._primary_pointer_id = 1
+        self._last_hover_target = hover_target
+        self.invalidated = 0
+
+    def invalidate(self, immediate: bool = False) -> None:
+        del immediate
+        self.invalidated += 1
+
+
+def _region(**kw) -> InteractionRegion:
+    region = Box(width=Sizing.fixed(100), height=Sizing.fixed(50)).modifier(pointer_input(**kw))
+    assert isinstance(region, InteractionRegion)
+    region.set_last_rect(0, 0, 100, 50)
+    return region
+
+
+def test_modifier_change_delivered_to_hovered_widget():
+    seen = []
+    region = _region(on_modifier_keys_change=lambda e: seen.append((e.modifier_keys, e.local_x, e.local_y)))
+    region.on_pointer_event(PointerEvent.mouse_event(1, T.ENTER, 10, 15))
+
+    app = _FakeApp(hover_target=region)
+    app._last_pointer_pos = (10.0, 15.0)
+
+    app._set_modifier_keys(MOD_ALT)
+    assert seen == [(MOD_ALT, 10.0, 15.0)]
+    assert app.invalidated == 1
+
+
+def test_modifier_change_cleared_on_deactivation():
+    seen = []
+    region = _region(on_modifier_keys_change=lambda e: seen.append(e.modifier_keys))
+    region.on_pointer_event(PointerEvent.mouse_event(1, T.ENTER, 10, 15))
+
+    app = _FakeApp(hover_target=region)
+    app._last_pointer_pos = (10.0, 15.0)
+
+    app._set_modifier_keys(MOD_ALT)
+    # Deactivation (e.g. Cmd+Tab) clears the mask and notifies handlers so no
+    # stuck modifier state survives.
+    app._clear_modifier_keys()
+    assert seen == [MOD_ALT, 0]
+    assert app._modifier_keys == 0
+
+
+def test_no_dispatch_when_mask_unchanged():
+    seen = []
+    region = _region(on_modifier_keys_change=lambda e: seen.append(1))
+    region.on_pointer_event(PointerEvent.mouse_event(1, T.ENTER, 10, 15))
+
+    app = _FakeApp(hover_target=region)
+    app._last_pointer_pos = (10.0, 15.0)
+
+    app._set_modifier_keys(MOD_ALT)
+    app._set_modifier_keys(MOD_ALT)  # same mask — mirrors a non-modifier keypress
+    assert seen == [1]  # exactly one delivery, the second call is a no-op
+
+
+def test_modifier_change_delivered_while_captured_outside():
+    seen = []
+    region = _region(on_modifier_keys_change=lambda e: seen.append(e.modifier_keys), capture=True)
+    # Press inside so the listener node marks itself active/captured.
+    region.on_pointer_event(PointerEvent.mouse_event(1, T.PRESS, 10, 15, button=BUTTON_LEFT))
+
+    app = _FakeApp(hover_target=None)
+    app._pointer_capture_manager.capture(
+        region, PointerEvent.mouse_event(1, T.PRESS, 10, 15, button=BUTTON_LEFT)
+    )
+    # Pointer has since moved well outside the widget bounds.
+    app._last_pointer_pos = (500.0, 500.0)
+
+    app._set_modifier_keys(MOD_ALT)
+    assert seen == [MOD_ALT]

--- a/tests/widgets/test_pointer_listener_node.py
+++ b/tests/widgets/test_pointer_listener_node.py
@@ -1,0 +1,138 @@
+"""Raw pointer-stream node backing ``pointer_input()`` (issue #308).
+
+Exercises ``PointerListenerNode`` at the node level: local coordinates, button
+filtering, capture on/off, the individual press/move/release/enter/leave/scroll
+callbacks, and ``on_modifier_keys_change`` delivery gating.
+"""
+
+from nuiitivet.input.codes import BUTTON_LEFT, BUTTON_RIGHT, MOD_ALT, MOD_CTRL
+from nuiitivet.input.pointer import PointerEvent, PointerEventType as T
+from nuiitivet.widgets.interaction import PointerListenerNode
+
+# x, y, w, h — a widget whose top-left is (10, 20).
+_BOUNDS = (10, 20, 100, 40)
+
+
+def _ev(et, x, y, **kw):
+    return PointerEvent.mouse_event(1, et, x, y, **kw)
+
+
+def test_press_inside_populates_widget_local_coords():
+    seen = []
+    node = PointerListenerNode(on_press=lambda e: seen.append((e.local_x, e.local_y)), capture=False)
+    node.handle_pointer_event(_ev(T.PRESS, 30, 55, button=BUTTON_LEFT), _BOUNDS)
+    # local = screen - widget top-left = (30-10, 55-20)
+    assert seen == [(20.0, 35.0)]
+
+
+def test_press_outside_bounds_is_ignored():
+    seen = []
+    node = PointerListenerNode(on_press=lambda e: seen.append(1), capture=False)
+    assert node.handle_pointer_event(_ev(T.PRESS, 5, 5, button=BUTTON_LEFT), _BOUNDS) is False
+    assert seen == []
+
+
+def test_button_filter_suppresses_nonmatching_press():
+    presses = []
+    node = PointerListenerNode(
+        on_press=lambda e: presses.append(e.button), buttons=(BUTTON_LEFT,), capture=False
+    )
+    assert node.handle_pointer_event(_ev(T.PRESS, 30, 55, button=BUTTON_RIGHT), _BOUNDS) is False
+    assert presses == []
+    node.handle_pointer_event(_ev(T.PRESS, 30, 55, button=BUTTON_LEFT), _BOUNDS)
+    assert presses == [BUTTON_LEFT]
+
+
+def test_capture_true_delivers_move_and_release_outside():
+    moves, releases = [], []
+    node = PointerListenerNode(
+        on_move=lambda e: moves.append((e.local_x, e.local_y)),
+        on_release=lambda e: releases.append(1),
+        capture=True,
+    )
+    node.handle_pointer_event(_ev(T.PRESS, 30, 55, button=BUTTON_LEFT), _BOUNDS)
+    # A move well outside the bounds still arrives because the pointer is captured.
+    node.handle_pointer_event(_ev(T.MOVE, 500, 500, buttons=BUTTON_LEFT), _BOUNDS)
+    assert moves == [(490.0, 480.0)]
+    node.handle_pointer_event(_ev(T.RELEASE, 500, 500, button=BUTTON_LEFT), _BOUNDS)
+    assert releases == [1]
+
+
+def test_capture_false_suppresses_move_outside():
+    moves = []
+    node = PointerListenerNode(on_move=lambda e: moves.append(1), capture=False)
+    node.handle_pointer_event(_ev(T.PRESS, 30, 55, button=BUTTON_LEFT), _BOUNDS)
+    node.handle_pointer_event(_ev(T.MOVE, 500, 500, buttons=BUTTON_LEFT), _BOUNDS)
+    assert moves == []
+    # A move that stays inside still reports.
+    node.handle_pointer_event(_ev(T.MOVE, 40, 55, buttons=BUTTON_LEFT), _BOUNDS)
+    assert moves == [1]
+
+
+def test_move_carries_held_button_mask():
+    seen = []
+    node = PointerListenerNode(on_move=lambda e: seen.append(e.buttons), capture=False)
+    node.handle_pointer_event(_ev(T.MOVE, 30, 55, buttons=BUTTON_LEFT), _BOUNDS)
+    assert seen == [BUTTON_LEFT]
+
+
+def test_enter_leave_callbacks():
+    events = []
+    node = PointerListenerNode(
+        on_enter=lambda e: events.append("enter"),
+        on_leave=lambda e: events.append("leave"),
+    )
+    node.handle_pointer_event(_ev(T.ENTER, 30, 55), _BOUNDS)
+    node.handle_pointer_event(_ev(T.LEAVE, 30, 55), _BOUNDS)
+    assert events == ["enter", "leave"]
+
+
+def test_scroll_callback():
+    scrolls = []
+    node = PointerListenerNode(on_scroll=lambda e: scrolls.append((e.scroll_x, e.scroll_y)))
+    node.handle_pointer_event(PointerEvent.scroll_event(1, 30, 55, 0.0, 2.0), _BOUNDS)
+    assert scrolls == [(0.0, 2.0)]
+
+
+def test_modifier_change_fires_while_inside():
+    seen = []
+    node = PointerListenerNode(on_modifier_keys_change=lambda e: seen.append(e.modifier_keys))
+    node.handle_pointer_event(_ev(T.ENTER, 30, 55), _BOUNDS)
+    assert node.handle_modifier_keys_change(_ev(T.MOVE, 30, 55, modifier_keys=MOD_ALT), _BOUNDS) is True
+    assert seen == [MOD_ALT]
+
+
+def test_modifier_change_fires_while_captured_outside():
+    seen = []
+    node = PointerListenerNode(
+        on_modifier_keys_change=lambda e: seen.append(e.modifier_keys), capture=True
+    )
+    node.handle_pointer_event(_ev(T.PRESS, 30, 55, button=BUTTON_LEFT), _BOUNDS)
+    # Pointer is now conceptually outside but still captured.
+    assert (
+        node.handle_modifier_keys_change(_ev(T.MOVE, 500, 500, modifier_keys=MOD_CTRL), _BOUNDS)
+        is True
+    )
+    assert seen == [MOD_CTRL]
+
+
+def test_modifier_change_suppressed_when_neither_inside_nor_captured():
+    seen = []
+    node = PointerListenerNode(on_modifier_keys_change=lambda e: seen.append(1))
+    assert (
+        node.handle_modifier_keys_change(_ev(T.MOVE, 30, 55, modifier_keys=MOD_ALT), _BOUNDS)
+        is False
+    )
+    assert seen == []
+
+
+def test_modifier_change_stops_after_leave():
+    seen = []
+    node = PointerListenerNode(on_modifier_keys_change=lambda e: seen.append(1))
+    node.handle_pointer_event(_ev(T.ENTER, 30, 55), _BOUNDS)
+    node.handle_pointer_event(_ev(T.LEAVE, 30, 55), _BOUNDS)
+    assert (
+        node.handle_modifier_keys_change(_ev(T.MOVE, 30, 55, modifier_keys=MOD_ALT), _BOUNDS)
+        is False
+    )
+    assert seen == []


### PR DESCRIPTION
Closes #308

## Summary
- Add `pointer_input()` — a low-level "Listener" modifier surfacing the raw
  pointer stream (press / move / release / enter / leave / scroll), each
  delivering a full `PointerEvent`, rather than the semantic click/hover of
  `clickable` / `hoverable`.
- `PointerEvent` gains `local_x` / `local_y` (widget-relative), populated at
  dispatch time; `x` / `y` remain screen coordinates. `held_buttons` reuses the
  existing `buttons` mask added in #305.
- `PointerListenerNode` is a **separate** node from the default
  `PointerInputNode`, so `pointer_input` composes with `clickable` on the same
  widget without either clobbering the other. Supports a `buttons` filter and a
  `capture` toggle.
- `on_modifier_keys_change` fires while the pointer is inside or captured when
  the held modifier-key mask changes — even with the pointer stationary and even
  mid-stroke off the widget. Routed from the `Application`'s authoritative mask,
  which is cleared on window deactivation (no stuck mask after Cmd+Tab).
- Exports: `nuiitivet.modifiers.pointer_input`, `nv.pointer_input`;
  `PointerEvent` / `PointerEventType` exposed at the package root.
- Docs & sample: a Pillow-backed paint canvas sample (Ctrl+click picks a color)
  and a "Raw pointer input" guide section covering local vs screen coordinates.

## Test plan
- [x] `PointerListenerNode` unit tests: local coords, button filter, capture
      on/off, held-button mask, enter/leave/scroll, modifier-change gating
- [x] Modifier-level: attaches listener node, composes with `clickable`,
      re-apply reconfigures a single node
- [x] App-level: modifier-change delivery to hovered/captured widget,
      deactivation clear, no-op on unchanged mask
- [x] Full suite green (1657 + new), `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)