### PR TITLE
fix: give tappable TextField icons MD3 icon-button feedback (#302)

### DIFF
--- a/docs/md3/text_fields.md
+++ b/docs/md3/text_fields.md
@@ -11,6 +11,39 @@
 - Five interactive states are represented across the current token sets: Enabled, Disabled, Hovered, Focused, and Error.
 - Values were resolved from the Material token table using the Light + Default + Expressive context when available, with Light + Default as fallback.
 
+## Interactive (tappable) icons — design note
+
+Investigated for #302 (2026-07-11).
+
+The text-field token set models the leading / trailing icon as **decorative
+only**: the icon tokens are colors per *field* state
+(`{hover,focus,error,disabled}.{leading,trailing}-icon.color`) and a `24dp`
+size, describing how the glyph is tinted while the **field** is in that state.
+Both `hover.trailing-icon.color` and the enabled `trailing-icon.color` resolve
+to `#49454F`, confirming the token describes field state, not a hover of the
+icon itself. There is **no icon state-layer token** in any text-field set — the
+only state-layer tokens are for the filled field's own container.
+
+MD3 does not spell out a token for an *interactive* text-field icon. The
+governing principle is stated generally: "Apply states consistently across
+components," and the Enabled state description ("An enabled state communicates
+an interactive component… Enabled states use the default styling for each
+interactive component") means an interactive element is expected to carry the
+usual state layers. Following the Flutter and Jetpack Compose implementations,
+an interactive text-field icon is therefore realized as a **standard icon
+button** (`md.comp.icon-button.standard.*`), which brings hover (8%), focus
+(10%), and pressed state layers plus keyboard focusability.
+
+**Implementation:** in `TextField`, a leading / trailing icon with a tap
+callback (`on_tap_leading_icon` / `on_tap_trailing_icon`) is built as a standard
+`IconButton`; a decorative icon (no callback) stays a plain, feedback-free
+`Icon`. Hit testing is handled by the framework's coordinate-translating widget
+tree (offset-safe; see #300), not a field-local rectangle test.
+
+**Known gap:** the framework has no mouse-cursor-shape API, so the pointer does
+not change to a hand over the tappable icon (no existing widget changes the
+cursor either). Tracked separately in #316.
+
 ## Tokens & Specs
 
 ### Token Sets Discovered

--- a/src/nuiitivet/material/text_fields.py
+++ b/src/nuiitivet/material/text_fields.py
@@ -56,7 +56,20 @@ def _build_text_field_icon(
     icon: Any,
     *,
     arg_name: str,
+    on_tap: Optional[Callable[[], None]] = None,
 ) -> Optional[Widget]:
+    """Build the widget rendered for a leading / trailing text-field icon.
+
+    A *decorative* icon (``on_tap is None``) is a plain :class:`Icon`: it
+    carries no state layer, hover, focus, or press feedback, matching the MD3
+    text-field icon tokens which only model a tinted, non-interactive glyph.
+
+    A *tappable* icon (``on_tap`` supplied) is upgraded to a standard
+    :class:`IconButton`. MD3 has no icon state-layer token in the text-field
+    set; per the Flutter / Compose implementations an interactive text-field
+    icon is a standard icon button, so it brings its own hover (8%), focus
+    (10%), and pressed state layers plus keyboard focusability.
+    """
     if icon is None:
         return None
 
@@ -72,6 +85,11 @@ def _build_text_field_icon(
     )
     if not ok:
         raise TypeError(f"{arg_name} must be a Symbol/str (or an Observable of them). " f"Got: {type(icon)!r}")
+
+    if on_tap is not None:
+        from nuiitivet.material.buttons import IconButton
+
+        return IconButton(icon, on_click=on_tap)
 
     from nuiitivet.material.icon import Icon
 
@@ -93,9 +111,13 @@ class TextField(InteractiveWidget):
     - on_change: Callback when value changes
     - label: Floating label text (supports Observable)
     - leading_icon: Icon source (Symbol/str or Observable of them)
-    - on_tap_leading_icon: Callback invoked when the leading icon is tapped
+    - on_tap_leading_icon: Callback invoked when the leading icon is tapped.
+      Supplying it upgrades the icon to a standard IconButton with hover /
+      focus / pressed state layers; a decorative icon (no callback) renders
+      as a plain, feedback-free glyph.
     - trailing_icon: Icon source (Symbol/str or Observable of them)
     - on_tap_trailing_icon: Callback invoked when the trailing icon is tapped
+      (see ``on_tap_leading_icon`` for the interactive-icon behavior)
     - obscure_text: Whether to mask text display (password-style)
     - supporting_text: Supporting text to display below the field (supports Observable)
     - is_error: Whether the field is in error state (supports Observable)
@@ -250,17 +272,24 @@ class TextField(InteractiveWidget):
             initial_disabled = bool(disabled)
 
         self.label = label_value
-        self.leading_icon = _build_text_field_icon(leading_icon, arg_name="leading_icon")
-        self.trailing_icon = _build_text_field_icon(trailing_icon, arg_name="trailing_icon")
         self._on_tap_leading_icon = on_tap_leading_icon
         self._on_tap_trailing_icon = on_tap_trailing_icon
+
+        if on_tap_leading_icon is not None and leading_icon is None:
+            raise ValueError("on_tap_leading_icon requires leading_icon to be provided")
+        if on_tap_trailing_icon is not None and trailing_icon is None:
+            raise ValueError("on_tap_trailing_icon requires trailing_icon to be provided")
+
+        # A tap callback upgrades the icon to a standard IconButton (state
+        # layers + keyboard focus); a decorative icon stays a plain Icon.
+        self.leading_icon = _build_text_field_icon(
+            leading_icon, arg_name="leading_icon", on_tap=on_tap_leading_icon
+        )
+        self.trailing_icon = _build_text_field_icon(
+            trailing_icon, arg_name="trailing_icon", on_tap=on_tap_trailing_icon
+        )
         self.supporting_text = supporting_text_value
         self.is_error = initial_is_error
-
-        if self._on_tap_leading_icon is not None and self.leading_icon is None:
-            raise ValueError("on_tap_leading_icon requires leading_icon to be provided")
-        if self._on_tap_trailing_icon is not None and self.trailing_icon is None:
-            raise ValueError("on_tap_trailing_icon requires trailing_icon to be provided")
 
         self._user_style = style
 
@@ -352,6 +381,13 @@ class TextField(InteractiveWidget):
 
         self.state.disabled = next_disabled
         self._editable.state.disabled = next_disabled
+
+        # Tappable icons are IconButton children with their own interaction
+        # state; disable them alongside the field so they stop responding to
+        # hover / press / tap.
+        for icon in (self.leading_icon, self.trailing_icon):
+            if isinstance(icon, InteractiveWidget):
+                icon.disabled = next_disabled
 
         if next_disabled:
             # Ensure visual state doesn't get stuck.
@@ -630,55 +666,18 @@ class TextField(InteractiveWidget):
         self._editable.focus()
 
     def _handle_press(self, event: PointerEvent) -> None:
+        # Reached only when the press was not consumed by a child (i.e. it
+        # landed on the field body, padding, or a decorative icon). A tappable
+        # icon is a real ``IconButton`` child that handles its own press,
+        # hover, focus, and tap callback via the framework's hit testing, so
+        # it never bubbles here.
         if self.disabled:
             return
 
-        # All press paths route focus through the editable's pointer-focus
-        # entry point so that ``EditableText._focus_from_pointer`` is set
-        # consistently regardless of where the press lands (icons, padding,
-        # or the editable area itself). This avoids the focus ring showing
-        # for clicks per MD3 spec.
-        if self._is_point_in_icon_rect(event, self.leading_icon):
-            self._invoke_icon_tap_callback(self._on_tap_leading_icon, key="leading")
-            self._editable.request_focus_from_pointer()
-            return
-
-        if self._is_point_in_icon_rect(event, self.trailing_icon):
-            self._invoke_icon_tap_callback(self._on_tap_trailing_icon, key="trailing")
-            self._editable.request_focus_from_pointer()
-            return
-
+        # Route focus through the editable's pointer-focus entry point so that
+        # ``EditableText._focus_from_pointer`` is set and the focus ring is
+        # suppressed for clicks per MD3 spec.
         self._editable.request_focus_from_pointer()
-
-    def _is_point_in_icon_rect(self, event: PointerEvent, icon: Optional[Widget]) -> bool:
-        if icon is None:
-            return False
-        rect = icon.layout_rect
-        if rect is None:
-            return False
-
-        # Pointer events carry root coordinates, while the icon's layout rect is
-        # relative to this field. Rebase the point onto the field's own origin,
-        # which is (0, 0) only when the field sits at the root.
-        origin = self.global_layout_rect
-        ox, oy = (origin[0], origin[1]) if origin is not None else (0, 0)
-        px, py = event.x - ox, event.y - oy
-
-        rx, ry, rw, rh = rect
-        return rx <= px <= (rx + rw) and ry <= py <= (ry + rh)
-
-    def _invoke_icon_tap_callback(self, cb: Optional[Callable[[], None]], *, key: str) -> None:
-        if cb is None:
-            return
-        try:
-            cb()
-        except Exception:
-            exception_once(
-                _logger,
-                f"text_field_tap_{key}_icon_exc",
-                "TextField %s icon tap callback raised",
-                key,
-            )
 
     def _get_font(self):
         # Use locale-aware fallbacks so that label / supporting text written

--- a/tests/material/test_text_field.py
+++ b/tests/material/test_text_field.py
@@ -13,7 +13,7 @@ from nuiitivet.input.codes import (
     TEXT_MOTION_BACKSPACE,
     TEXT_MOTION_LEFT,
 )
-from nuiitivet.input.pointer import PointerEvent, PointerEventType
+from nuiitivet.input.pointer import PointerEventType
 
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
@@ -236,6 +236,20 @@ def _click_at(root, x: float, y: float) -> None:
     send_pointer_event_for_test_via_app_routing(root, PointerEventType.RELEASE, x, y, button=1)
 
 
+def _icon_button(icon) -> IconButton:
+    """Assert ``icon`` is an IconButton and return it (narrows Optional[Widget])."""
+    assert isinstance(icon, IconButton)
+    return icon
+
+
+def _icon_center(icon, ox: float = 0.0, oy: float = 0.0) -> tuple[float, float]:
+    """Return the root-space center of a tappable icon offset by ``(ox, oy)``."""
+    rect = _icon_button(icon).layout_rect
+    assert rect is not None
+    ix, iy, iw, ih = rect
+    return ox + ix + iw / 2, oy + iy + ih / 2
+
+
 def _mount_field_at(tf: TextField, ox: int, oy: int, w: int = 200, h: int = 56):
     """Place ``tf`` inside a root Box at ``(ox, oy)`` and return the root."""
     root = Box()
@@ -271,8 +285,8 @@ def test_text_field_invokes_icon_tap_callbacks_on_press() -> None:
     root = _mount_field_at(tf, 0, 0)
 
     for icon in (tf.leading_icon, tf.trailing_icon):
-        ix, iy, iw, ih = icon.layout_rect
-        _click_at(root, ix + iw / 2, iy + ih / 2)
+        cx, cy = _icon_center(icon)
+        _click_at(root, cx, cy)
 
     assert leading_tapped is True
     assert trailing_tapped is True
@@ -295,8 +309,8 @@ def test_text_field_invokes_icon_tap_callbacks_when_field_is_offset_from_root() 
     tf = TextField(value="", trailing_icon="close", on_tap_trailing_icon=_on_trailing)
     root = _mount_field_at(tf, 24, 24)
 
-    ix, iy, iw, ih = tf.trailing_icon.layout_rect
-    _click_at(root, 24 + ix + iw / 2, 24 + iy + ih / 2)
+    cx, cy = _icon_center(tf.trailing_icon, 24, 24)
+    _click_at(root, cx, cy)
 
     assert trailing_tapped is True
 
@@ -343,8 +357,8 @@ def test_text_field_does_not_invoke_icon_callbacks_when_disabled() -> None:
     )
     root = _mount_field_at(tf, 0, 0)
 
-    ix, iy, iw, ih = tf.leading_icon.layout_rect
-    _click_at(root, ix + iw / 2, iy + ih / 2)
+    cx, cy = _icon_center(tf.leading_icon)
+    _click_at(root, cx, cy)
 
     assert leading_tapped is False
 
@@ -354,9 +368,8 @@ def test_text_field_tappable_icon_shows_hover_and_press_feedback() -> None:
     tf = TextField(value="", trailing_icon="close", on_tap_trailing_icon=lambda: None)
     root = _mount_field_at(tf, 24, 24)
 
-    icon = tf.trailing_icon
-    ix, iy, iw, ih = icon.layout_rect
-    cx, cy = 24 + ix + iw / 2, 24 + iy + ih / 2
+    icon = _icon_button(tf.trailing_icon)
+    cx, cy = _icon_center(icon, 24, 24)
 
     assert icon.state.hovered is False
     send_pointer_event_for_test_via_app_routing(root, PointerEventType.ENTER, cx, cy)
@@ -380,9 +393,10 @@ def test_text_field_disabling_field_disables_tappable_icon() -> None:
     root = _mount_field_at(tf, 0, 0)
     tf.disabled = True
 
-    assert tf.trailing_icon.disabled is True
-    ix, iy, iw, ih = tf.trailing_icon.layout_rect
-    _click_at(root, ix + iw / 2, iy + ih / 2)
+    icon = _icon_button(tf.trailing_icon)
+    assert icon.disabled is True
+    cx, cy = _icon_center(icon)
+    _click_at(root, cx, cy)
     assert tapped is False
 
 

--- a/tests/material/test_text_field.py
+++ b/tests/material/test_text_field.py
@@ -5,6 +5,8 @@ import pytest
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.icon import Icon
+from nuiitivet.material.buttons import IconButton
+from nuiitivet.widgets.box import Box
 from nuiitivet.widgets.text_editing import TextRange
 from nuiitivet.observable import Observable
 from nuiitivet.input.codes import (
@@ -12,6 +14,8 @@ from nuiitivet.input.codes import (
     TEXT_MOTION_LEFT,
 )
 from nuiitivet.input.pointer import PointerEvent, PointerEventType
+
+from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
 
 def test_text_field_initial_value():
@@ -203,15 +207,46 @@ def test_text_field_ime_composition():
     assert tf._editable._state_internal.value.selection == TextRange(2, 2)
 
 
-def test_text_field_accepts_icon_sources_as_strings() -> None:
+def test_text_field_decorative_icons_are_plain_icons() -> None:
     tf = TextField(value="", leading_icon="search", trailing_icon="close")
     assert isinstance(tf.leading_icon, Icon)
     assert isinstance(tf.trailing_icon, Icon)
 
 
+def test_text_field_tappable_icons_are_icon_buttons() -> None:
+    """A tap callback upgrades the icon to a standard IconButton (state layers)."""
+    tf = TextField(
+        value="",
+        leading_icon="search",
+        on_tap_leading_icon=lambda: None,
+        trailing_icon="close",
+        on_tap_trailing_icon=lambda: None,
+    )
+    assert isinstance(tf.leading_icon, IconButton)
+    assert isinstance(tf.trailing_icon, IconButton)
+
+
 def test_text_field_rejects_widget_icon_instances() -> None:
     with pytest.raises(TypeError):
         TextField(value="", leading_icon=Icon("search"))  # type: ignore[arg-type]
+
+
+def _click_at(root, x: float, y: float) -> None:
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.PRESS, x, y, button=1)
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.RELEASE, x, y, button=1)
+
+
+def _mount_field_at(tf: TextField, ox: int, oy: int, w: int = 200, h: int = 56):
+    """Place ``tf`` inside a root Box at ``(ox, oy)`` and return the root."""
+    root = Box()
+    root.add_child(tf)
+    root.layout(ox + w + 50, oy + h + 50)
+    root.set_layout_rect(0, 0, ox + w + 50, oy + h + 50)
+    root.set_last_rect(0, 0, ox + w + 50, oy + h + 50)
+    tf.layout(w, h)
+    tf.set_layout_rect(ox, oy, w, h)
+    tf.set_last_rect(ox, oy, w, h)
+    return root
 
 
 def test_text_field_invokes_icon_tap_callbacks_on_press() -> None:
@@ -233,17 +268,24 @@ def test_text_field_invokes_icon_tap_callbacks_on_press() -> None:
         trailing_icon="close",
         on_tap_trailing_icon=_on_trailing,
     )
-    tf.layout(200, 56)
+    root = _mount_field_at(tf, 0, 0)
 
-    tf._handle_press(PointerEvent.mouse_event(1, PointerEventType.PRESS, 13, 28))
-    tf._handle_press(PointerEvent.mouse_event(2, PointerEventType.PRESS, 187, 28))
+    for icon in (tf.leading_icon, tf.trailing_icon):
+        ix, iy, iw, ih = icon.layout_rect
+        _click_at(root, ix + iw / 2, iy + ih / 2)
 
     assert leading_tapped is True
     assert trailing_tapped is True
 
 
 def test_text_field_invokes_icon_tap_callbacks_when_field_is_offset_from_root() -> None:
-    """Pointer events arrive in root coordinates, not coordinates local to the field."""
+    """Hit testing must keep working when the field is offset from the root.
+
+    Regression guard for #300: pointer events arrive in root coordinates, and
+    the tappable icon (an IconButton child) is discovered through the
+    framework's coordinate-translating hit test rather than a field-local
+    rectangle comparison.
+    """
     trailing_tapped = False
 
     def _on_trailing() -> None:
@@ -251,18 +293,10 @@ def test_text_field_invokes_icon_tap_callbacks_when_field_is_offset_from_root() 
         trailing_tapped = True
 
     tf = TextField(value="", trailing_icon="close", on_tap_trailing_icon=_on_trailing)
-    tf.layout(200, 56)
-    # Place the field away from the root origin, the way any real layout does.
-    tf.set_layout_rect(24, 24, 200, 56)
+    root = _mount_field_at(tf, 24, 24)
 
-    icon = tf.trailing_icon
-    assert icon is not None
-    icon_rect = icon.layout_rect
-    assert icon_rect is not None
-    ix, iy, iw, ih = icon_rect
-    tf._handle_press(
-        PointerEvent.mouse_event(1, PointerEventType.PRESS, 24 + ix + iw / 2, 24 + iy + ih / 2)
-    )
+    ix, iy, iw, ih = tf.trailing_icon.layout_rect
+    _click_at(root, 24 + ix + iw / 2, 24 + iy + ih / 2)
 
     assert trailing_tapped is True
 
@@ -286,9 +320,9 @@ def test_text_field_does_not_invoke_icon_callbacks_when_pressing_non_icon_area()
         trailing_icon="close",
         on_tap_trailing_icon=_on_trailing,
     )
-    tf.layout(200, 56)
+    root = _mount_field_at(tf, 0, 0)
 
-    tf._handle_press(PointerEvent.mouse_event(1, PointerEventType.PRESS, 100, 28))
+    _click_at(root, 100, 28)
 
     assert leading_tapped is False
     assert trailing_tapped is False
@@ -307,11 +341,49 @@ def test_text_field_does_not_invoke_icon_callbacks_when_disabled() -> None:
         on_tap_leading_icon=_on_leading,
         disabled=True,
     )
-    tf.layout(200, 56)
+    root = _mount_field_at(tf, 0, 0)
 
-    tf._handle_press(PointerEvent.mouse_event(1, PointerEventType.PRESS, 13, 28))
+    ix, iy, iw, ih = tf.leading_icon.layout_rect
+    _click_at(root, ix + iw / 2, iy + ih / 2)
 
     assert leading_tapped is False
+
+
+def test_text_field_tappable_icon_shows_hover_and_press_feedback() -> None:
+    """The tappable icon renders interaction feedback (state layers) — #302."""
+    tf = TextField(value="", trailing_icon="close", on_tap_trailing_icon=lambda: None)
+    root = _mount_field_at(tf, 24, 24)
+
+    icon = tf.trailing_icon
+    ix, iy, iw, ih = icon.layout_rect
+    cx, cy = 24 + ix + iw / 2, 24 + iy + ih / 2
+
+    assert icon.state.hovered is False
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.ENTER, cx, cy)
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.HOVER, cx, cy)
+    assert icon.state.hovered is True
+
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.PRESS, cx, cy, button=1)
+    assert icon.state.pressed is True
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.RELEASE, cx, cy, button=1)
+    assert icon.state.pressed is False
+
+
+def test_text_field_disabling_field_disables_tappable_icon() -> None:
+    tapped = False
+
+    def _on_trailing() -> None:
+        nonlocal tapped
+        tapped = True
+
+    tf = TextField(value="", trailing_icon="close", on_tap_trailing_icon=_on_trailing)
+    root = _mount_field_at(tf, 0, 0)
+    tf.disabled = True
+
+    assert tf.trailing_icon.disabled is True
+    ix, iy, iw, ih = tf.trailing_icon.layout_rect
+    _click_at(root, ix + iw / 2, iy + ih / 2)
+    assert tapped is False
 
 
 def test_text_field_supporting_text_uses_dedicated_color_tokens() -> None:

--- a/tests/material/test_text_field_api.py
+++ b/tests/material/test_text_field_api.py
@@ -4,11 +4,12 @@ import pytest
 
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
+from nuiitivet.material.buttons import IconButton
 from nuiitivet.widgets.box import Box
 from nuiitivet.widgets.text_editing import TextRange
 from nuiitivet.observable import Observable
 from nuiitivet.input.codes import MOD_META, TEXT_MOTION_BACKSPACE
-from nuiitivet.input.pointer import PointerEvent, PointerEventType
+from nuiitivet.input.pointer import PointerEventType
 
 from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
@@ -149,7 +150,11 @@ def test_text_field_api_invokes_trailing_icon_callback_on_icon_press() -> None:
     tf.set_layout_rect(0, 0, 200, 56)
     tf.set_last_rect(0, 0, 200, 56)
 
-    ix, iy, iw, ih = tf.trailing_icon.layout_rect
+    trailing = tf.trailing_icon
+    assert isinstance(trailing, IconButton)
+    rect = trailing.layout_rect
+    assert rect is not None
+    ix, iy, iw, ih = rect
     cx, cy = ix + iw / 2, iy + ih / 2
     send_pointer_event_for_test_via_app_routing(root, PointerEventType.PRESS, cx, cy, button=1)
     send_pointer_event_for_test_via_app_routing(root, PointerEventType.RELEASE, cx, cy, button=1)

--- a/tests/material/test_text_field_api.py
+++ b/tests/material/test_text_field_api.py
@@ -4,10 +4,13 @@ import pytest
 
 from nuiitivet.material.text_fields import TextField
 from nuiitivet.material.styles.text_field_style import TextFieldStyle
+from nuiitivet.widgets.box import Box
 from nuiitivet.widgets.text_editing import TextRange
 from nuiitivet.observable import Observable
 from nuiitivet.input.codes import MOD_META, TEXT_MOTION_BACKSPACE
 from nuiitivet.input.pointer import PointerEvent, PointerEventType
+
+from tests.helpers.pointer import send_pointer_event_for_test_via_app_routing
 
 
 def test_text_field_value_property():
@@ -137,9 +140,19 @@ def test_text_field_api_invokes_trailing_icon_callback_on_icon_press() -> None:
         trailing_icon="close",
         on_tap_trailing_icon=_on_trailing,
     )
+    root = Box()
+    root.add_child(tf)
+    root.layout(250, 106)
+    root.set_layout_rect(0, 0, 250, 106)
+    root.set_last_rect(0, 0, 250, 106)
     tf.layout(200, 56)
+    tf.set_layout_rect(0, 0, 200, 56)
+    tf.set_last_rect(0, 0, 200, 56)
 
-    tf._handle_press(PointerEvent.mouse_event(1, PointerEventType.PRESS, 187, 28))
+    ix, iy, iw, ih = tf.trailing_icon.layout_rect
+    cx, cy = ix + iw / 2, iy + ih / 2
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.PRESS, cx, cy, button=1)
+    send_pointer_event_for_test_via_app_routing(root, PointerEventType.RELEASE, cx, cy, button=1)
 
     assert tapped is True
 


### PR DESCRIPTION
## Summary
- A `TextField` icon with an `on_tap_leading_icon` / `on_tap_trailing_icon` callback now renders as a standard `IconButton`, so it carries MD3 hover / focus / pressed state layers and keyboard focus. A decorative icon (no callback) stays a plain, feedback-free `Icon`.
- Investigation confirmed MD3 models only a *decorative* text-field icon (color per field state, no icon state-layer token); an interactive icon is a standard icon button, matching Flutter / Compose. Recorded in `docs/md3/text_fields.md`.
- Hit testing now goes through the framework's coordinate-translating widget tree instead of a field-local rect test, so it stays correct when the field is offset from the root (regression guard for #300).
- Disabling the field now also disables its tappable icons.
- Pointer-cursor-change item deferred: the framework has no mouse-cursor-shape API (tracked in #316).

## Test plan
- [x] `on_tap_*_icon` callbacks fire via real pointer routing, including when the field is offset from the root (#300 guard)
- [x] Tappable icon shows hover / pressed state-layer feedback
- [x] Decorative icons remain plain `Icon`; tappable icons are `IconButton`
- [x] Disabling the field disables its tappable icons (callbacks suppressed)
- [x] Full `tests/material/` suite (772) passes; mypy clean (569 files); flake8 clean (`--max-line-length=120 --extend-ignore=E203`)

Closes #302