### PR TITLE
fix: strip control characters in EditableText input (#307)

### DIFF
--- a/src/nuiitivet/widgets/editable_text.py
+++ b/src/nuiitivet/widgets/editable_text.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import unicodedata
 from typing import Optional, Tuple, Union, cast
 
 from nuiitivet.input.pointer import PointerEvent
@@ -40,6 +41,22 @@ from nuiitivet.theme.types import ColorSpec
 from nuiitivet.common.logging_once import exception_once
 
 _logger = logging.getLogger(__name__)
+
+
+def _strip_control_chars(text: str) -> str:
+    """Remove Unicode control characters (category ``Cc``) from ``text``.
+
+    Backends do not uniformly filter control characters out of the text they
+    deliver. On macOS, for example, pressing Return dispatches ``on_text('\\r')``
+    through a code path that bypasses the control-character guard applied to
+    every other key (see issue #307). Filtering here keeps the widget's value
+    free of stray control characters regardless of which backend feeds it.
+
+    ``EditableText`` is single-line only, so newlines are dropped as well. When
+    multi-line support lands, ``'\\r'`` should be normalized to ``'\\n'`` and only
+    ``'\\n'`` permitted, rather than allowing raw control characters through here.
+    """
+    return "".join(ch for ch in text if unicodedata.category(ch) != "Cc")
 
 
 class EditableText(InteractionHostMixin, Widget):
@@ -393,6 +410,10 @@ class EditableText(InteractionHostMixin, Widget):
             )
 
     def _handle_text(self, text: str) -> bool:
+        text = _strip_control_chars(text)
+        if not text:
+            return False
+
         current_value = self._state_internal.value
         selection = current_value.selection
         full_text = current_value.text
@@ -415,6 +436,8 @@ class EditableText(InteractionHostMixin, Widget):
         return False
 
     def _handle_ime_composition(self, text: str, start: int, length: int) -> bool:
+        text = _strip_control_chars(text)
+
         current_value = self._state_internal.value
         full_text = current_value.text
 

--- a/tests/widgets/test_editable_text_control_chars.py
+++ b/tests/widgets/test_editable_text_control_chars.py
@@ -1,0 +1,45 @@
+"""Control-character handling in EditableText (issue #307).
+
+Enter delivered as ``on_text('\\r')`` (macOS Cocoa's ``insertNewline_`` path)
+used to bypass the backend control-character filter and land a stray carriage
+return in the value. The widget now strips control characters itself, on both
+the ``on_text`` and IME composition paths.
+"""
+
+from nuiitivet.widgets.editable_text import EditableText
+
+
+def test_handle_text_inserts_printable_character():
+    w = EditableText()
+    assert w._handle_text("a") is True
+    assert w._state_internal.value.text == "a"
+
+
+def test_handle_text_rejects_carriage_return():
+    w = EditableText()
+    for ch in "ab":
+        w._handle_text(ch)
+
+    # Enter delivers '\r' on the macOS backend; it must not modify the value.
+    assert w._handle_text("\r") is False
+    assert w._state_internal.value.text == "ab"
+
+
+def test_handle_text_rejects_tab():
+    w = EditableText()
+    w._handle_text("a")
+    assert w._handle_text("\t") is False
+    assert w._state_internal.value.text == "a"
+
+
+def test_handle_text_strips_control_chars_from_mixed_string():
+    w = EditableText()
+    # A backend could deliver a multi-character payload containing controls.
+    assert w._handle_text("a\rb") is True
+    assert w._state_internal.value.text == "ab"
+
+
+def test_handle_ime_composition_strips_control_chars():
+    w = EditableText()
+    w._handle_ime_composition("a\rb", 2, 0)
+    assert w._state_internal.value.text == "ab"


### PR DESCRIPTION
## Summary
- Fix Enter inserting a stray carriage return (`'\r'`) into a single-line `TextField` value. On macOS, Return is dispatched as `on_text('\r')` through pyglet's Cocoa `insertNewline_` path, bypassing the control-character guard applied to every other key (#307).
- Add `_strip_control_chars` (Unicode category `Cc`) in `EditableText`, applied on both the `on_text` and IME composition paths — a backend-agnostic fix at the layer shared by every backend.
- Single-line only for now, so newlines are dropped; multi-line normalization (`'\r'`→`'\n'`) is deferred to #319.

## Test plan
- [x] `_handle_text('\r')` and `_handle_text('\t')` leave the value unchanged
- [x] A normal printable character still inserts
- [x] Control chars stripped from a mixed multi-character payload
- [x] IME composition path strips control characters
- [x] flake8 (`--max-line-length=120`) and mypy clean; full suite 847 passed

## Related
- Closes #307
- Follow-ups: #318 (on_submit callback), #319 (multi-line support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)