### PR TITLE
perf: use concrete ObservableBase for hot-path isinstance instead of runtime_checkable Protocol (#324)

### DIFF
--- a/src/nuiitivet/animation/animatable.py
+++ b/src/nuiitivet/animation/animatable.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Callable, Generic, Optional, TypeVar, Any, cast
+from typing import Callable, Optional, TypeVar, Any, cast
 
+from nuiitivet.observable.protocols import ObservableBase
 from nuiitivet.observable.value import _ObservableValue
 from nuiitivet.observable import runtime
 
@@ -14,11 +15,15 @@ T = TypeVar("T")
 V = TypeVar("V")
 
 
-class Animatable(Generic[T]):
+class Animatable(ObservableBase[T]):
     """Declarative, retargetable animation value.
 
     Assign to ``target`` to retarget motion without reversing.
     ``value`` is read-only and reflects the current animated value.
+
+    Subclasses :class:`ObservableBase` so it is recognised by the pure-C
+    ``isinstance`` fast path used on the widget construction hot path (#324);
+    it also structurally satisfies :class:`ReadOnlyObservableProtocol`.
     """
 
     def __init__(self: "Animatable[float]", initial_value: float, motion: Optional[Motion] = None) -> None:

--- a/src/nuiitivet/layout/collapsible.py
+++ b/src/nuiitivet/layout/collapsible.py
@@ -38,7 +38,7 @@ from nuiitivet.animation.motion import BezierMotion, Motion
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.layout.alignment import normalize_alignment
 from nuiitivet.layout.measure import preferred_size as measure_preferred_size
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 from nuiitivet.rendering.skia.geometry import clip_rect, make_rect
 from nuiitivet.widgeting.widget import Widget
 
@@ -59,8 +59,8 @@ _EPSILON = 0.5
 _DEFAULT_MOTION: Motion = BezierMotion(0.38, 1.21, 0.22, 1.00, 0.50)
 
 
-def _read_opened(opened: Union[bool, ReadOnlyObservableProtocol[bool]]) -> bool:
-    if isinstance(opened, ReadOnlyObservableProtocol):
+def _read_opened(opened: Union[bool, ObservableBase[bool]]) -> bool:
+    if isinstance(opened, ObservableBase):
         try:
             return bool(opened.value)
         except Exception:
@@ -86,7 +86,7 @@ class Collapsible(Widget):
         self,
         child: Optional[Widget] = None,
         *,
-        opened: Union[bool, ReadOnlyObservableProtocol[bool]] = True,
+        opened: Union[bool, ObservableBase[bool]] = True,
         motion: Motion = _DEFAULT_MOTION,
         motion_out: Optional[Motion] = None,
         axis: Axis = "both",
@@ -108,7 +108,7 @@ class Collapsible(Widget):
             alignment: Alignment of the child within the animated rectangle.
         """
         super().__init__(max_children=1, overflow_policy="replace_last")
-        self._opened: Union[bool, ReadOnlyObservableProtocol[bool]] = opened
+        self._opened: Union[bool, ObservableBase[bool]] = opened
         self._motion_in = motion
         self._motion_out = motion_out if motion_out is not None else motion
         self._axis: Axis = axis
@@ -141,7 +141,7 @@ class Collapsible(Widget):
         super().on_mount()
         self._width_sub = self._width_anim.subscribe(self._on_tick)
         self._height_sub = self._height_anim.subscribe(self._on_tick)
-        if isinstance(self._opened, ReadOnlyObservableProtocol):
+        if isinstance(self._opened, ObservableBase):
             self.observe(self._opened, self._on_opened_changed)
 
     def on_unmount(self) -> None:

--- a/src/nuiitivet/layout/column.py
+++ b/src/nuiitivet/layout/column.py
@@ -9,7 +9,7 @@ from .metrics import compute_aligned_offsets, align_offset
 from .layout_utils import expand_layout_children
 from .for_each import ForEach, ItemsLike, BuilderFn
 from .measure import preferred_size as measure_preferred_size
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 
 
 class Column(Widget):
@@ -36,7 +36,7 @@ class Column(Widget):
         width: SizingLike = None,
         height: SizingLike = None,
         padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
-        gap: Union[int, ReadOnlyObservableProtocol] = 0,
+        gap: Union[int, ObservableBase] = 0,
         main_alignment: str = "start",
         cross_alignment: str = "start",
     ):
@@ -69,8 +69,8 @@ class Column(Widget):
         return getattr(self, "_gap", 0)
 
     @gap.setter
-    def gap(self, value: Union[int, ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def gap(self, value: Union[int, ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             if hasattr(self, "observe"):
                 self.observe(value, lambda v: setattr(self, "gap", v))
             return

--- a/src/nuiitivet/layout/gap.py
+++ b/src/nuiitivet/layout/gap.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from typing import Union
 
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 
 
-def normalize_gap(value: Union[int, float, str, ReadOnlyObservableProtocol, None]) -> int:
+def normalize_gap(value: Union[int, float, str, ObservableBase, None]) -> int:
     """Normalize a gap value to a non-negative integer.
 
     Args:
@@ -18,7 +18,7 @@ def normalize_gap(value: Union[int, float, str, ReadOnlyObservableProtocol, None
     # If it is observable, we cannot resolve it to int here.
     # The caller must check for instance before calling this if they support observability.
     # Currently existing code assumes int return.
-    if isinstance(value, ReadOnlyObservableProtocol):
+    if isinstance(value, ObservableBase):
         return 0
     try:
         return max(0, int(value))

--- a/src/nuiitivet/layout/row.py
+++ b/src/nuiitivet/layout/row.py
@@ -9,7 +9,7 @@ from .metrics import compute_aligned_offsets, align_offset
 from .layout_utils import expand_layout_children
 from .for_each import ForEach, ItemsLike, BuilderFn
 from .measure import preferred_size as measure_preferred_size
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 
 
 class Row(Widget):
@@ -32,7 +32,7 @@ class Row(Widget):
         width: SizingLike = None,
         height: SizingLike = None,
         padding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
-        gap: Union[int, ReadOnlyObservableProtocol] = 0,
+        gap: Union[int, ObservableBase] = 0,
         main_alignment: str = "start",
         cross_alignment: str = "start",
     ):
@@ -63,8 +63,8 @@ class Row(Widget):
         return getattr(self, "_gap", 0)
 
     @gap.setter
-    def gap(self, value: Union[int, ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def gap(self, value: Union[int, ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             if hasattr(self, "observe"):
                 self.observe(value, lambda v: setattr(self, "gap", v))
             return

--- a/src/nuiitivet/layout/scrollable.py
+++ b/src/nuiitivet/layout/scrollable.py
@@ -21,7 +21,7 @@ import logging
 from typing import ClassVar, Optional, Tuple, Union
 
 from nuiitivet.common.logging_once import exception_once
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 
 from ..widgeting.widget import Widget
 from ..scrolling import (
@@ -45,11 +45,11 @@ from .scroll_viewport import ScrollViewport
 logger = logging.getLogger(__name__)
 
 
-ScrollbarVisibleLike = Union[bool, ReadOnlyObservableProtocol[bool]]
+ScrollbarVisibleLike = Union[bool, ObservableBase[bool]]
 
 
 def _read_bool(value: ScrollbarVisibleLike) -> bool:
-    if isinstance(value, ReadOnlyObservableProtocol):
+    if isinstance(value, ObservableBase):
         try:
             return bool(value.value)
         except Exception:
@@ -192,7 +192,7 @@ class _ScrollableBase(Widget):
         self._scroll_unsubscribe = axis_state.offset.subscribe(_offset_cb)
 
         # Reactive scrollbar visibility: relayout / repaint when it changes.
-        if isinstance(self._scrollbar_visible, ReadOnlyObservableProtocol):
+        if isinstance(self._scrollbar_visible, ObservableBase):
             self.observe(self._scrollbar_visible, self._on_scrollbar_visible_changed)
 
     def _on_scrollbar_visible_changed(self, _value: bool) -> None:

--- a/src/nuiitivet/material/app.py
+++ b/src/nuiitivet/material/app.py
@@ -17,7 +17,7 @@ from nuiitivet.theme.types import ColorSpec
 from nuiitivet.widgeting.widget import Widget
 
 if TYPE_CHECKING:
-    from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+    from nuiitivet.observable.protocols import ObservableBase
     from nuiitivet.runtime.chrome import CustomChrome, OSChrome
 
 
@@ -50,7 +50,7 @@ class MaterialApp(App):
         height: WindowSizingLike = "auto",
         background: ColorSpec = ColorRole.SURFACE,
         theme: Optional[Any] = None,
-        title: str | None | ReadOnlyObservableProtocol[str | None] = None,
+        title: str | None | ObservableBase[str | None] = None,
         chrome: OSChrome | CustomChrome | None = _UNSET,  # type: ignore[assignment]
         window_position: WindowPosition | None = None,
         resizable: bool = True,

--- a/src/nuiitivet/material/button_group.py
+++ b/src/nuiitivet/material/button_group.py
@@ -30,7 +30,7 @@ from nuiitivet.layout.row import Row
 from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL, STANDARD_BUTTON_GROUP_WIDTH
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.observable import ObservableProtocol, ReadOnlyObservableProtocol
+from nuiitivet.observable import MutableObservableBase, ObservableBase
 from nuiitivet.rendering.sizing import Sizing, SizingLike
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.widgeting.callbacks import invoke_event_handler, BoolCallback
@@ -96,11 +96,11 @@ class GroupButton(InteractiveWidget):
 
     Args:
         label: Optional text label.  Can be a plain ``str`` or a
-            ``ReadOnlyObservableProtocol[str]`` for dynamic text.
+            ``ObservableBase[str]`` for dynamic text.
         icon: Optional icon.  Accepts a ``Symbol``, ``str`` icon name, or
-            ``ReadOnlyObservableProtocol`` wrapping either.
+            ``ObservableBase`` wrapping either.
         selected: Initial selected (toggle) state.  Pass an
-            ``ObservableProtocol[bool]`` to bind to external state.
+            ``MutableObservableBase[bool]`` to bind to external state.
         on_change: Callback fired with the new ``bool`` selected state after each
             toggle.  In ``ConnectedButtonGroup`` this callback is composed with
             the group-level selection logic.
@@ -112,12 +112,12 @@ class GroupButton(InteractiveWidget):
 
     def __init__(
         self,
-        label: "str | ReadOnlyObservableProtocol[str] | None" = None,
-        icon: "Symbol | str | ReadOnlyObservableProtocol | None" = None,
+        label: "str | ObservableBase[str] | None" = None,
+        icon: "Symbol | str | ObservableBase | None" = None,
         *,
-        selected: "bool | ObservableProtocol[bool]" = False,
+        selected: "bool | MutableObservableBase[bool]" = False,
         on_change: Optional[BoolCallback] = None,
-        disabled: "bool | ObservableProtocol[bool]" = False,
+        disabled: "bool | MutableObservableBase[bool]" = False,
         width: SizingLike = None,
         style: "Optional[ButtonGroupStyle]" = None,
     ) -> None:
@@ -146,9 +146,9 @@ class GroupButton(InteractiveWidget):
         self._on_change: Optional[BoolCallback] = on_change
 
         # Selected state
-        self._selected_external: "Optional[ObservableProtocol[bool]]" = None
+        self._selected_external: "Optional[MutableObservableBase[bool]]" = None
         if hasattr(selected, "subscribe") and hasattr(selected, "value"):
-            self._selected_external = cast("ObservableProtocol[bool]", selected)
+            self._selected_external = cast("MutableObservableBase[bool]", selected)
             self._selected: bool = bool(self._selected_external.value)
         else:
             self._selected = bool(selected)
@@ -387,7 +387,7 @@ class GroupButton(InteractiveWidget):
         # Write back to external observable if mutable
         if self._selected_external is not None:
             ext = self._selected_external
-            if hasattr(ext, "value") and not isinstance(ext, ReadOnlyObservableProtocol):
+            if hasattr(ext, "value") and not isinstance(ext, ObservableBase):
                 try:
                     ext.value = bool(value)  # type: ignore[assignment]
                 except AttributeError:

--- a/src/nuiitivet/material/date_picker.py
+++ b/src/nuiitivet/material/date_picker.py
@@ -42,7 +42,7 @@ from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.theme.type_scale import TypeScaleToken
 from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.material.theme.elevation import md3_elevation_to_shadow
-from nuiitivet.observable import Observable, ObservableProtocol, ReadOnlyObservableProtocol
+from nuiitivet.observable import Observable, ObservableProtocol, ObservableBase
 from nuiitivet.overlay import OverlayAware
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.widgets.box import Box
@@ -917,8 +917,8 @@ class _MonthYearHeader(ComposableWidget):
         on_toggle_year_picker: Optional[VoidCallback] = None,
         year_picker_active: bool = False,
         active_view: Optional[Literal["month", "year"]] = None,
-        month_rotation: Optional[ReadOnlyObservableProtocol[float]] = None,
-        year_rotation: Optional[ReadOnlyObservableProtocol[float]] = None,
+        month_rotation: Optional[ObservableBase[float]] = None,
+        year_rotation: Optional[ObservableBase[float]] = None,
         variant: Literal["inline", "modal"] = "inline",
         nav_padding: Tuple[int, int, int, int] = (12, 6, 12, 2),
         style: "CalendarStyle",
@@ -980,7 +980,7 @@ class _MonthYearHeader(ComposableWidget):
 
             def _dropdown(
                 on_tap: Optional[VoidCallback],
-                rotation: Optional[ReadOnlyObservableProtocol[float]],
+                rotation: Optional[ObservableBase[float]],
             ) -> Widget:
                 btn: Widget = IconButton("arrow_drop_down", on_click=on_tap, style=dropdown_style)
                 if rotation is not None:
@@ -994,7 +994,7 @@ class _MonthYearHeader(ComposableWidget):
                 on_prev: Optional[VoidCallback],
                 on_next: Optional[VoidCallback],
                 on_tap: Optional[VoidCallback],
-                rotation: Optional[ReadOnlyObservableProtocol[float]],
+                rotation: Optional[ObservableBase[float]],
             ) -> Widget:
                 # The full chevron/dropdown structure is always built so the label
                 # keeps its position; hidden parts are merely made invisible via

--- a/src/nuiitivet/material/sheet.py
+++ b/src/nuiitivet/material/sheet.py
@@ -16,7 +16,7 @@ from nuiitivet.material.styles.text_style import TextStyle
 from nuiitivet.theme.type_scale import TypeScaleToken
 from nuiitivet.material.text import Text
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.observable.protocols import ObservableProtocol, ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import MutableObservableBase, ObservableBase
 from nuiitivet.overlay import OverlayAware
 from nuiitivet.rendering.sizing import Sizing
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -69,9 +69,9 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
         self,
         content: Widget,
         *,
-        headline: Union[str, ReadOnlyObservableProtocol[str]],
+        headline: Union[str, ObservableBase[str]],
         on_back: Optional[Callable[[], None]] = None,
-        show_back_button: Union[bool, ReadOnlyObservableProtocol[bool]] = False,
+        show_back_button: Union[bool, ObservableBase[bool]] = False,
         style: Optional[SideSheetStyle] = None,
     ) -> None:
         """Initialize SideSheet.
@@ -99,7 +99,7 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
         return self._user_style if self._user_style is not None else SideSheetStyle()
 
     def _resolve_show_back(self) -> bool:
-        if isinstance(self._show_back_button, ReadOnlyObservableProtocol):
+        if isinstance(self._show_back_button, ObservableBase):
             return bool(self._show_back_button.value)
         return bool(self._show_back_button)
 
@@ -112,7 +112,7 @@ class SideSheet(ComposableWidget, OverlayAware[None]):
     def on_mount(self) -> None:
         """Mount and subscribe to show_back_button observable if provided."""
         super().on_mount()
-        if isinstance(self._show_back_button, ReadOnlyObservableProtocol):
+        if isinstance(self._show_back_button, ObservableBase):
             sub = self._show_back_button.subscribe(lambda _: self.rebuild())
             self.bind(sub)
 
@@ -191,7 +191,7 @@ class BottomSheet(ComposableWidget, OverlayAware[None]):
         self,
         content: Widget,
         *,
-        headline: Union[str, ReadOnlyObservableProtocol[str]],
+        headline: Union[str, ObservableBase[str]],
         style: Optional[BottomSheetStyle] = None,
     ) -> None:
         """Initialize BottomSheet.
@@ -302,9 +302,9 @@ class StandardSideSheet(ComposableWidget):
         self,
         content: Widget,
         *,
-        opened: Union[bool, ObservableProtocol[bool]] = True,
+        opened: Union[bool, MutableObservableBase[bool]] = True,
         on_close_click: Optional[Callable[[], None]] = None,
-        headline: Optional[Union[str, ReadOnlyObservableProtocol[str]]] = None,
+        headline: Optional[Union[str, ObservableBase[str]]] = None,
         side: Literal["right", "left"] = "right",
         style: Optional[StandardSideSheetStyle] = None,
     ) -> None:
@@ -336,7 +336,7 @@ class StandardSideSheet(ComposableWidget):
 
     def _can_auto_close(self) -> bool:
         """Return whether *opened* is writable, i.e. the sheet can close itself."""
-        return isinstance(self._opened, ObservableProtocol)
+        return isinstance(self._opened, MutableObservableBase)
 
     def _show_close_button(self) -> bool:
         return self._on_close_click is not None or self._can_auto_close()
@@ -346,13 +346,13 @@ class StandardSideSheet(ComposableWidget):
         if self._on_close_click is not None:
             self._on_close_click()
             return
-        if isinstance(self._opened, ObservableProtocol):
+        if isinstance(self._opened, MutableObservableBase):
             self._opened.value = False
 
     def on_mount(self) -> None:
         """Mount and subscribe to headline observable if provided."""
         super().on_mount()
-        if isinstance(self._headline, ReadOnlyObservableProtocol):
+        if isinstance(self._headline, ObservableBase):
             sub = self._headline.subscribe(lambda _: self.rebuild())
             self.bind(sub)
 

--- a/src/nuiitivet/material/split_button.py
+++ b/src/nuiitivet/material/split_button.py
@@ -19,7 +19,7 @@ from nuiitivet.input.pointer import PointerEvent
 from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.material.motion import EXPRESSIVE_FAST_SPATIAL, EXPRESSIVE_DEFAULT_SPATIAL
 from nuiitivet.material.theme.color_role import ColorRole
-from nuiitivet.observable import ObservableProtocol
+from nuiitivet.observable import MutableObservableBase
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.widgeting.callbacks import invoke_event_handler, VoidCallback, BoolCallback
@@ -97,7 +97,7 @@ class _SplitLeadingButton(InteractiveWidget):
         child: "Widget",
         style: "SplitButtonStyle",
         on_click: Optional[VoidCallback] = None,
-        disabled: "bool | ObservableProtocol[bool]" = False,
+        disabled: "bool | MutableObservableBase[bool]" = False,
     ) -> None:
         """Initialize the leading button segment.
 
@@ -237,8 +237,8 @@ class _SplitTrailingButton(InteractiveWidget):
         self,
         style: "SplitButtonStyle",
         on_menu_toggle: Optional[BoolCallback] = None,
-        menu_open: "bool | ObservableProtocol[bool]" = False,
-        disabled: "bool | ObservableProtocol[bool]" = False,
+        menu_open: "bool | MutableObservableBase[bool]" = False,
+        disabled: "bool | MutableObservableBase[bool]" = False,
     ) -> None:
         """Initialize the trailing button segment.
 
@@ -256,10 +256,10 @@ class _SplitTrailingButton(InteractiveWidget):
         self._own_pressed: bool = False
 
         # Selected state (menu open)
-        self._selected_external: "Optional[ObservableProtocol[bool]]" = None
+        self._selected_external: "Optional[MutableObservableBase[bool]]" = None
         if hasattr(menu_open, "subscribe") and hasattr(menu_open, "value"):
             self._selected_external = menu_open  # type: ignore[assignment]
-            ext_obs: "ObservableProtocol[bool]" = self._selected_external  # type: ignore[assignment]
+            ext_obs: "MutableObservableBase[bool]" = self._selected_external  # type: ignore[assignment]
             self._selected: bool = bool(ext_obs.value)
         else:
             self._selected = bool(menu_open)
@@ -377,9 +377,9 @@ class _SplitTrailingButton(InteractiveWidget):
         # Write back to external observable if mutable
         ext = self._selected_external
         if ext is not None and hasattr(ext, "value"):
-            from nuiitivet.observable import ReadOnlyObservableProtocol
+            from nuiitivet.observable import ObservableBase
 
-            if not isinstance(ext, ReadOnlyObservableProtocol):
+            if not isinstance(ext, ObservableBase):
                 try:
                     ext.value = bool(value)  # type: ignore[assignment]
                 except AttributeError:
@@ -527,8 +527,8 @@ class SplitButton(Box):
         *,
         on_click: Optional[VoidCallback] = None,
         on_menu_toggle: Optional[BoolCallback] = None,
-        menu_open: "bool | ObservableProtocol[bool]" = False,
-        disabled: "bool | ObservableProtocol[bool]" = False,
+        menu_open: "bool | MutableObservableBase[bool]" = False,
+        disabled: "bool | MutableObservableBase[bool]" = False,
         width: SizingLike = None,
         style: "Optional[SplitButtonStyle]" = None,
     ) -> None:
@@ -539,12 +539,12 @@ class SplitButton(Box):
                 ``icon`` (or both) must be provided.
             icon: Leading icon for the leading button.  Accepts a
                 :class:`Symbol`, a symbol name string, or a
-                :class:`ReadOnlyObservableProtocol`.
+                :class:`ObservableBase`.
             on_click: Callback invoked when the leading button is clicked.
             on_menu_toggle: Callback invoked with the new ``bool`` menu open
                 state when the trailing button is clicked.
             menu_open: Initial menu open (selected) state of the trailing
-                button.  Pass an :class:`ObservableProtocol` to bind
+                button.  Pass an :class:`MutableObservableBase` to bind
                 externally.
             disabled: Disables both button halves when ``True``.
             width: Optional width sizing for the overall widget.

--- a/src/nuiitivet/modifiers/ignore_pointer.py
+++ b/src/nuiitivet/modifiers/ignore_pointer.py
@@ -23,14 +23,14 @@ from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
 from nuiitivet.common.logging_once import exception_once
-from nuiitivet.observable import ReadOnlyObservableProtocol
+from nuiitivet.observable import ObservableBase
 from nuiitivet.widgeting.modifier import ModifierElement
 from nuiitivet.widgeting.widget import Widget
 
 logger = logging.getLogger(__name__)
 
 
-IgnorePointerConditionLike = Union[bool, ReadOnlyObservableProtocol[bool]]
+IgnorePointerConditionLike = Union[bool, ObservableBase[bool]]
 
 
 class IgnorePointerBox(Widget):
@@ -49,7 +49,7 @@ class IgnorePointerBox(Widget):
 
     @staticmethod
     def _read_initial(condition: IgnorePointerConditionLike) -> bool:
-        if isinstance(condition, ReadOnlyObservableProtocol):
+        if isinstance(condition, ObservableBase):
             try:
                 return bool(condition.value)
             except Exception:
@@ -63,7 +63,7 @@ class IgnorePointerBox(Widget):
 
     def on_mount(self) -> None:
         super().on_mount()
-        if isinstance(self._condition, ReadOnlyObservableProtocol):
+        if isinstance(self._condition, ObservableBase):
             self.observe(self._condition, self._set_active)
 
     def _set_active(self, value: bool) -> None:

--- a/src/nuiitivet/modifiers/transform.py
+++ b/src/nuiitivet/modifiers/transform.py
@@ -5,7 +5,7 @@ import logging
 from typing import Optional, Tuple, Union
 
 from nuiitivet.common.logging_once import exception_once
-from nuiitivet.observable import ReadOnlyObservableProtocol
+from nuiitivet.observable import ObservableBase
 from ..rendering.sizing import SizingLike
 from ..widgeting.modifier import ModifierElement
 from ..widgeting.widget import Widget
@@ -14,10 +14,10 @@ from ..widgeting.widget import Widget
 logger = logging.getLogger(__name__)
 
 
-AngleLike = Union[float, ReadOnlyObservableProtocol[float]]
-ScaleLike = Union[float, Tuple[float, float], ReadOnlyObservableProtocol[float]]
-TranslateLike = Union[Tuple[float, float], ReadOnlyObservableProtocol[Tuple[float, float]]]
-OpacityLike = Union[float, ReadOnlyObservableProtocol[float]]
+AngleLike = Union[float, ObservableBase[float]]
+ScaleLike = Union[float, Tuple[float, float], ObservableBase[float]]
+TranslateLike = Union[Tuple[float, float], ObservableBase[Tuple[float, float]]]
+OpacityLike = Union[float, ObservableBase[float]]
 OriginLike = Union[str, Tuple[float, float]]
 
 
@@ -78,7 +78,7 @@ class TransformBox(Widget):
 
     def _bind_rotation(self, rotation: AngleLike) -> None:
         self._rotation_source = rotation
-        if isinstance(rotation, ReadOnlyObservableProtocol):
+        if isinstance(rotation, ObservableBase):
             try:
                 self.observe(rotation, self._set_rotation)
                 return
@@ -99,7 +99,7 @@ class TransformBox(Widget):
 
     def _bind_scale(self, scale: ScaleLike) -> None:
         self._scale_source = scale
-        if isinstance(scale, ReadOnlyObservableProtocol):
+        if isinstance(scale, ObservableBase):
             try:
                 self.observe(scale, self._set_scale)
                 return
@@ -125,7 +125,7 @@ class TransformBox(Widget):
 
     def _bind_translation(self, translation: TranslateLike) -> None:
         self._translation_source = translation
-        if isinstance(translation, ReadOnlyObservableProtocol):
+        if isinstance(translation, ObservableBase):
             try:
                 self.observe(translation, self._set_translation)
                 return
@@ -148,7 +148,7 @@ class TransformBox(Widget):
 
     def _bind_opacity(self, opacity: OpacityLike) -> None:
         self._opacity_source = opacity
-        if isinstance(opacity, ReadOnlyObservableProtocol):
+        if isinstance(opacity, ObservableBase):
             try:
                 self.observe(opacity, self._set_opacity)
                 return

--- a/src/nuiitivet/modifiers/visible.py
+++ b/src/nuiitivet/modifiers/visible.py
@@ -42,7 +42,7 @@ from nuiitivet.animation.animatable import Animatable
 from nuiitivet.animation.transition_definition import TransitionDefinition
 from nuiitivet.animation.transition_pattern import TransitionVisuals
 from nuiitivet.common.logging_once import exception_once
-from nuiitivet.observable import ReadOnlyObservableProtocol
+from nuiitivet.observable import ObservableBase
 from nuiitivet.observable.computed import ComputedObservable
 from nuiitivet.widgeting.modifier import Modifier, ModifierElement
 from nuiitivet.widgeting.widget import Widget
@@ -57,11 +57,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-VisibleConditionLike = Union[bool, ReadOnlyObservableProtocol[bool]]
+VisibleConditionLike = Union[bool, ObservableBase[bool]]
 
 
 def _read_initial_condition(condition: VisibleConditionLike) -> bool:
-    if isinstance(condition, ReadOnlyObservableProtocol):
+    if isinstance(condition, ObservableBase):
         try:
             return bool(condition.value)
         except Exception:
@@ -111,7 +111,7 @@ class _AnimatedVisibleBox(Widget):
 
     def on_mount(self) -> None:
         super().on_mount()
-        if isinstance(self._condition, ReadOnlyObservableProtocol):
+        if isinstance(self._condition, ObservableBase):
             self.observe(self._condition, self._on_condition_changed)
 
     def on_unmount(self) -> None:
@@ -307,8 +307,8 @@ def _has_visual_effect(visuals: TransitionVisuals) -> bool:
 
 def _hidden_observable(
     condition: VisibleConditionLike,
-) -> Union[bool, ReadOnlyObservableProtocol[bool]]:
-    if isinstance(condition, ReadOnlyObservableProtocol):
+) -> Union[bool, ObservableBase[bool]]:
+    if isinstance(condition, ObservableBase):
         source = condition
         return ComputedObservable(lambda: not bool(source.value))
     return not bool(condition)
@@ -316,8 +316,8 @@ def _hidden_observable(
 
 def _opacity_observable(
     condition: VisibleConditionLike,
-) -> Union[float, ReadOnlyObservableProtocol[float]]:
-    if isinstance(condition, ReadOnlyObservableProtocol):
+) -> Union[float, ObservableBase[float]]:
+    if isinstance(condition, ObservableBase):
         source = condition
         return ComputedObservable(lambda: 1.0 if bool(source.value) else 0.0)
     return 1.0 if bool(condition) else 0.0

--- a/src/nuiitivet/observable/__init__.py
+++ b/src/nuiitivet/observable/__init__.py
@@ -3,7 +3,14 @@
 from .batching import BatchContext, batch, detach_batch
 from .combine import CombineBuilder, combine
 from .computed import ComputedObservable
-from .protocols import CompareFunc, Disposable, ObservableProtocol, ReadOnlyObservableProtocol
+from .protocols import (
+    CompareFunc,
+    Disposable,
+    MutableObservableBase,
+    ObservableBase,
+    ObservableProtocol,
+    ReadOnlyObservableProtocol,
+)
 from .runtime import clock, set_clock
 from .timed import DebouncedObservable, ThrottledObservable
 from .value import Observable, _ObservableValue
@@ -18,7 +25,9 @@ __all__ = [
     "ComputedObservable",
     "DebouncedObservable",
     "Disposable",
+    "MutableObservableBase",
     "Observable",
+    "ObservableBase",
     "ObservableProtocol",
     "ReadOnlyObservableProtocol",
     "ThrottledObservable",

--- a/src/nuiitivet/observable/computed.py
+++ b/src/nuiitivet/observable/computed.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Any, Callable, Generic, List, Optional, Set, TypeVar, TYPE_CHECKING
+from typing import Any, Callable, List, Optional, Set, TypeVar, TYPE_CHECKING
 
 from nuiitivet.common.logging_once import debug_once, exception_once
 
 from .contexts import _batch_context, _tracking_context
-from .protocols import Disposable, ReadOnlyObservableProtocol
+from .protocols import Disposable, ObservableBase, ReadOnlyObservableProtocol
 from . import runtime
 
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-class ComputedObservable(Generic[T]):
+class ComputedObservable(ObservableBase[T]):
     """Computed observable with automatic dependency tracking (Signals pattern)."""
 
     def __init__(

--- a/src/nuiitivet/observable/protocols.py
+++ b/src/nuiitivet/observable/protocols.py
@@ -17,6 +17,52 @@ class Disposable:
             self._disposed = True
 
 
+class ObservableBase(Generic[T]):
+    """Concrete base for all observables (read-capable).
+
+    Every built-in observable subclasses this so hot paths can use a pure-C
+    ``isinstance(value, ObservableBase)`` check instead of the much slower
+    ``@runtime_checkable`` Protocol instance check (which, on CPython < 3.12,
+    runs the metaclass ``__instancecheck__`` in Python and ``hasattr``-probes
+    every member on every call).
+
+    The read interface is declared here so an ``ObservableBase`` value is also a
+    structural :class:`ReadOnlyObservableProtocol`, letting callers keep the
+    Protocol as the wider static type where duck typing is still wanted.
+    Subclasses provide the real implementations; the stubs never run.
+    """
+
+    __slots__ = ()
+
+    def subscribe(self, cb: Callable[[T], None]) -> Disposable:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def changes(self) -> "ReadOnlyObservableProtocol[T]":  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    @property
+    def value(self) -> T:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+class MutableObservableBase(ObservableBase[T]):
+    """Concrete base for observables whose ``value`` is writable.
+
+    Runtime counterpart of :class:`ObservableProtocol` (mirrors what
+    :class:`ObservableBase` is to :class:`ReadOnlyObservableProtocol`).
+    """
+
+    __slots__ = ()
+
+    @property
+    def value(self) -> T:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    @value.setter
+    def value(self, v: T) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
 @runtime_checkable
 class ReadOnlyObservableProtocol(Protocol, Generic[T]):
     def subscribe(self, cb: Callable[[T], None]) -> Disposable: ...

--- a/src/nuiitivet/observable/timed.py
+++ b/src/nuiitivet/observable/timed.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Generic, List, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 from nuiitivet.common.logging_once import debug_once
 
 from .combine import CombineBuilder
 from .computed import ComputedObservable
-from .protocols import Disposable, ReadOnlyObservableProtocol
+from .protocols import Disposable, ObservableBase, ReadOnlyObservableProtocol
 from . import runtime
 
 T = TypeVar("T")
@@ -16,7 +16,7 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-class DebouncedObservable(Generic[T]):
+class DebouncedObservable(ObservableBase[T]):
     """Debounced observable that emits value only after delay with no new changes."""
 
     def __init__(self, source: ReadOnlyObservableProtocol[T], seconds: float):
@@ -76,7 +76,7 @@ class DebouncedObservable(Generic[T]):
         return self
 
 
-class ThrottledObservable(Generic[T]):
+class ThrottledObservable(ObservableBase[T]):
     """Throttled observable that emits first value then ignores changes for duration."""
 
     def __init__(self, source: ReadOnlyObservableProtocol[T], seconds: float):

--- a/src/nuiitivet/observable/value.py
+++ b/src/nuiitivet/observable/value.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import logging
 import threading
 import warnings
-from typing import Any, Callable, Generic, List, Optional, TypeVar, TYPE_CHECKING
+from typing import Any, Callable, List, Optional, TypeVar, TYPE_CHECKING
 
 from nuiitivet.common.logging_once import debug_once
 
 from .contexts import _batch_context, _tracking_context
-from .protocols import CompareFunc, Disposable, ReadOnlyObservableProtocol
+from .protocols import CompareFunc, Disposable, MutableObservableBase, ReadOnlyObservableProtocol
 from . import runtime
 
 if TYPE_CHECKING:
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 _UNSET = object()
 
 
-class _ObservableValue(Generic[T]):
+class _ObservableValue(MutableObservableBase[T]):
     def __init__(
         self,
         initial: T,

--- a/src/nuiitivet/runtime/app.py
+++ b/src/nuiitivet/runtime/app.py
@@ -30,7 +30,7 @@ from .app_events import (
 )
 from .chrome import OSChrome, CustomChrome
 from .title_bar import WindowDragArea
-from nuiitivet.observable.protocols import Disposable, ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import Disposable, ObservableBase
 from .window import WindowSizingLike, WindowPosition, parse_window_sizing
 from .renderer import RendererMode, parse_renderer_mode
 from nuiitivet.layout.column import Column
@@ -164,7 +164,7 @@ class App:
         root: Widget,
         width: WindowSizingLike,
         height: WindowSizingLike,
-        title: "str | None | ReadOnlyObservableProtocol[str | None]",
+        title: "str | None | ObservableBase[str | None]",
         chrome: "OSChrome | CustomChrome | None",
         background: ColorSpec,
         theme: Optional[Any] = None,
@@ -278,7 +278,7 @@ class App:
         # Wrap the root widget with AppScope to provide access to the App instance
         self.root = AppScope(app=self, child=self.root)
 
-        self._title_value: str | None | ReadOnlyObservableProtocol[str | None] = title
+        self._title_value: str | None | ObservableBase[str | None] = title
         self._title_disposable: Optional[Disposable] = None
 
         self._scale = 1.0
@@ -430,7 +430,7 @@ class App:
         width: WindowSizingLike = "auto",
         height: WindowSizingLike = "auto",
         *,
-        title: "str | None | ReadOnlyObservableProtocol[str | None]" = None,
+        title: "str | None | ObservableBase[str | None]" = None,
         chrome: "OSChrome | CustomChrome | None" = _UNSET,  # type: ignore[assignment]
         background: ColorSpec = PlainColorRole.SURFACE,
         overlay_factory: Callable[[], "Overlay"] | None = None,
@@ -451,7 +451,7 @@ class App:
             width: Window width specification.
             height: Window height specification.
             title: OS window title. Accepts a plain string or a
-                :class:`~nuiitivet.observable.protocols.ReadOnlyObservableProtocol`
+                :class:`~nuiitivet.observable.protocols.ObservableBase`
                 for dynamic updates (e.g. ``Observable("Untitled")``). Pass
                 ``None`` for no title.
             chrome: Window decoration. Pass an :class:`OSChrome` instance to
@@ -626,7 +626,7 @@ class App:
         self._theme_subscription = None
 
     def _subscribe_title_updates(self) -> None:
-        if not isinstance(self._title_value, ReadOnlyObservableProtocol):
+        if not isinstance(self._title_value, ObservableBase):
             return
         app_ref = weakref.ref(self)
 

--- a/src/nuiitivet/widgeting/widget_kernel.py
+++ b/src/nuiitivet/widgeting/widget_kernel.py
@@ -9,7 +9,7 @@ from ..common.logging_once import exception_once
 from ..rendering.padding import parse_padding
 from ..rendering.sizing import Sizing, SizingLike, parse_sizing
 from ..runtime.threading import assert_ui_thread
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 
 
 _logger = logging.getLogger(__name__)
@@ -28,9 +28,9 @@ class WidgetKernel:
     def __init__(
         self,
         *,
-        width: Union[SizingLike, ReadOnlyObservableProtocol] = None,
-        height: Union[SizingLike, ReadOnlyObservableProtocol] = None,
-        padding: Union[PaddingLike, ReadOnlyObservableProtocol] = None,
+        width: Union[SizingLike, ObservableBase] = None,
+        height: Union[SizingLike, ObservableBase] = None,
+        padding: Union[PaddingLike, ObservableBase] = None,
         **_: Any,
     ) -> None:
         super().__init__()
@@ -134,8 +134,8 @@ class WidgetKernel:
         return self._width_sizing
 
     @width_sizing.setter
-    def width_sizing(self, value: Union[SizingLike, ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def width_sizing(self, value: Union[SizingLike, ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             if hasattr(self, "observe"):
                 self.observe(value, lambda v: setattr(self, "width_sizing", v))  # type: ignore
             return
@@ -147,8 +147,8 @@ class WidgetKernel:
         return self._height_sizing
 
     @height_sizing.setter
-    def height_sizing(self, value: Union[SizingLike, ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def height_sizing(self, value: Union[SizingLike, ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             if hasattr(self, "observe"):
                 self.observe(value, lambda v: setattr(self, "height_sizing", v))  # type: ignore
             return
@@ -161,8 +161,8 @@ class WidgetKernel:
         return self._padding
 
     @padding.setter
-    def padding(self, pad: Union[PaddingLike, ReadOnlyObservableProtocol]) -> None:
-        if isinstance(pad, ReadOnlyObservableProtocol):
+    def padding(self, pad: Union[PaddingLike, ObservableBase]) -> None:
+        if isinstance(pad, ObservableBase):
             if hasattr(self, "observe"):
                 self.observe(pad, lambda v: setattr(self, "padding", v))  # type: ignore
             return

--- a/src/nuiitivet/widgets/box.py
+++ b/src/nuiitivet/widgets/box.py
@@ -17,7 +17,7 @@ from ..layout.layout_engine import LayoutEngine
 from ..layout.alignment import normalize_alignment
 from ..layout.measure import preferred_size as measure_preferred_size
 from ..widgeting.modifier import Modifier
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 
 _logger = logging.getLogger(__name__)
 
@@ -81,8 +81,8 @@ class Box(CachedPaintMixin, Widget):
         return self._bgcolor
 
     @bgcolor.setter
-    def bgcolor(self, value: Union[Optional[ColorSpec], ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def bgcolor(self, value: Union[Optional[ColorSpec], ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             self.observe(value, lambda v: setattr(self, "bgcolor", v))
             return
         self._bgcolor = value
@@ -93,8 +93,8 @@ class Box(CachedPaintMixin, Widget):
         return self._border_color
 
     @border_color.setter
-    def border_color(self, value: Union[Optional[ColorSpec], ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def border_color(self, value: Union[Optional[ColorSpec], ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             self.observe(value, lambda v: setattr(self, "border_color", v))
             return
         self._border_color = value
@@ -105,8 +105,8 @@ class Box(CachedPaintMixin, Widget):
         return self._shadow_color
 
     @shadow_color.setter
-    def shadow_color(self, value: Union[Optional[ColorSpec], ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def shadow_color(self, value: Union[Optional[ColorSpec], ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             self.observe(value, lambda v: setattr(self, "shadow_color", v))
             return
         self._shadow_color = value
@@ -117,8 +117,8 @@ class Box(CachedPaintMixin, Widget):
         return getattr(self, "_corner_radius", 0)
 
     @corner_radius.setter
-    def corner_radius(self, value: Union[float, Tuple[float, float, float, float], ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def corner_radius(self, value: Union[float, Tuple[float, float, float, float], ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             self.observe(value, lambda v: setattr(self, "corner_radius", v))
             return
         self._corner_radius = value
@@ -129,8 +129,8 @@ class Box(CachedPaintMixin, Widget):
         return getattr(self, "_border_width", 0.0)
 
     @border_width.setter
-    def border_width(self, value: Union[float, ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def border_width(self, value: Union[float, ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             self.observe(value, lambda v: setattr(self, "border_width", v))
             return
         self._border_width = float(value) if value is not None else 0.0
@@ -141,8 +141,8 @@ class Box(CachedPaintMixin, Widget):
         return getattr(self, "_shadow_blur", 0.0)
 
     @shadow_blur.setter
-    def shadow_blur(self, value: Union[float, ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def shadow_blur(self, value: Union[float, ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             self.observe(value, lambda v: setattr(self, "shadow_blur", v))
             return
         self._shadow_blur = float(value) if value is not None else 0.0
@@ -153,8 +153,8 @@ class Box(CachedPaintMixin, Widget):
         return getattr(self, "_shadow_offset", (0.0, 0.0))
 
     @shadow_offset.setter
-    def shadow_offset(self, value: Union[Tuple[float, float], ReadOnlyObservableProtocol]) -> None:
-        if isinstance(value, ReadOnlyObservableProtocol):
+    def shadow_offset(self, value: Union[Tuple[float, float], ObservableBase]) -> None:
+        if isinstance(value, ObservableBase):
             self.observe(value, lambda v: setattr(self, "shadow_offset", v))
             return
         self._shadow_offset = value if value is not None else (0.0, 0.0)

--- a/src/nuiitivet/widgets/image.py
+++ b/src/nuiitivet/widgets/image.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.layout.alignment import AlignmentLike, normalize_alignment
-from nuiitivet.observable.protocols import ReadOnlyObservableProtocol
+from nuiitivet.observable.protocols import ObservableBase
 from nuiitivet.rendering.fit import Fit
 from nuiitivet.rendering.sizing import SizingLike
 from nuiitivet.rendering.skia import clip_rect, make_rect
@@ -29,7 +29,7 @@ class Image(Widget):
 
     def __init__(
         self,
-        source: bytes | None | ReadOnlyObservableProtocol[bytes | None],
+        source: bytes | None | ObservableBase[bytes | None],
         *,
         fit: Fit = "contain",
         width: SizingLike = None,
@@ -52,12 +52,12 @@ class Image(Widget):
         self._align_raw: AlignmentLike = alignment
         self._alignment: tuple[str, str] = normalize_alignment(alignment, default=("center", "center"))
 
-        self._source: bytes | None | ReadOnlyObservableProtocol[bytes | None] = source
+        self._source: bytes | None | ObservableBase[bytes | None] = source
         self._resolved_source: bytes | None = None
         self._decoded_image: Any | None = None
         self._decoded_token: tuple[int, int] | None = None
 
-        if isinstance(source, ReadOnlyObservableProtocol):
+        if isinstance(source, ObservableBase):
             self.observe(source, self._on_source_change)
         else:
             self._on_source_change(source)

--- a/tests/observable/test_observable_base.py
+++ b/tests/observable/test_observable_base.py
@@ -1,0 +1,71 @@
+"""Concrete observable base classes back the hot-path isinstance fast path (issue #324).
+
+Every built-in observable must subclass :class:`ObservableBase` (and the mutable
+ones :class:`MutableObservableBase`) so widget construction can use a pure-C
+``isinstance`` check instead of the slow ``@runtime_checkable`` Protocol check,
+while still satisfying the Protocols structurally.
+"""
+
+from nuiitivet.observable import Observable, combine
+from nuiitivet.observable.computed import ComputedObservable
+from nuiitivet.observable.protocols import (
+    MutableObservableBase,
+    ObservableBase,
+    ObservableProtocol,
+    ReadOnlyObservableProtocol,
+)
+from nuiitivet.observable.timed import DebouncedObservable, ThrottledObservable
+from nuiitivet.observable.value import _ObservableValue
+
+
+def test_mutable_observables_are_mutable_base():
+    obs = Observable(0)
+    assert isinstance(obs, MutableObservableBase)
+    assert isinstance(obs, ObservableBase)
+    assert isinstance(_ObservableValue(0), MutableObservableBase)
+
+
+def test_readonly_observables_are_readonly_base_only():
+    computed = ComputedObservable(lambda: 1)
+    debounced = DebouncedObservable(Observable(0), 0.1)
+    throttled = ThrottledObservable(Observable(0), 0.1)
+
+    for ro in (computed, debounced, throttled):
+        assert isinstance(ro, ObservableBase)
+        # read-only observables expose no writable ``value``
+        assert not isinstance(ro, MutableObservableBase)
+
+
+def test_bases_still_satisfy_protocols_structurally():
+    obs = Observable(0)
+    computed = ComputedObservable(lambda: 1)
+    assert isinstance(obs, ObservableProtocol)
+    assert isinstance(obs, ReadOnlyObservableProtocol)
+    assert isinstance(computed, ReadOnlyObservableProtocol)
+
+
+def test_plain_values_are_not_observables():
+    for value in (12, 1.5, "red", (1, 2, 3, 4), None):
+        assert not isinstance(value, ObservableBase)
+        assert not isinstance(value, MutableObservableBase)
+
+
+def test_combine_result_is_observable_base():
+    combined = combine(Observable(1), Observable(2)).compute(lambda a, b: a + b)
+    assert isinstance(combined, ObservableBase)
+
+
+def test_animatable_is_recognised_as_observable():
+    """Animatable is a duck-typed observable; it must ride the fast path too.
+
+    Regression guard for #324: widget setters use ``isinstance(x, ObservableBase)``
+    to decide whether to observe a value, so Animatable (passed e.g. to ``rotate``)
+    must subclass ObservableBase or it would silently be treated as a plain value.
+    """
+    from nuiitivet.animation.animatable import Animatable
+
+    anim = Animatable(0.0)
+    assert isinstance(anim, ObservableBase)
+    assert isinstance(anim, ReadOnlyObservableProtocol)
+    # read-only: no writable ``value``
+    assert not isinstance(anim, MutableObservableBase)


### PR DESCRIPTION
Closes #324

## Summary
- Introduce concrete marker bases `ObservableBase` (read-capable) and `MutableObservableBase` (writable); every built-in observable now subclasses them
- Replace the ~36 hot-path `isinstance(x, ReadOnly/ObservableProtocol)` checks (Box/WidgetKernel setters and many widgets) with the pure-C concrete `isinstance(x, ObservableBase)` — the `@runtime_checkable` Protocol check is uncached on CPython < 3.12 (~9.8 µs/call)
- Chose **ObservableBase-only** over the issue's hybrid: widget args are typically `Observable | int`, and the common `int` case would fall through the hybrid's fast positive check into the slow Protocol fallback, gaining nothing
- Make `Animatable` subclass `ObservableBase` — it is a duck-typed observable passed e.g. to `rotate()`, and would otherwise be treated as a plain value (breaking bindings like the DatePicker dropdown-arrow rotation)
- Keep the Protocols for structural static typing; `ObservableBase` satisfies them

## Measured (CPython 3.10)
- `isinstance` on a plain `int`: **9.86 µs → 0.076 µs**
- `Box(...)` construction: **~117 µs → 19.2 µs**

## Test plan
- [x] `mypy` / `flake8` clean
- [x] `pytest` — 1684 existing + 6 new pass
- [x] Added `tests/observable/test_observable_base.py` (base-class recognition + Animatable regression guard)
- [x] E2E verified: `rotate(Animatable)` takes the observe path (subscriber count 1) and rotation follows value changes (0 → 180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)