### PR TITLE
feat(interaction): land RadioGroup and the button groups on FocusScope

### DIFF
--- a/docs/design/INTERACTION_ARCHITECTURE.md
+++ b/docs/design/INTERACTION_ARCHITECTURE.md
@@ -57,7 +57,7 @@ Holding focus and being a stop in the Tab sequence are **two separate properties
 | Focusable | owning a `FocusNode` | The widget can hold focus, receive key events, and paint a focus ring. |
 | Traversable | `FocusNode.traversable` (default `True`) | The global Tab sequence stops on it. |
 
-`App._collect_focus_nodes` collects only the **traversable** nodes. A node with `traversable=False` is still focusable: it can be focused programmatically (typically by the `FocusScope` that owns it), it still receives keys, and its keys still bubble — Tab merely never lands on it. `Clickable` and `InteractiveWidget` expose `traversable` as a constructor argument.
+`App._collect_focus_nodes` collects only the **traversable** nodes. A node with `traversable=False` is still focusable: it can be focused programmatically (typically by the `FocusScope` that owns it), it still receives keys, and its keys still bubble — Tab merely never lands on it. `Clickable` and `InteractiveWidget` expose `traversable` as a constructor argument, and `Clickable.set_traversable()` flips it afterwards — a widget does not always know at construction that it belongs to a group (a `RadioButton` meets its `RadioGroup` only when it is mounted).
 
 This split is what makes a group (menu, multi-handle slider) expressible: without it, every focusable part of a widget is unavoidably its own Tab stop.
 
@@ -110,6 +110,7 @@ Deliberately small, so that real-node owners and virtual-stop owners implement t
 | `members()` | The members, in traversal order. |
 | `current_index()` | Index of the current member, or `-1` if none. |
 | `set_current(index)` | Make that member current (focusing it, if it is a real node). |
+| `entry_index(backwards)` | The member Tab enters the group at. Defaults to the first (last on Shift+Tab). |
 | `on_boundary(direction)` | Tab stepped past the last / before the first member: consume it, or let it escape. |
 
 A **member** is whatever the owner traverses between. Two shapes are built in:
@@ -119,7 +120,7 @@ A **member** is whatever the owner traverses between. Two shapes are built in:
 
 ### Scope behavior
 
-- **Entry direction** — Tab enters the group at its first member, Shift+Tab at its last (`FocusScope.on_enter`). `App` calls this when traversal focuses a widget that hosts a scope, so Shift+Tab into a `RangeSlider` lands on the far handle.
+- **Entry member** — `FocusScope.on_enter` asks the policy (`entry_index`). By default Tab enters the group at its first member and Shift+Tab at its last, so Shift+Tab into a `RangeSlider` lands on the far handle; a `RadioGroup` overrides it to enter at the *selected* radio. `App` calls this when traversal focuses a widget that hosts a scope.
 - **Roving** — `FocusScope.move(step, wrap=)` moves to the adjacent member. Whether *Tab* does the roving is the scope's `tab_roves` flag: a slider roves on Tab; a menu roves on the arrow keys and sets `tab_roves=False`, so every Tab is a boundary.
 - **Boundary** — the policy decides: returning `False` (the default) lets Tab escape to the next stop outside the group; returning `True` consumes it (a popup menu dismisses itself).
 
@@ -131,14 +132,21 @@ When a scope lets Tab escape and the focused node is not itself a stop, traversa
 
 ### Applied
 
-| | `Menu` (popup) | `Menu` (inline) | `RangeSlider` |
-| :--- | :--- | :--- | :--- |
-| Members | enabled items (real `FocusNode`s) | same | handle indices (virtual stops) |
-| External Tab stops | none — entered by opening it | one (the surface); WAI-ARIA makes a permanently visible menu a single stop | one (the slider) |
-| Roving keys | Tab (no wrap) and Up/Down (wrap) | same | Tab |
-| At the boundary | dismiss | escape to the next widget | escape to the next widget |
+| Widget | Members | External Tab stop | Entered at | Roving keys | At the boundary |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `Menu` (popup) | enabled items (real `FocusNode`s) | none — entered by opening it | first item | Tab (no wrap) and Up/Down (wrap) | dismiss |
+| `Menu` (inline) | same | one (the surface); WAI-ARIA makes a permanently visible menu a single stop | first / last item | same | escape to the next widget |
+| `RangeSlider` | handle indices (virtual stops) | one (the slider) | first / last handle | Tab | escape to the next widget |
+| `RadioGroup` | enabled radios (real `FocusNode`s) | one (the group) | **the selected radio** | arrows on both axes (wrap) | escape to the next widget |
+| `StandardButtonGroup` / `ConnectedButtonGroup` | enabled items (real `FocusNode`s) | one (the group) | first / last item | Left/Right (**no wrap**) | escape to the next widget |
 
 A single-handle `Slider` is a one-member scope: Tab enters, finds no second member, and hands the key straight back to the global sequence. Submenus are nested scopes.
+
+**Wrap vs. stop-at-edge, and what roving means, are per-widget decisions** — `FocusScope.move(step, wrap=)` takes the choice per call:
+
+- A `RadioGroup` follows the WAI-ARIA radio group: the arrows **wrap**, and moving the focus **moves the selection with it** ("selection follows focus"), which is also why Tab enters the group at the selected radio rather than the first one. Both axes rove, because a radio group is laid out as a `Row` or a `Column` and the keys must work either way.
+- A button group follows the WAI-ARIA toolbar: Left/Right **stop at the ends**, and roving moves the focus only — its items are actions or independent toggles, so activation stays on Enter/Space.
+- A member is taken out of the group when it is disabled: a disabled `Clickable` has no `FocusNode` at all, so the policies enumerate exactly the members the keyboard should reach.
 
 ### Menu keyboard model (provisional)
 
@@ -163,7 +171,7 @@ The open question is whether Tab and the arrow keys should both rove, and whethe
 
 When screen reader / accessibility tree support is implemented (via `SemanticsNode`), revisit how the members of a scope are announced. Virtual stops (slider handles) carry no `FocusNode` and therefore no natural place for a per-thumb semantic label (e.g., "Start value: 30"); the `SemanticsNode` design will decide whether the policy grows a semantics hook or virtual stops become real nodes.
 
-Widget groups not yet on this primitive — segmented buttons, radio groups, toolbars, tab bars — all want roving with a single external stop and should be migrated onto it rather than growing their own navigation.
+Widget groups not yet on this primitive — segmented buttons, tab bars, toolbars — all want roving with a single external stop and should be migrated onto it rather than growing their own navigation. `NavigationRail` is a group too, but it is keyboard-unreachable today and how it should *show* the focus is unsettled (MD3 shows no focus ring on rail items, and a ring around the active indicator would collide with its neighbours); that is tracked separately.
 
 ## Node Roles & Extensibility
 
@@ -173,7 +181,7 @@ The Node-based architecture allows for future expansion by adding specialized no
 | :--- | :--- | :--- |
 | **`PointerInputNode`** (Core) | **Point Interaction.** Manages hover, click, and press states. Handles simple tap and mouse-over events. | Successor to `InteractionController`. Triggers "Click-to-Focus". |
 | **`FocusNode`** (Core) | **Keyboard & Order.** Manages focus state, Tab traversal order (`traversable`), and key event reception/bubbling. | Gateway for IME integration. Focusable and traversable are separate properties. |
-| **`FocusScope`** (Core) | **Grouped Traversal.** Marks a subtree as a single Tab stop and roves between its members via a `FocusTraversalPolicy`. | Used by `Menu` (real-node members) and `RangeSlider` (virtual stops). Replaces the `wants_tab` interception. |
+| **`FocusScope`** (Core) | **Grouped Traversal.** Marks a subtree as a single Tab stop and roves between its members via a `FocusTraversalPolicy`. | Used by `Menu`, `RadioGroup` and the button groups (real-node members) and by `RangeSlider` (virtual stops). Replaces the `wants_tab` interception. |
 | **`DraggableNode`** (Core) | **Movement (Source).** Handles drag start, delta updates, and end detection. Manages drag previews. | Distinct from `PointerInputNode`; handles movement (deltas). Includes long-press initiation logic. |
 | **`DropTargetNode`** (Future) | **Acceptance (Target).** Determines whether dropped data is accepted and processes data on drop. | `InteractionRegion` hit-testing identifies this node as a drop candidate. |
 | **`ScrollableNode`** (Future) | **Scrolling.** Handles mouse wheel, touchpad pan, and inertia calculations. | Collaborates with `ScrollViewport`. Consumes pointer events to produce scroll offsets. |

--- a/src/nuiitivet/material/button_group.py
+++ b/src/nuiitivet/material/button_group.py
@@ -35,6 +35,7 @@ from nuiitivet.rendering.sizing import Sizing, SizingLike
 from nuiitivet.theme.types import ColorSpec
 from nuiitivet.widgeting.callbacks import invoke_event_handler, BoolCallback
 from nuiitivet.widgets.box import Box
+from nuiitivet.widgets.interaction import FocusNode, FocusNodePolicy, FocusScope, InteractionHostMixin
 
 if TYPE_CHECKING:
     from nuiitivet.material.styles.button_group_style import (
@@ -716,11 +717,17 @@ class _ButtonGroupRow(Row):
 # ---------------------------------------------------------------------------
 
 
-class _ButtonGroupBase(Box):
+class _ButtonGroupBase(InteractionHostMixin, Box):
     """Internal base for StandardButtonGroup and ConnectedButtonGroup.
 
     Validates items, builds the Row layout, and calls ``set_position()`` on
     each item during ``on_mount()``.
+
+    The group is also one focus traversal group: a single Tab stop, with Left and
+    Right roving the items inside it (the group is always a Row). Roving stops at
+    the ends rather than wrapping — the WAI-ARIA toolbar pattern — and moves the
+    focus only: unlike a radio group, the selection follows Enter or Space, not the
+    focus, because a group's items are actions or independent toggles.
     """
 
     def __init__(
@@ -768,6 +775,14 @@ class _ButtonGroupBase(Box):
         )
 
         super().__init__(child=row, width=group_width)
+
+        # The group is the Tab stop; its items are not (see on_mount). Tab lands
+        # here, the scope hands the focus to the first item, and the arrow keys
+        # take over. Tab does not rove: it leaves the group for the next widget.
+        self._focus_node = FocusNode(on_key=self.on_key_event)
+        self.add_node(self._focus_node)
+        self._focus_scope = FocusScope(FocusNodePolicy(self._item_focus_nodes), tab_roves=False)
+        self.add_node(self._focus_scope)
 
         # Propagate the group's sized style to items now, so the tree measures
         # correctly even before mount.  Window auto-sizing calls preferred_size
@@ -817,6 +832,27 @@ class _ButtonGroupBase(Box):
             "pressed_inner_corner_radius": self._style.pressed_inner_corner_radius,
         }
 
+    def _item_focus_nodes(self) -> List[FocusNode]:
+        """Return the FocusNodes of the items the arrow keys can rove.
+
+        A disabled item has no FocusNode at all (see ``Clickable``), which is
+        exactly the set the keyboard should skip.
+        """
+        nodes = [item.get_node(FocusNode) for item in self._items]
+        return [node for node in nodes if isinstance(node, FocusNode)]
+
+    def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:
+        """Rove the items with Left and Right, stopping at the ends."""
+        key_name = str(key).lower()
+
+        if key_name == "right":
+            return self._focus_scope.move(1)
+
+        if key_name == "left":
+            return self._focus_scope.move(-1)
+
+        return False
+
     def on_mount(self) -> None:
         """Assign positions, sync size-layout tokens, and set neighbors for all items."""
         super().on_mount()
@@ -825,6 +861,9 @@ class _ButtonGroupBase(Box):
         self._apply_item_sizing()
         n = len(self._items)
         for i, item in enumerate(self._items):
+            # The group owns the Tab stop; the items are roved by its FocusScope.
+            item.set_traversable(False)
+
             if n == 1:
                 pos: ButtonGroupPosition = "only"
             elif i == 0:

--- a/src/nuiitivet/material/selection_controls.py
+++ b/src/nuiitivet/material/selection_controls.py
@@ -16,6 +16,7 @@ from nuiitivet.common.logging_once import exception_once
 from nuiitivet.layout.container import Container
 from nuiitivet.observable import Observable, ObservableProtocol
 from nuiitivet.widgeting.widget import Widget
+from nuiitivet.widgets.interaction import FocusNode, FocusNodePolicy, FocusScope, InteractionHostMixin
 from nuiitivet.widgets.toggleable import Toggleable
 from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_EFFECTS, EXPRESSIVE_DEFAULT_SPATIAL
@@ -456,8 +457,36 @@ class Checkbox(Toggleable, InteractiveWidget):
             return
 
 
-class RadioGroup(Container):
-    """Container that manages a single selected value for descendant RadioButtons."""
+class _RadioTraversalPolicy(FocusNodePolicy):
+    """Traversal over the enabled radios of a group, entered at the selected one.
+
+    WAI-ARIA makes the *selected* radio the group's stop in the Tab sequence, not
+    the first one: Tab into a group with the third option selected lands on the
+    third radio. Only an empty selection enters at an end.
+    """
+
+    def __init__(self, group: "RadioGroup") -> None:
+        super().__init__(group._radio_focus_nodes)
+        self._group = group
+
+    def entry_index(self, backwards: bool) -> int:
+        radios = self._group.radios()
+        for index, radio in enumerate(radios):
+            if radio.option_value == self._group.value:
+                return index
+        return super().entry_index(backwards)
+
+
+class RadioGroup(InteractionHostMixin, Container):
+    """Container that manages a single selected value for descendant RadioButtons.
+
+    The group is one focus traversal group (WAI-ARIA): a single Tab stop, entered
+    at the selected radio, with the arrow keys roving between the radios. Roving
+    also moves the selection ("selection follows focus"), so the arrows are how the
+    keyboard picks an option; Space and Enter select the current one as well. The
+    arrows wrap at the ends, and either axis roves — a radio group may be laid out
+    as a Row or a Column, and the keys must work whichever it is.
+    """
 
     def __init__(
         self,
@@ -487,6 +516,14 @@ class RadioGroup(Container):
         self._value_internal: Observable[object | None] = Observable(initial_value)
         self._on_change = on_change
 
+        # The group is the Tab stop; the radios inside it are not (see
+        # RadioButton.on_mount). Tab lands here, the scope hands the focus to the
+        # selected radio, and the arrow keys take over from there.
+        self._focus_node = FocusNode(on_key=self.on_key_event)
+        self.add_node(self._focus_node)
+        self._focus_scope = FocusScope(_RadioTraversalPolicy(self), tab_roves=False)
+        self.add_node(self._focus_scope)
+
     @property
     def value(self) -> object | None:
         """Current selected value."""
@@ -502,6 +539,57 @@ class RadioGroup(Container):
         super().on_mount()
         if self._value_external is not None:
             self.observe(self._value_external, lambda _v: self._invalidate_descendant_radios())
+
+    def radios(self) -> list["RadioButton"]:
+        """Return the radios the keyboard can rove, in tree order.
+
+        Disabled radios are left out: they are not selectable, so the arrow keys
+        skip over them rather than roving onto a dead option. A disabled radio has
+        no FocusNode either (see :class:`~nuiitivet.widgets.clickable.Clickable`),
+        which keeps this list and :meth:`_radio_focus_nodes` index-aligned.
+        """
+        found: list[RadioButton] = []
+
+        def _walk(node: Widget) -> None:
+            for child in node.children_snapshot():
+                if not isinstance(child, Widget):
+                    continue
+                if isinstance(child, RadioGroup):
+                    continue
+                if isinstance(child, RadioButton):
+                    if isinstance(child.get_node(FocusNode), FocusNode):
+                        found.append(child)
+                _walk(child)
+
+        _walk(self)
+        return found
+
+    def _radio_focus_nodes(self) -> list[FocusNode]:
+        """Return the FocusNodes of :meth:`radios`, in the same order."""
+        return [cast(FocusNode, radio.get_node(FocusNode)) for radio in self.radios()]
+
+    def on_key_event(self, key: str, modifier_keys: int = 0) -> bool:
+        """Rove the radios with the arrow keys, moving the selection with the focus."""
+        key_name = str(key).lower()
+
+        if key_name in ("down", "right"):
+            return self._move_focus(1)
+
+        if key_name in ("up", "left"):
+            return self._move_focus(-1)
+
+        return False
+
+    def _move_focus(self, step: int) -> bool:
+        """Focus the next (+1) or previous (-1) radio, wrapping, and select it."""
+        if not self._focus_scope.move(step, wrap=True):
+            return False
+
+        for radio in self.radios():
+            if radio.state.focused:
+                self.select(radio.option_value)
+                break
+        return True
 
     def select(self, new_value: object | None) -> None:
         """Select a new value and notify listeners."""
@@ -609,6 +697,12 @@ class RadioButton(Toggleable, InteractiveWidget):
                     self.invalidate()
             except Exception:
                 pass
+
+        # Inside a group the radio is no Tab stop of its own: the group is the stop
+        # and its FocusScope roves the radios (WAI-ARIA). A radio placed on its own
+        # stays an ordinary stop.
+        self.set_traversable(self.find_ancestor(RadioGroup) is None)
+
         self._sync_selected_state()
 
     def _selected(self) -> bool:

--- a/src/nuiitivet/widgets/clickable.py
+++ b/src/nuiitivet/widgets/clickable.py
@@ -87,6 +87,19 @@ class Clickable(InteractionHostMixin, Box):
         if not initial_disabled and focusable:
             self.add_node(FocusNode(traversable=self._traversable))
 
+    def set_traversable(self, traversable: bool) -> None:
+        """Set whether the global Tab sequence stops on this widget.
+
+        Membership of a focus traversal group is not always known when the widget
+        is built — a RadioButton only meets its RadioGroup once it is mounted — so
+        the flag can be flipped afterwards. It is kept on the widget as well as on
+        the node because disabling and re-enabling rebuilds the FocusNode.
+        """
+        self._traversable = bool(traversable)
+        node = self.get_node(FocusNode)
+        if isinstance(node, FocusNode):
+            node.traversable = self._traversable
+
     def _apply_disabled(self, value: bool) -> None:
         next_disabled = bool(value)
 

--- a/src/nuiitivet/widgets/interaction.py
+++ b/src/nuiitivet/widgets/interaction.py
@@ -1019,6 +1019,19 @@ class FocusTraversalPolicy:
         """Make the member at ``index`` current, focusing it if it is a real node."""
         raise NotImplementedError
 
+    def entry_index(self, backwards: bool) -> int:
+        """Return the member Tab enters the scope at: the last one backwards, else the first.
+
+        Which member the group hands the focus to is the policy's decision, not the
+        scope's: a radio group is entered at its *selected* radio (WAI-ARIA), while
+        a menu or a slider is entered at the end the user came from. Return -1 to
+        enter with no member current.
+        """
+        count = len(self.members())
+        if count == 0:
+            return -1
+        return count - 1 if backwards else 0
+
     def on_boundary(self, direction: int) -> bool:
         """Handle Tab stepping past the last (``+1``) or first (``-1``) member.
 
@@ -1108,8 +1121,10 @@ class FocusScope(InteractionNode):
 
     The group is the unit Tab enters and leaves: it is a single stop in the
     global sequence, and the :class:`FocusTraversalPolicy` roves between its
-    members inside. Tab enters the scope at its first member and Shift+Tab at its
-    last. Stepping past the last (or before the first) member hits the boundary,
+    members inside. Tab enters the scope at the member the policy names
+    (:meth:`FocusTraversalPolicy.entry_index` — the first one, or the last one on
+    Shift+Tab, unless the policy says otherwise). Stepping past the last (or
+    before the first) member hits the boundary,
     where the policy either consumes the key (a menu dismisses itself) or lets Tab
     escape to the next stop outside the scope (a slider, a toolbar).
 
@@ -1131,11 +1146,16 @@ class FocusScope(InteractionNode):
         self.tab_roves = bool(tab_roves)
 
     def on_enter(self, backwards: bool = False) -> bool:
-        """Make the entry member current: the last one on Shift+Tab, else the first."""
+        """Make the policy's entry member current — the last one on Shift+Tab, else the first."""
         members = self.policy.members()
         if not members:
             return False
-        self.policy.set_current(len(members) - 1 if backwards else 0)
+
+        index = self.policy.entry_index(backwards)
+        if not 0 <= index < len(members):
+            return False
+
+        self.policy.set_current(index)
         return True
 
     def move(self, step: int, *, wrap: bool = False) -> bool:

--- a/tests/input/test_focus_scope.py
+++ b/tests/input/test_focus_scope.py
@@ -6,6 +6,8 @@ from nuiitivet.input.pointer import PointerEventType
 from nuiitivet.layout.column import Column
 from nuiitivet.layout.container import Container
 from nuiitivet.material import Checkbox, Menu, MenuItem, SubMenuItem
+from nuiitivet.material.button_group import ConnectedButtonGroup, GroupButton, StandardButtonGroup
+from nuiitivet.material.selection_controls import RadioButton, RadioGroup
 from nuiitivet.material.slider import HorizontalRangeSlider, HorizontalSlider
 from nuiitivet.overlay import Overlay
 from nuiitivet.runtime.app import App
@@ -429,3 +431,179 @@ def test_single_handle_slider_is_a_pass_through_stop() -> None:
 
     app._dispatch_key_press("tab")
     assert app._focused_node is _focus_node(after)
+
+
+# --- RadioGroup ---------------------------------------------------------------
+
+
+def _radio_group(value: object | None = None, disabled_second: bool = False) -> tuple[RadioGroup, list[RadioButton]]:
+    radios = [
+        RadioButton("a"),
+        RadioButton("b", disabled=disabled_second),
+        RadioButton("c"),
+    ]
+    return RadioGroup(child=Column(list(radios)), value=value), radios
+
+
+def test_a_radio_group_is_a_single_tab_stop() -> None:
+    """WAI-ARIA: the group is one stop, not one stop per radio."""
+    before = Checkbox()
+    group, _radios = _radio_group()
+    app = _mounted_app(Column([before, group]))
+
+    assert app._collect_focus_nodes() == [_focus_node(before), _focus_node(group)]
+
+
+def test_tab_enters_a_radio_group_at_its_selected_radio() -> None:
+    """The selected radio is the group's stop — not the first one."""
+    group, radios = _radio_group(value="c")
+    app = _mounted_app(Column([group]))
+
+    app._dispatch_key_press("tab")
+
+    assert app._focused_node is _focus_node(radios[2])
+
+
+def test_tab_enters_an_unselected_radio_group_at_its_first_radio() -> None:
+    """With nothing selected there is no selected radio to enter at."""
+    group, radios = _radio_group()
+    app = _mounted_app(Column([group]))
+
+    app._dispatch_key_press("tab")
+
+    assert app._focused_node is _focus_node(radios[0])
+
+
+def test_radio_arrow_keys_rove_and_move_the_selection_with_the_focus() -> None:
+    """Selection follows focus (WAI-ARIA), on both axes, wrapping at the ends."""
+    changed: list[object | None] = []
+    radios = [RadioButton("a"), RadioButton("b"), RadioButton("c")]
+    group = RadioGroup(child=Column(list(radios)), value="a", on_change=changed.append)
+    app = _mounted_app(Column([group]))
+    app._dispatch_key_press("tab")
+
+    app._dispatch_key_press("down")
+    assert app._focused_node is _focus_node(radios[1])
+    assert group.value == "b"
+
+    # Either axis roves: a radio group may be laid out as a Row or a Column.
+    app._dispatch_key_press("right")
+    assert app._focused_node is _focus_node(radios[2])
+    assert group.value == "c"
+
+    # The ends wrap.
+    app._dispatch_key_press("down")
+    assert app._focused_node is _focus_node(radios[0])
+    assert group.value == "a"
+
+    app._dispatch_key_press("up")
+    assert app._focused_node is _focus_node(radios[2])
+    assert group.value == "c"
+
+    assert changed == ["b", "c", "a", "c"]
+
+
+def test_radio_arrow_keys_skip_a_disabled_radio() -> None:
+    """A disabled radio is not selectable, so roving must not stop on it."""
+    group, radios = _radio_group(value="a", disabled_second=True)
+    app = _mounted_app(Column([group]))
+    app._dispatch_key_press("tab")
+
+    app._dispatch_key_press("down")
+
+    assert app._focused_node is _focus_node(radios[2])
+    assert group.value == "c"
+
+
+def test_tab_leaves_a_radio_group_rather_than_roving_it() -> None:
+    """Tab is how the group is left; the arrows are how it is roved."""
+    group, radios = _radio_group(value="a")
+    after = Checkbox()
+    app = _mounted_app(Column([group, after]))
+
+    app._dispatch_key_press("tab")
+    assert app._focused_node is _focus_node(radios[0])
+
+    app._dispatch_key_press("tab")
+    assert app._focused_node is _focus_node(after)
+
+    app._dispatch_key_press("tab", modifier_keys=SHIFT)
+    assert app._focused_node is _focus_node(radios[0])
+
+
+def test_a_radio_outside_a_group_stays_an_ordinary_tab_stop() -> None:
+    """Only group membership takes a radio out of the global sequence."""
+    radio = RadioButton("a")
+    app = _mounted_app(Column([radio]))
+
+    assert app._collect_focus_nodes() == [_focus_node(radio)]
+
+
+# --- ButtonGroup --------------------------------------------------------------
+
+
+def test_a_button_group_is_a_single_tab_stop() -> None:
+    """Both group types are one stop, entered at the first item."""
+    items = [GroupButton(label="One"), GroupButton(label="Two"), GroupButton(label="Three")]
+    group = ConnectedButtonGroup(items=items)
+    app = _mounted_app(Column([group]))
+
+    assert app._collect_focus_nodes() == [_focus_node(group)]
+
+    app._dispatch_key_press("tab")
+    assert app._focused_node is _focus_node(items[0])
+
+
+def test_button_group_arrows_rove_and_stop_at_the_edges() -> None:
+    """The toolbar pattern: Left/Right rove the items, and the ends do not wrap."""
+    items = [GroupButton(label="One"), GroupButton(label="Two"), GroupButton(label="Three")]
+    group = StandardButtonGroup(items=items)
+    app = _mounted_app(Column([group]))
+    app._dispatch_key_press("tab")
+
+    app._dispatch_key_press("left")
+    assert app._focused_node is _focus_node(items[0])  # already at the first item
+
+    app._dispatch_key_press("right")
+    assert app._focused_node is _focus_node(items[1])
+
+    app._dispatch_key_press("right")
+    assert app._focused_node is _focus_node(items[2])
+
+    app._dispatch_key_press("right")
+    assert app._focused_node is _focus_node(items[2])  # stops at the last item
+
+
+def test_button_group_selection_does_not_follow_the_focus() -> None:
+    """Unlike a radio group, roving a button group toggles nothing: Enter does."""
+    toggled: list[tuple[str, bool]] = []
+    items = [
+        GroupButton(label="One", on_change=lambda v: toggled.append(("One", v))),
+        GroupButton(label="Two", on_change=lambda v: toggled.append(("Two", v))),
+    ]
+    group = StandardButtonGroup(items=items)
+    app = _mounted_app(Column([group]))
+
+    app._dispatch_key_press("tab")
+    app._dispatch_key_press("right")
+    assert toggled == []
+
+    app._dispatch_key_press("enter")
+    assert toggled == [("Two", True)]
+
+
+def test_tab_leaves_a_button_group_rather_than_roving_it() -> None:
+    """Tab is a boundary for the group: it leaves for the next widget."""
+    items = [GroupButton(label="One"), GroupButton(label="Two")]
+    group = ConnectedButtonGroup(items=items)
+    after = Checkbox()
+    app = _mounted_app(Column([group, after]))
+
+    app._dispatch_key_press("tab")
+    assert app._focused_node is _focus_node(items[0])
+
+    app._dispatch_key_press("tab")
+    assert app._focused_node is _focus_node(after)
+
+    app._dispatch_key_press("tab", modifier_keys=SHIFT)
+    assert app._focused_node is _focus_node(items[1])  # Shift+Tab enters at the last item


### PR DESCRIPTION
## Summary
- `RadioGroup` and `StandardButtonGroup` / `ConnectedButtonGroup` are now focus
  traversal groups: one Tab stop each, with the keys roving inside. They were
  one Tab stop *per member* before, so Tab walked every radio and every button
  of a group it should have entered once. Closes #334.
- `RadioGroup` follows the WAI-ARIA radio group: the arrows rove on both axes
  (the child may be a Row or a Column) and wrap at the ends, and the selection
  follows the focus — which is why Tab enters the group at the *selected* radio
  rather than the first one.
- The button groups follow the WAI-ARIA toolbar instead: Left/Right rove, they
  stop at the ends rather than wrapping, and only Enter/Space activates — a
  group's items are actions or independent toggles, not one choice.
- New primitive: `FocusTraversalPolicy.entry_index(backwards)` names the member
  a scope is entered at. The default (first, or last on Shift+Tab) is the old
  behaviour, so `Menu` and `RangeSlider` are unchanged.
- New API: `Clickable.set_traversable()`. Group membership is not always known
  at construction — a `RadioButton` meets its `RadioGroup` only when it mounts.
- `NavigationRail` was part of #334 and is split out to #336: it is
  keyboard-unreachable today, and how it should *show* the focus is unsettled
  (MD3 shows no focus ring on rail items, and a ring around the active indicator
  would collide with its neighbours).
- `docs/design/INTERACTION_ARCHITECTURE.md`: the "Applied" table now covers the
  migrated widgets and records each one's wrap vs. stop-at-edge choice.

## Test plan
- [x] `tests/input/test_focus_scope.py` — 11 new tests: each group is a single
      Tab stop; Tab enters a radio group at its selected radio (and at the first
      one when nothing is selected); the arrows rove, wrap and carry the
      selection; a disabled radio is skipped; the button groups rove with
      Left/Right and stop at the ends; roving a button group activates nothing;
      Tab leaves both group types rather than roving them; a radio outside a
      group stays an ordinary Tab stop.
- [x] Regression: unrelated widgets keep exactly one Tab stop each and traverse
      in tree order (existing test), and the `Menu` / `RangeSlider` scopes are
      untouched.
- [x] Full suite: 1761 passed. `mypy` clean on the changed files.
- [x] Driven end-to-end against a real `App`: Tab stops are
      `[RadioGroup, ConnectedButtonGroup, Checkbox]`, the selection tracks the
      arrows, the button group stops at its right edge, and exactly one widget
      shows a focus ring at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
