### PR TITLE
fix: give the disabled Checkbox its own MD3 colors (#337)

### DIFF
--- a/src/nuiitivet/material/selection_controls.py
+++ b/src/nuiitivet/material/selection_controls.py
@@ -22,12 +22,21 @@ from nuiitivet.material.interactive_widget import InteractiveWidget
 from nuiitivet.material.motion import EXPRESSIVE_DEFAULT_EFFECTS, EXPRESSIVE_DEFAULT_SPATIAL
 
 if TYPE_CHECKING:
+    from nuiitivet.theme.theme import Theme
     from nuiitivet.material.styles.checkbox_style import CheckboxStyle
     from nuiitivet.material.styles.radio_button_style import RadioButtonStyle
     from nuiitivet.material.styles.switch_style import SwitchStyle
 
 
 _logger = logging.getLogger(__name__)
+
+RGBA = Tuple[int, int, int, int]
+
+
+def _scale_alpha(color: RGBA, factor: float) -> RGBA:
+    """Return `color` with its alpha multiplied by `factor` (0.0..1.0)."""
+    r, g, b, a = color
+    return (r, g, b, max(0, min(255, int(round(a * factor)))))
 
 
 class Checkbox(Toggleable, InteractiveWidget):
@@ -305,6 +314,30 @@ class Checkbox(Toggleable, InteractiveWidget):
             return CheckboxStyle()
         return theme.checkbox_style
 
+    def _resolve_box_colors(self, theme: Optional["Theme"] = None) -> Tuple[RGBA, RGBA, RGBA]:
+        """Resolve the (outline, checked container, mark) colors for the current state.
+
+        MD3 draws a disabled selection control from on-surface at 38%, with the
+        checkmark (or the indeterminate bar) in surface. `theme` defaults to the
+        widget's ambient theme.
+        """
+        from nuiitivet.theme.resolver import resolve_color_to_rgba
+        from nuiitivet.theme.theme import Theme
+
+        style = self.style
+        if theme is None:
+            theme = Theme.of(self)
+
+        if self.disabled:
+            disabled = resolve_color_to_rgba((style.disabled_color, style.disabled_alpha), theme=theme)
+            return (disabled, disabled, resolve_color_to_rgba(style.disabled_mark, theme=theme))
+
+        return (
+            resolve_color_to_rgba((style.stroke_color, style.stroke_alpha), theme=theme),
+            resolve_color_to_rgba(style.checked_background, theme=theme),
+            resolve_color_to_rgba(style.checked_foreground, theme=theme),
+        )
+
     def paint(self, canvas, x: int, y: int, width: int, height: int):
         """Paint checkbox with padding support (M3準拠)."""
         try:
@@ -316,6 +349,7 @@ class Checkbox(Toggleable, InteractiveWidget):
                 make_rect,
                 path_line_to,
                 path_move_to,
+                rgba_to_skia_color,
                 skcolor,
             )
 
@@ -345,19 +379,22 @@ class Checkbox(Toggleable, InteractiveWidget):
             from nuiitivet.material.theme.color_role import ColorRole
             from nuiitivet.material.theme.theme_data import MaterialThemeData
 
-            mat = Theme.of(self).extension(MaterialThemeData)
+            theme = Theme.of(self)
+            mat = theme.extension(MaterialThemeData)
             roles = mat.roles if mat is not None else {}
 
-            fg_hex = roles.get(ColorRole.ON_SURFACE, "#000000")
-            stroke_color = skcolor(fg_hex, 0.54)
-            stroke_p = make_paint(color=stroke_color, style="stroke", stroke_width=stroke_w, aa=True)
+            outline_color, container_color, mark_color = self._resolve_box_colors(theme)
+
+            stroke_p = make_paint(
+                color=rgba_to_skia_color(outline_color), style="stroke", stroke_width=stroke_w, aa=True
+            )
             rect = make_rect(icon_x, icon_y, icon_sz, icon_sz)
 
             # Check for keyboard focus (Ring visible)
             is_keyboard_focus = self.should_show_focus_ring
 
-            # Determine State Layer opacity
-            overlay_alpha = self._get_active_state_layer_opacity()
+            # Determine State Layer opacity (a disabled checkbox has no state layer per M3)
+            overlay_alpha = 0.0 if self.disabled else self._get_active_state_layer_opacity()
 
             if overlay_alpha > 0.0:
                 cx_center = float(cx + touch_sz / 2.0)
@@ -401,8 +438,11 @@ class Checkbox(Toggleable, InteractiveWidget):
             val = self.value
             selection_progress = self._get_selection_progress()
             if selection_progress > 1e-6:
-                prim = roles.get(ColorRole.PRIMARY, "#000000")
-                fill_p = make_paint(color=skcolor(prim, selection_progress), style="fill", aa=True)
+                fill_p = make_paint(
+                    color=rgba_to_skia_color(_scale_alpha(container_color, selection_progress)),
+                    style="fill",
+                    aa=True,
+                )
                 if rect is not None and fill_p is not None:
                     draw_round_rect(canvas, rect, corner, fill_p)
 
@@ -420,9 +460,8 @@ class Checkbox(Toggleable, InteractiveWidget):
             if (val is True or val is None) and selection_progress > 1e-6:
                 mark_is_none = val is None
                 mark_style = "stroke" if not mark_is_none else "fill"
-                onp = roles.get(ColorRole.ON_PRIMARY, "#000000")
                 mark_p = make_paint(
-                    color=skcolor(onp, selection_progress),
+                    color=rgba_to_skia_color(_scale_alpha(mark_color, selection_progress)),
                     style=mark_style,
                     stroke_width=max(1.0, icon_sz * 0.12),
                     aa=True,

--- a/src/nuiitivet/material/styles/checkbox_style.py
+++ b/src/nuiitivet/material/styles/checkbox_style.py
@@ -43,6 +43,11 @@ class CheckboxStyle:
     checked_background: ColorSpec = ColorRole.PRIMARY
     checked_foreground: ColorSpec = ColorRole.ON_PRIMARY
 
+    # Disabled colors (M3: outline and container are on-surface @ 38%, mark is surface)
+    disabled_color: ColorSpec = ColorRole.ON_SURFACE
+    disabled_mark: ColorSpec = ColorRole.SURFACE
+    disabled_alpha: float = 0.38
+
     # State layer (hover/press overlay)
     state_layer_ratio: float = 40.0 / 48.0  # State layer diameter relative to touch target
     hover_alpha: float = 0.08
@@ -65,6 +70,8 @@ class CheckboxStyle:
             "stroke_color": resolve_color_to_rgba(self.stroke_color, theme=theme),
             "checked_background": resolve_color_to_rgba(self.checked_background, theme=theme),
             "checked_foreground": resolve_color_to_rgba(self.checked_foreground, theme=theme),
+            "disabled_color": resolve_color_to_rgba(self.disabled_color, theme=theme),
+            "disabled_mark": resolve_color_to_rgba(self.disabled_mark, theme=theme),
             "focus_color": resolve_color_to_rgba(self.focus_color, theme=theme),
         }
 

--- a/tests/material/test_checkbox.py
+++ b/tests/material/test_checkbox.py
@@ -172,6 +172,69 @@ def test_indeterminate_observable_separate_from_checked():
     assert called == [True]
 
 
+def _light_theme():
+    from nuiitivet.material.theme.material_theme import MaterialThemeFactory
+
+    return MaterialThemeFactory.light("#6750A4")
+
+
+def _rgba(spec, alpha: float = 1.0):
+    from nuiitivet.theme.resolver import resolve_color_to_rgba
+
+    return resolve_color_to_rgba((spec, alpha), theme=_light_theme())
+
+
+def test_enabled_box_colors_come_from_style_tokens():
+    from nuiitivet.material.styles.checkbox_style import CheckboxStyle
+
+    style = CheckboxStyle()
+    c = Checkbox(style=style)
+    outline, container, mark = c._resolve_box_colors(_light_theme())
+
+    assert outline == _rgba(style.stroke_color, style.stroke_alpha)
+    assert container == _rgba(style.checked_background)
+    assert mark == _rgba(style.checked_foreground)
+
+
+def test_disabled_box_colors_come_from_disabled_tokens():
+    """A disabled checkbox is on-surface @ 38% (outline and container), mark in surface."""
+    from nuiitivet.material.styles.checkbox_style import CheckboxStyle
+
+    style = CheckboxStyle()
+    c = Checkbox(disabled=True, style=style)
+    outline, container, mark = c._resolve_box_colors(_light_theme())
+
+    disabled = _rgba(style.disabled_color, style.disabled_alpha)
+    assert outline == disabled
+    assert container == disabled
+    assert mark == _rgba(style.disabled_mark)
+
+
+def test_disabled_box_colors_are_visibly_distinct_from_enabled():
+    from nuiitivet.material.styles.checkbox_style import CheckboxStyle
+
+    theme = _light_theme()
+    style = CheckboxStyle()
+    for value in (False, True, None):
+        enabled = Checkbox(checked=bool(value), indeterminate=value is None, style=style)
+        disabled = Checkbox(checked=bool(value), indeterminate=value is None, disabled=True, style=style)
+        assert enabled.value is value
+        assert disabled.value is value
+        assert disabled._resolve_box_colors(theme) != enabled._resolve_box_colors(theme)
+
+
+def test_disabled_box_colors_honor_custom_tokens():
+    from nuiitivet.material.styles.checkbox_style import CheckboxStyle
+
+    style = CheckboxStyle().copy_with(disabled_color="#FF0000", disabled_mark="#00FF00", disabled_alpha=0.5)
+    c = Checkbox(disabled=True, style=style)
+    outline, container, mark = c._resolve_box_colors(_light_theme())
+
+    assert outline == (255, 0, 0, 127)
+    assert container == (255, 0, 0, 127)
+    assert mark == (0, 255, 0, 255)
+
+
 def test_checkbox_padding():
     """Test padding support for Checkbox (M3: space between UI elements)."""
     c1 = Checkbox()

--- a/tests/material/test_checkbox_style.py
+++ b/tests/material/test_checkbox_style.py
@@ -2,8 +2,10 @@
 
 from nuiitivet.material import Checkbox
 from nuiitivet.material.styles import CheckboxStyle
+from nuiitivet.material.theme.color_role import ColorRole
 from nuiitivet.material.theme.material_theme import MaterialThemeFactory
 from nuiitivet.material.theme.theme_data import MaterialThemeData
+from nuiitivet.theme.resolver import resolve_color_to_rgba
 from dataclasses import replace
 
 
@@ -57,6 +59,25 @@ def test_theme_with_custom_checkbox_style():
     new_mat_data = replace(mat_data, _checkbox_style=custom_style)
     assert new_mat_data.checkbox_style.default_touch_target == 56
     assert new_mat_data.checkbox_style.hover_alpha == 0.1
+
+
+def test_checkbox_style_disabled_tokens_default_to_m3():
+    """MD3 draws a disabled selection control from on-surface @ 38%, mark in surface."""
+    style = CheckboxStyle()
+    assert style.disabled_color == ColorRole.ON_SURFACE
+    assert style.disabled_mark == ColorRole.SURFACE
+    assert style.disabled_alpha == 0.38
+
+
+def test_checkbox_style_resolve_colors_includes_disabled():
+    """resolve_colors exposes the disabled colors alongside the enabled ones."""
+    light, _ = MaterialThemeFactory.from_seed_pair("#6750A4")
+    colors = CheckboxStyle().resolve_colors(theme=light)
+
+    mat = light.extension(MaterialThemeData)
+    assert mat is not None
+    assert colors["disabled_color"] == resolve_color_to_rgba(mat.roles[ColorRole.ON_SURFACE])
+    assert colors["disabled_mark"] == resolve_color_to_rgba(mat.roles[ColorRole.SURFACE])
 
 
 def test_checkbox_touch_target_from_style():


### PR DESCRIPTION
## Summary
- `Checkbox.paint` never read `self.disabled` and hardcoded its colors (`on-surface` @ 54%, `primary`, `on-primary`), so a disabled checkbox painted exactly like an enabled one — the only cue was that the state layer stopped responding.
- Added the missing disabled tokens to `CheckboxStyle`: `disabled_color` (`ON_SURFACE`), `disabled_mark` (`SURFACE`) and `disabled_alpha` (0.38), and exposed them from `resolve_colors()`.
- Introduced `Checkbox._resolve_box_colors()`, which resolves the outline / checked container / mark colors from the style tokens and branches on `disabled`. `paint` now only consumes it, so no color literals remain in `paint`. The state layer is explicitly suppressed while disabled.
- Per MD3, a disabled checkbox is now drawn from `on-surface` @ 38% (outline and checked container) with the checkmark / indeterminate bar in `surface`.

Closes #337

## Test plan
- [x] `uv run pytest tests` — 1777 passed
- [x] `uv run mypy` on the touched modules — clean
- [x] Verified the resolved colors under a mounted Material theme: enabled = `on-surface` α137 / `primary` / `on-primary`; disabled = `on-surface` α96 / `on-surface` α96 / `surface`, for unselected, selected and indeterminate alike
- [x] Manually checked in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)