### PR TITLE
fix: enable mypy check_untyped_defs for src and samples (#342)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,15 @@ docs = [
 [tool.mypy]
 files = ["src", "tests", "samples"]
 mypy_path = "stubs"
+check_untyped_defs = true
+
+# Tests rely on monkeypatching and hand-written stub classes, which do not
+# survive body checking. Keep their bodies unchecked and drop the resulting
+# "untyped body" notes.
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+check_untyped_defs = false
+disable_error_code = ["annotation-unchecked"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/nuiitivet/backends/pyglet/ime/linux.py
+++ b/src/nuiitivet/backends/pyglet/ime/linux.py
@@ -1,7 +1,7 @@
 import ctypes
 import logging
 import sys
-from typing import Any
+from typing import Any, TypedDict
 
 from nuiitivet.common.logging_once import exception_once
 
@@ -112,10 +112,14 @@ if sys.platform == "linux":
             None, XIC, ctypes.c_void_p, ctypes.POINTER(XIMPreeditCaretCallbackStruct)
         )
 
+        class _CompositionState(TypedDict):
+            text: str
+            cursor: int
+
         # Global references
         _callbacks = []
         _ic_map: dict[Any, Any] = {}  # XIC -> Window
-        _composition_state = {}  # Window -> {text: str, cursor: int}
+        _composition_state: dict[Any, _CompositionState] = {}  # Window -> state
 
         def _preedit_start(ic, client_data, call_data):
             return -1  # No limit

--- a/src/nuiitivet/backends/pyglet/ime/macos.py
+++ b/src/nuiitivet/backends/pyglet/ime/macos.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from typing import Any
 
-from nuiitivet.common.logging_once import exception_once
+from nuiitivet.common.logging_once import exception_once, warning_once
 
 
 _logger = logging.getLogger(__name__)
@@ -90,16 +90,19 @@ else:
 
             # frame() returns NSRect
             frame = cocoapy.send_message(screen, "frame", restype=NSRect)
-            screen_height = frame.size.height
+            if frame is None:
+                warning_once(_logger, "ime_macos_screen_frame_none", "Screen frame is unavailable; using default rect")
+            else:
+                screen_height = frame.size.height
 
-            # Calculate screen coordinates (Cocoa: bottom-left origin)
-            # Pyglet Window (wx, wy) is top-left of window content area in screen coords (top-left origin).
+                # Calculate screen coordinates (Cocoa: bottom-left origin)
+                # Pyglet Window (wx, wy) is top-left of window content area in screen coords (top-left origin).
 
-            # NSRect origin is bottom-left of the rect.
-            origin_y = (screen_height - wy) - cy - ch
-            origin_x = wx + cx
+                # NSRect origin is bottom-left of the rect.
+                origin_y = (screen_height - wy) - cy - ch
+                origin_x = wx + cx
 
-            rect = NSRect(NSPoint(origin_x, origin_y), NSSize(cw, ch))
+                rect = NSRect(NSPoint(origin_x, origin_y), NSSize(cw, ch))
 
         except Exception:
             exception_once(_logger, "ime_macos_first_rect_exc", "firstRectForCharacterRange failed")

--- a/src/nuiitivet/material/icon.py
+++ b/src/nuiitivet/material/icon.py
@@ -327,7 +327,6 @@ class Icon(IconBase):
                 symbols_root = None
         except Exception:
             exception_once(logger, "icon_importlib_resources_exc", "Failed to import importlib.resources")
-            resources = None
             symbols_root = None
 
         # Helper to try loading font bytes via importlib.resources and create a

--- a/src/nuiitivet/material/overlay.py
+++ b/src/nuiitivet/material/overlay.py
@@ -132,26 +132,6 @@ class MaterialOverlay(Overlay):
 
         self._intent_resolver = intent_resolver
 
-    @classmethod
-    def root(cls) -> "MaterialOverlay":
-        overlay = Overlay.root()
-        if not isinstance(overlay, cls):
-            raise RuntimeError(f"Root overlay is not {cls.__name__}")
-        return overlay
-
-    @classmethod
-    def of(cls, context: Widget, root: bool = False) -> "MaterialOverlay":
-        if root:
-            return cls.root()
-
-        found = context.find_ancestor(cls)
-        if found is None:
-            raise RuntimeError(
-                f"No {cls.__name__} found in the widget tree above {context.__class__.__name__}. "
-                "Did you forget to initialize MaterialApp with MaterialOverlay?"
-            )
-        return found
-
     def dialog(
         self,
         dialog: Widget | Any,

--- a/src/nuiitivet/navigation/navigator.py
+++ b/src/nuiitivet/navigation/navigator.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 import inspect
 import logging
-from typing import Any, Callable, ClassVar, Literal, Mapping
+from typing import Any, Callable, ClassVar, Literal, Mapping, TypeVar
 
 from nuiitivet.common.logging_once import exception_once
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
@@ -17,6 +17,10 @@ from .transition_engine import TransitionEngine, TransitionHandle
 from .transition_spec import EmptyTransitionSpec, TransitionPhase
 
 _logger = logging.getLogger(__name__)
+
+# Lets ``root()``/``of()`` keep the concrete subclass type, so that
+# ``MaterialNavigator.root()`` is a ``MaterialNavigator`` and not a ``Navigator``.
+NavigatorT = TypeVar("NavigatorT", bound="Navigator")
 
 
 @dataclass(slots=True)
@@ -153,14 +157,17 @@ class Navigator(ComposableWidget):
         cls._root = navigator
 
     @classmethod
-    def root(cls) -> Navigator:
-        if cls._root is None:
+    def root(cls: type[NavigatorT]) -> NavigatorT:
+        navigator = cls._root
+        if navigator is None:
             raise RuntimeError("Navigator root is not set")
-        return cls._root
+        if not isinstance(navigator, cls):
+            raise RuntimeError(f"Navigator root is not a {cls.__name__} instance")
+        return navigator
 
     @classmethod
-    def of(cls, context: Widget) -> Navigator:
-        navigator = context.find_ancestor(Navigator)
+    def of(cls: type[NavigatorT], context: Widget) -> NavigatorT:
+        navigator = context.find_ancestor(cls)
         if navigator is None:
             raise RuntimeError("Navigator not found in ancestors")
         return navigator

--- a/src/nuiitivet/overlay/overlay.py
+++ b/src/nuiitivet/overlay/overlay.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 from nuiitivet.widgeting.widget import ComposableWidget, Widget
 from nuiitivet.layout.stack import Stack
@@ -29,6 +29,10 @@ from .layer_composer import OverlayLayerComposer, OverlayLayerCompositionContext
 from .transition_state import OverlayTransitionState
 
 logger = logging.getLogger(__name__)
+
+# Lets ``root()``/``of()`` keep the concrete subclass type, so that
+# ``MaterialOverlay.root()`` is a ``MaterialOverlay`` and not an ``Overlay``.
+OverlayT = TypeVar("OverlayT", bound="Overlay")
 
 
 def _find_overlay_aware(widget: Widget) -> OverlayAware[Any] | None:
@@ -886,21 +890,24 @@ class Overlay(ComposableWidget):
         cls._root_overlay = overlay
 
     @classmethod
-    def root(cls) -> "Overlay":
-        if cls._root_overlay is None:
-            raise RuntimeError("No root overlay found. Did you forget to initialize the App with an Overlay?")
-        return cls._root_overlay
+    def root(cls: type[OverlayT]) -> OverlayT:
+        overlay = cls._root_overlay
+        if overlay is None:
+            raise RuntimeError(f"No root overlay found. Did you forget to initialize the App with an {cls.__name__}?")
+        if not isinstance(overlay, cls):
+            raise RuntimeError(f"Root overlay is not a {cls.__name__} instance")
+        return overlay
 
     @classmethod
-    def of(cls, context: Widget, root: bool = False) -> "Overlay":
+    def of(cls: type[OverlayT], context: Widget, root: bool = False) -> OverlayT:
         if root:
             return cls.root()
 
-        overlay = context.find_ancestor(Overlay)
+        overlay = context.find_ancestor(cls)
         if overlay is None:
             raise RuntimeError(
-                f"No Overlay found in the widget tree above {context.__class__.__name__}. "
-                "Did you forget to wrap your widget in an Overlay?"
+                f"No {cls.__name__} found in the widget tree above {context.__class__.__name__}. "
+                f"Did you forget to wrap your widget in an {cls.__name__}?"
             )
         return overlay
 

--- a/src/nuiitivet/rendering/skia/geometry.py
+++ b/src/nuiitivet/rendering/skia/geometry.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 Number = Union[int, float]
-RadiiInput = Union[list[Number], tuple[Number], Number, None]
+RadiiInput = Union[list[Number], tuple[Number, ...], Number, None]
 
 
 def _normalize_radii(radii: Sequence[Number]) -> Sequence[float]:


### PR DESCRIPTION
Closes #342

## Summary

`uv run mypy` succeeded but printed 106 `annotation-unchecked` notes, because the bodies of functions without annotations are skipped by default. This enables `check_untyped_defs` for `src` and `samples`, and fixes the errors that surfaced. `tests` keep unchecked bodies — their monkeypatching and hand-written stub classes produce 160 errors that are not worth reworking — with the note disabled via an override.

Result: `uv run mypy` reports no errors and no notes.

## Changes

**mypy config** (`pyproject.toml`): `check_untyped_defs = true`, plus a `tests.*` override that keeps bodies unchecked and disables `annotation-unchecked`.

**Errors surfaced by the new setting:**

- `backends/pyglet/ime/macos.py` — `send_message(..., restype=NSRect)` returns `NSRect | None`; guard before reading `.size` and warn once, leaving the default rect in place.
- `material/icon.py` — dead `resources = None` assignment (the name is never read afterwards).
- `rendering/skia/geometry.py` — `RadiiInput` declared `tuple[Number]`, a *1-element* tuple, while callers pass per-corner radii. Widened to `tuple[Number, ...]`.
- `navigation/navigator.py` — `root()`/`of()` returned the base `Navigator`, so callers going through the Material root (`nv.Navigator` is `MaterialNavigator`) had no typed way to obtain one. They now return the calling class's type via a `TypeVar` (`Self` is unavailable on Python 3.10), and `root()` validates the instance type.

**Follow-on refactor (beyond the issue):** `Overlay` had the same weakness, but it was hidden because `MaterialOverlay` re-implemented `root()`/`of()` purely to narrow the type back — the same logic now in the base class. The base is generic over the calling class and the two `MaterialOverlay` overrides are removed. Error messages name the concrete class instead of hardcoding `Overlay`.

## Verification

- `uv run mypy`: no errors, no notes (was: 106 notes)
- `uv run pytest`: 1777 passed
- `uv run flake8 --select=F,E3 src/`: clean
- Rendered the samples that exercise the changed lookups at runtime — `samples/navigation/intent.py` (`nv.Navigator.root()`), `samples/overlay/dialogs/basic_usage.py` and `view_model_intent.py` (`nv.Overlay.root()`) — to confirm the new isinstance checks pass in a real app.

## Out of scope

Enabling `check_untyped_defs` for `tests` (160 errors, mostly test-double patterns). Worth a separate issue if we want the suite fully type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)